### PR TITLE
TBR: Proper fix for fw 23.1.4 (openvpn_get_active_servers() removed)

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -495,7 +495,7 @@ class CoordinatorEntityManager:
                 # del self.entities[entity_unique_id]
 
     async def async_remove_entity(self, entity):
-        registry = await async_get_registry(self.hass)
+        registry = await async_get(self.hass)
         if entity.entity_id in registry.entities:
             registry.async_remove(entity.entity_id)
 

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -909,6 +909,8 @@ if (!function_exists('openvpn_get_active_servers')) {
   }
 }
 
+$ovpn_servers = openvpn_get_active_servers();
+
 $toreturn = [
     "pfstate" => [
         "used" => (int) $system_api_data["kernel"]["pf"]["states"],


### PR DESCRIPTION
Issue: openvpn_get_active_servers() was removed
New Widget code to populate $ovpn_servers: https://github.com/opnsense/core/commit/bb1aa668026a1071a2af40a58a5c4ffddab9dcd0#diff-3287df0b334ee7ebfe91949288b86b35d91c0856fac92271f1dc42d3e3aeb26c
Original code of function openvpn_get_active_servers(): https://github.com/opnsense/core/commit/bb1aa668026a1071a2af40a58a5c4ffddab9dcd0#diff-7d3ee1c5a3214827fdd7fd01c482767479b28fc034dd73c2c303be98b2162f1c
