### PR TITLE
ARP table sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,26 @@ Initial development was done againt `OPNsense` `21.7` and `Home Assistant` `2021
 
 # Overview
 
-- [Installation](#Installation)
-  - [OPNsense plugin](#OPNsense_plugin)
-  - [Home Assistant integration](#HomeAssistant_integration)
-    - [HACS installation](#HACS_installation)
-    - [Manual installation](#Manual_installation)
-- [Configuration](#Configuration)
-  - [OPNsense](#OPNsense_plugin)
-  - [HA Config](#config)
-  - [Options](#options)
-- [Entities](#entities)
-  - [Binary Sensor](#binary_sensor)
-  - [Device Tracker](#device_tracker)
-  - [Sensor](#sensor)
-  - [Switch](#switch)
-  - [Services](#services)
+- [hass-opnsense](#hass-opnsense)
+- [Overview](#overview)
+- [installation](#installation)
+- [Installation](#installation-1)
+  - [OPNsense\_plugin](#opnsense_plugin)
+  - [HomeAssistant\_integration](#homeassistant_integration)
+    - [HACS\_installation](#hacs_installation)
+    - [Manual\_installation](#manual_installation)
+- [Configuration](#configuration)
+  - [OPNsense](#opnsense)
+  - [config](#config)
+  - [options](#options)
+- [entities](#entities)
+  - [binary\_sensor](#binary_sensor)
+  - [device\_tracker](#device_tracker)
+  - [sensor](#sensor)
+  - [switch](#switch)
+- [services](#services)
 - [Known Issues](#known-issues)
-  - [AdGuardHome](#AdGuardHome)
+  - [AdGuardHome](#adguardhome)
 
 # installation
 
@@ -160,6 +163,7 @@ causing issues with the tracker. See #22 for details.
 - ~~dhcp stats (total, online, and offline clients)~~
 - OpenVPN server stats (per-server basis - connected client count, bytes
   sent/received, kB/s sent/received)
+- ARP table (count in ARP, all IPs, and broken up by "subnet")
 
 ## switch
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -730,6 +730,14 @@ class OPNSenseArpTableSensor(OPNSenseSensor):
                     attributes[subnet] = []
                 attributes[subnet].append(ip)
 
+        def sort_by_ip(ip_string):
+            octets = ip_string.split(".")
+            return tuple(int(octet) for octet in octets)
+
+        for key in attributes:
+            if key != "state":
+                attributes[key] = sorted(attributes[key], key=sort_by_ip)
+
         return attributes
 
     @property


### PR DESCRIPTION
Related: https://github.com/travisghansen/hass-opnsense/discussions/73

This is an attempt to get a sensor listing all of the IPs in the ARP table. 

@travisghansen, I've tried a lot of different variations of `dict_get(state, "arp_table")` and they always return `None`. Via some error logging through `_LOGGER.error(...)`, I can see that the data is retrieved and set successfully [here](https://github.com/travisghansen/hass-opnsense/blob/main/custom_components/opnsense/__init__.py#L309), but if I print out the whole `state` object in my added `native_value()` method, it _never_ has an "arp_table" property. Any idea what's going on?