### PR TITLE
Allow interface traffic to be used in statistics

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -395,22 +395,6 @@ class OPNSenseData:
 
                         new_property = f"{property}_{label}"
                         interface[new_property] = int(round(value, 0))
-                    for property in [
-                        "inbytes",
-                        "outbytes",
-                        "inpkts",
-                        "outpkts",
-                    ]:
-                        for timespan in [
-                            "day",
-                            "week",
-                            "month",
-                            "year"
-                        ]:
-                            label = "total_this_" + timespan
-                            value = interface[property]
-                            new_property = f"{property}_{label}"
-                            interface[new_property] = int(round(value, 0))
 
                 for server_name in dict_get(
                     self._state, "telemetry.openvpn.servers", {}

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -395,6 +395,22 @@ class OPNSenseData:
 
                         new_property = f"{property}_{label}"
                         interface[new_property] = int(round(value, 0))
+                    for property in [
+                        "inbytes",
+                        "outbytes",
+                        "inpkts",
+                        "outpkts",
+                    ]:
+                        for timespan in [
+                            "day",
+                            "week",
+                            "month",
+                            "year"
+                        ]:
+                            label = "total_this_" + timespan
+                            value = interface[property]
+                            new_property = f"{property}_{label}"
+                            interface[new_property] = int(round(value, 0))
 
                 for server_name in dict_get(
                     self._state, "telemetry.openvpn.servers", {}

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1,10 +1,12 @@
 """Provides a sensor to track various status aspects of OPNsense."""
 import logging
 import re
+from datetime import datetime, date
 
 from awesomeversion import AwesomeVersion
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL,
     SensorEntity,
     SensorEntityDescription,
 )
@@ -156,12 +158,28 @@ async def async_setup_entry(
                 # "outpktsblock_packets_per_second",
                 "inbytes",
                 "inbytes_kilobytes_per_second",
+                "inbytes_total_this_day",
+                "inbytes_total_this_week",
+                "inbytes_total_this_month",
+                "inbytes_total_this_year",
                 "outbytes",
                 "outbytes_kilobytes_per_second",
+                "outbytes_total_this_day",
+                "outbytes_total_this_week",
+                "outbytes_total_this_month",
+                "outbytes_total_this_year",
                 "inpkts",
                 "inpkts_packets_per_second",
+                "inpkts_total_this_day",
+                "inpkts_total_this_week",
+                "inpkts_total_this_month",
+                "inpkts_total_this_year",
                 "outpkts",
                 "outpkts_packets_per_second",
+                "outpkts_total_this_day",
+                "outpkts_total_this_week",
+                "outpkts_total_this_month",
+                "outpkts_total_this_year"
             ]:
                 state_class = None
                 native_unit_of_measurement = None
@@ -185,6 +203,33 @@ async def async_setup_entry(
                     or "_kilobytes_per_second" in property
                 ):
                     state_class = STATE_CLASS_MEASUREMENT
+
+                # utility meters
+                if (
+                    "_total_this" in property
+                ):
+                    state_class = STATE_CLASS_TOTAL
+                
+                if (
+                    "_day" in property
+                ):
+                    last_reset = datetime.now().day
+                    
+                if (
+                    "_week" in property
+                ):
+                    last_reset = date.today().isocalendar().week
+                
+                if (
+                    "_month" in property
+                ):
+                    last_reset = datetime.now().month
+                
+                if (
+                    "_year" in property
+                ):
+                    last_reset = datetime.now().year
+                    
 
                 # native_unit_of_measurement
                 if "_packets_per_second" in property:

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -222,7 +222,7 @@ async def async_setup_entry(
                         key="telemetry.interface.{}.{}".format(
                             interface_name, property
                         ),
-                        name="Interface {} {}".format(interface_name, property.replace("_", " ")),
+                        name="Interface {} {}".format(interface_name, property),
                         native_unit_of_measurement=native_unit_of_measurement,
                         icon=icon,
                         state_class=state_class,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1,7 +1,7 @@
 """Provides a sensor to track various status aspects of OPNsense."""
 import logging
 import re
-from datetime import datetime, date
+from datetime import datetime, date, timedelta, time
 
 from awesomeversion import AwesomeVersion
 from homeassistant.components.sensor import (
@@ -185,6 +185,7 @@ async def async_setup_entry(
                 native_unit_of_measurement = None
                 icon = None
                 enabled_default = False
+                last_reset = None
                 # entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
                 # enabled_default
@@ -213,22 +214,37 @@ async def async_setup_entry(
                 if (
                     "_day" in property
                 ):
-                    last_reset = datetime.now().day
+                    static_time = time(hour=0, minute=0, second=0)
+                    current_date = date.today()
+                    dt = datetime.combine(current_date, static_time)
+                    last_reset = dt
                     
                 if (
                     "_week" in property
                 ):
-                    last_reset = date.today().isocalendar().week
+                    today = date.today()  # get today's date
+                    week_start = today - timedelta(days=today.weekday())  # calculate the start of the week
+                    last_reset = week_start
                 
                 if (
                     "_month" in property
                 ):
-                    last_reset = datetime.now().month
+                    static_time = time(hour=0, minute=0, second=0)
+                    current_year = datetime.now().year
+                    current_month = datetime.now().month
+                    current_date = date(current_year, current_month, 1)
+                    dt = datetime.combine(current_date, static_time)
+                    last_reset = dt
                 
                 if (
                     "_year" in property
                 ):
-                    last_reset = datetime.now().year
+                    static_time = time(hour=0, minute=0, second=0)
+                    current_year = datetime.now().year
+                    current_month = 1
+                    current_date = date(current_year, current_month, 1)
+                    dt = datetime.combine(current_date, static_time)
+                    last_reset = dt
                     
 
                 # native_unit_of_measurement
@@ -269,6 +285,7 @@ async def async_setup_entry(
                         icon=icon,
                         state_class=state_class,
                         # entity_category=entity_category,
+                        last_reset=last_reset,
                     ),
                     enabled_default,
                 )

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -264,7 +264,7 @@ async def async_setup_entry(
                         key="telemetry.interface.{}.{}".format(
                             interface_name, property
                         ),
-                        name="Interface {} {}".format(interface_name, property),
+                        name="Interface {} {}".format(interface_name, property.replace("_", " ")),
                         native_unit_of_measurement=native_unit_of_measurement,
                         icon=icon,
                         state_class=state_class,


### PR DESCRIPTION
Was lacking the utility sensors I had from when I was using a off the shelf router and integration, so I decided to add them :) I also fixed the fact that the display name of the interface sensors doesn't clean up the _ making them not look good if you directly add them to lovelace without overwriting the display name on a card

closes #84 