### PR TITLE
Fix creating device trackers if no devices selected

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
         # seems unlikely *all* devices are intended to be monitored
         # disable by default and let users enable specific entries they care about
         enabled_default = False
-        device_per_arp_entry = False
+        device_per_arp_entry = True
 
         entities = []
         mac_addresses = []


### PR DESCRIPTION
Configuration description for choosing devices to track configuration page says "Choose which devices you want to track. If you don't select any devices, all devices will be tracked but will be disabled by default. If you do select any devices, only those devices will be tracked and will be enabled by default."

However, if I do not select any devices, no entities are added at all (even checking disabled ones) because device_per_arp_entry is always False.