### PR TITLE
Move get_system_info (except device_id) to REST API

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -283,13 +283,10 @@ class OPNsenseEntity(CoordinatorEntity, RestoreEntity):
     def opnsense_device_name(self) -> str:
         if self.config_entry.title and len(self.config_entry.title) > 0:
             return self.config_entry.title
-        return "{}.{}".format(
-            self._get_opnsense_state_value("system_info.hostname"),
-            self._get_opnsense_state_value("system_info.domain"),
-        )
+        return self._get_opnsense_state_value("system_info.name")
 
     @property
-    def opnsense_device_unique_id(self):
+    def opnsense_device_unique_id(self) -> str | None:
         return self._get_opnsense_state_value("system_info.device_id")
 
     def _get_opnsense_state_value(self, path, default=None):

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow for OPNsense integration."""
 
+from collections.abc import Mapping
 import logging
+from typing import Any
 from urllib.parse import quote_plus, urlparse
 import xmlrpc
 
@@ -86,12 +88,10 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     opts={"verify_ssl": verify_ssl},
                 )
-                system_info = await client.get_system_info()
+                system_info: Mapping[str, Any] = await client.get_system_info()
 
                 if name is None:
-                    name = "{}.{}".format(
-                        system_info["hostname"], system_info["domain"]
-                    )
+                    name: str = system_info["name"]
 
                 # https://developers.home-assistant.io/docs/config_entries_config_flow_handler#unique-ids
                 await self.async_set_unique_id(slugify(system_info["device_id"]))

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -51,7 +51,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         return inner
 
     @_log_timing
-    async def _get_system_info(self):
+    async def _get_system_info(self) -> Mapping[str, Any]:
         return await self._client.get_system_info()
 
     @_log_timing

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -17,10 +17,6 @@ import zoneinfo
 
 import aiohttp
 import awesomeversion
-<<<<<<< Move-get_system_info-(except-device_id)-to-REST-API
-from awesomeversion import AwesomeVersion
-=======
->>>>>>> main
 from dateutil.parser import parse
 
 # value to set as the socket timeout

--- a/function_method.md
+++ b/function_method.md
@@ -15,7 +15,6 @@
 | Clear Subsystem Dirty | Yes | No | Doesn't appear to be used anymore. Probably just remove altogether. |
 | Filter Configure | Yes | | |
 | Get Device ID | Yes | Maybe | Used as Unique ID for device. It is just a random 10 digit number generated the first time it is requested. May be able to transition to using the Config Entry ID or something else as a Unique ID. |
-| Get System Info | Yes | Partial | Returns hostname and domain as well as Device ID. Hostname and Domain can be obtained in REST API. |
 | Get Interfaces | Yes | Yes | Uses Get Config. Can use same function that is used for the Interface data for the Telemetry data. |
 | Enable Filter Rule | Yes | No | Uses Get Config, Filter Configure and Restore Config Section. |
 | Disable Filter Rule | Yes | No | Uses Get Config, Filter Configure and Restore Config Section. |
@@ -58,3 +57,4 @@
 | Upgrade Firmware | /api/core/firmware/update<br>/api/core/firmware/upgrade | 2018 | |
 | Firmware Upgrade Status | /api/core/firmware/upgradestatus | 2018 | |
 | Firmware Changelog | /api/core/firmware/changelog/ | 2018 | |
+| Get System Info | /api/diagnostics/system/systemInformation | 24.7 | Partial: Still using XMLRPC for Getting Device ID |


### PR DESCRIPTION
Keeps the legacy method for OPNsense < 24.7 as well (for now)