### PR TITLE
Move HA services from entity level to platform level

### DIFF
--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -145,7 +145,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     _LOGGER.error(message)
                     errors["base"] = "unknown"
-            except BaseException as err:
+            except Exception as err:
                 message = cleanse_sensitive_data(
                     f"Unexpected {err=}, {type(err)=}", [username, password]
                 )

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -58,7 +58,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
     async def _get_firmware_update_info(self):
         try:
             return await self._client.get_firmware_update_info()
-        except BaseException as e:
+        except Exception as e:
             _LOGGER.error(
                 f"Error in get_firmware_update_info. {e.__class__.__qualname__}: {e}"
             )
@@ -128,7 +128,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         if self._device_tracker_coordinator:
             try:
                 self._state["arp_table"] = await self._get_arp_table()
-            except BaseException as e:
+            except Exception as e:
                 _LOGGER.error(
                     f"Error getting arp table. {e.__class__.__qualname__}: {e}"
                 )

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -93,7 +93,7 @@ class OPNsenseClient(ABC):
                 return await func(self, *args, **kwargs)
             except asyncio.CancelledError as e:
                 raise e
-            except BaseException as e:
+            except Exception as e:
                 _LOGGER.error(
                     f"Error in {func.__name__.strip('_')}. {e.__class__.__qualname__}: {e}"
                 )

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -1,13 +1,18 @@
+from collections.abc import Mapping
 import logging
 
-from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_platform import async_get_platforms
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry,
+    entity_registry,
+)
 import voluptuous as vol
 
 from .const import (
     DOMAIN,
+    OPNSENSE_CLIENT,
     SERVICE_CLOSE_NOTICE,
     SERVICE_RESTART_SERVICE,
     SERVICE_SEND_WOL,
@@ -17,110 +22,295 @@ from .const import (
     SERVICE_SYSTEM_REBOOT,
 )
 
-_LOGGER = logging.getLogger(__name__)
-
-_data = set()
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-def async_get_entities(hass: HomeAssistant) -> dict[str, Entity]:
-    """Get entities for a domain."""
-    entities: dict[str, Entity] = {}
-    for platform in async_get_platforms(hass, DOMAIN):
-        entities.update(platform.entities)
-    return entities
+async def async_setup_services(hass: HomeAssistant) -> None:
+    async def _get_clients(
+        opndevice_id: str | None = None, opnentity_id: str | None = None
+    ) -> list:
+        if (
+            DOMAIN not in hass.data
+            or not isinstance(hass.data[DOMAIN], Mapping)
+            or len(hass.data[DOMAIN]) == 0
+        ):
+            return []
+        first_entry_id = next(iter(hass.data[DOMAIN]))
+        if len(hass.data[DOMAIN]) == 1:
+            if OPNSENSE_CLIENT in hass.data[DOMAIN][first_entry_id]:
+                _LOGGER.debug(f"[get_clients] Only 1 entry. entry_id: {first_entry_id}")
+                return [hass.data[DOMAIN][first_entry_id][OPNSENSE_CLIENT]]
+            return []
 
+        entry_ids: list = []
+        if opndevice_id:
+            try:
+                device_entry: device_registry.DeviceEntry = device_registry.async_get(
+                    hass
+                ).async_get(opndevice_id)
+            except Exception:
+                pass
+            else:
+                _LOGGER.debug(
+                    f"[get_clients] device_id: {opndevice_id}, device_entry: {device_entry}"
+                )
+                if device_entry.primary_config_entry not in entry_ids:
+                    entry_ids.append(device_entry.primary_config_entry)
+        if opnentity_id:
+            try:
+                entity_entry: entity_registry.RegistryEntry = entity_registry.async_get(
+                    hass
+                ).async_get(opnentity_id)
+            except Exception:
+                pass
+            else:
+                _LOGGER.debug(
+                    f"[get_clients] entity_id: {opnentity_id}, entity_entry: {entity_entry}"
+                )
+                if entity_entry.config_entry_id not in entry_ids:
+                    entry_ids.append(entity_entry.config_entry_id)
+        clients: list = []
+        _LOGGER.debug(f"[get_clients] entry_ids: {entry_ids}")
+        for entry_id, entry in hass.data[DOMAIN].items():
+            _LOGGER.debug(f"[get_clients] entry_id: {entry_id}")
+            if (
+                len(entry_ids) == 0 or entry_id in entry_ids
+            ) and OPNSENSE_CLIENT in entry:
+                clients.append(entry[OPNSENSE_CLIENT])
+        _LOGGER.debug(f"[get_clients] clients: {clients}")
+        return clients
 
-class ServiceRegistrar:
-    def __init__(
-        self,
-        hass: HomeAssistant,
-    ) -> None:
-        """Initialize with hass object."""
-        self.hass = hass
+    async def service_close_notice(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
+        )
+        _LOGGER.debug(f"[service_close_notice] clients: {clients}")
+        for client in clients:
+            _LOGGER.debug(
+                f"[service_close_notice] Calling stop_service for {call.data.get('id')}"
+            )
+            await client.close_notice(call.data.get("id"))
 
-    @callback
-    def async_register(self):
-        # services do not need to be reloaded for every config_entry
-        if "loaded" in _data:
-            return
-
-        _data.add("loaded")
-
-        # Setup services
-        async def _async_send_service(call: ServiceCall):
-            await self.hass.helpers.service.entity_service_call(
-                async_get_entities(self.hass), f"service_{call.service}", call
+    async def service_start_service(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
+        )
+        _LOGGER.debug(f"[service_start_service] clients: {clients}")
+        success = None
+        for client in clients:
+            _LOGGER.debug(
+                f"[service_start_service] Calling start_service for {call.data.get('service_id', call.data.get('service_name'))}"
+            )
+            response = await client.start_service(
+                call.data.get("service_id", call.data.get("service_name"))
+            )
+            if success is None or success:
+                success = response
+        if success is None or not success:
+            raise ServiceValidationError(
+                f"Start Service Failed: {call.data.get('service_id', call.data.get('service_name'))}"
             )
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_CLOSE_NOTICE,
-            schema=cv.make_entity_service_schema(
-                {
-                    vol.Optional("id", default="all"): vol.Any(
-                        cv.positive_int, cv.string
-                    ),
-                }
-            ),
-            service_func=_async_send_service,
+    async def service_stop_service(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
         )
+        _LOGGER.debug(f"[service_stop_service] clients: {clients}")
+        success = None
+        for client in clients:
+            _LOGGER.debug(
+                f"[service_stop_service] Calling stop_service for {call.data.get('service_id', call.data.get('service_name'))}"
+            )
+            response = await client.stop_service(
+                call.data.get("service_id", call.data.get("service_name"))
+            )
+            if success is None or success:
+                success = response
+        if success is None or not success:
+            raise ServiceValidationError(
+                f"Stop Service Failed: {call.data.get('service_id', call.data.get('service_name'))}"
+            )
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_START_SERVICE,
-            schema=cv.make_entity_service_schema(
-                {
-                    vol.Required("service_name"): vol.Any(cv.string),
-                }
-            ),
-            service_func=_async_send_service,
+    async def service_restart_service(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
         )
+        _LOGGER.debug(f"[service_restart_service] clients: {clients}")
+        success = None
+        if call.data.get("only_if_running"):
+            for client in clients:
+                _LOGGER.debug(
+                    f"[service_restart_service] Calling restart_service_if_running for {call.data.get('service_id', call.data.get('service_name'))}"
+                )
+                response = await client.restart_service_if_running(
+                    call.data.get(
+                        "service_id",
+                        call.data.get("service_name"),
+                    )
+                )
+                if success is None or success:
+                    success = response
+        else:
+            for client in clients:
+                _LOGGER.debug(
+                    f"[service_restart_service] Calling restart_service for {call.data.get('service_id', call.data.get('service_name'))}"
+                )
+                response = await client.restart_service(
+                    call.data.get(
+                        "service_id",
+                        call.data.get("service_name"),
+                    )
+                )
+                if success is None or success:
+                    success = response
+        if success is None or not success:
+            raise ServiceValidationError(
+                f"Restart Service Failed: {call.data.get('service_id', call.data.get('service_name'))}"
+            )
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_STOP_SERVICE,
-            schema=cv.make_entity_service_schema(
-                {
-                    vol.Required("service_name"): vol.Any(cv.string),
-                }
-            ),
-            service_func=_async_send_service,
+    async def service_system_halt(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
         )
+        _LOGGER.debug(f"[service_system_halt] clients: {clients}")
+        for client in clients:
+            _LOGGER.debug("[service_system_halt] Calling System Halt")
+            await client.system_halt()
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_RESTART_SERVICE,
-            schema=cv.make_entity_service_schema(
-                {
-                    vol.Required("service_name"): vol.Any(cv.string),
-                    vol.Optional("only_if_running"): cv.boolean,
-                }
-            ),
-            service_func=_async_send_service,
+    async def service_system_reboot(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
         )
+        _LOGGER.debug(f"[service_system_reboot] clients: {clients}")
+        for client in clients:
+            _LOGGER.debug("[service_system_reboot] Calling System Reboot")
+            await client.system_reboot()
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_SYSTEM_HALT,
-            schema=cv.make_entity_service_schema({}),
-            service_func=_async_send_service,
+    async def service_send_wol(call: ServiceCall) -> None:
+        clients: list = await _get_clients(
+            call.data.get("device_id", []), call.data.get("entity_id", [])
         )
+        _LOGGER.debug(f"[service_send_wol] clients: {clients}")
+        for client in clients:
+            _LOGGER.debug(
+                f"[service_send_wol] Calling WOL. interface: {call.data.get('interface')}, mac: {call.data.get('mac')}"
+            )
+            await client.send_wol(call.data.get("interface"), call.data.get("mac"))
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_SYSTEM_REBOOT,
-            schema=cv.make_entity_service_schema({}),
-            service_func=_async_send_service,
-        )
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_CLOSE_NOTICE,
+        schema=vol.Schema(
+            {
+                vol.Required("id", default="all"): vol.Any(cv.positive_int, cv.string),
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_close_notice,
+    )
 
-        self.hass.services.async_register(
-            domain=DOMAIN,
-            service=SERVICE_SEND_WOL,
-            schema=cv.make_entity_service_schema(
-                {
-                    vol.Required("interface"): vol.Any(cv.string),
-                    vol.Required("mac"): vol.Any(cv.string),
-                }
-            ),
-            service_func=_async_send_service,
-        )
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_START_SERVICE,
+        schema=vol.Schema(
+            {
+                vol.Exclusive(
+                    "service_id",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Exclusive(
+                    "service_name",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_start_service,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_STOP_SERVICE,
+        schema=vol.Schema(
+            {
+                vol.Exclusive(
+                    "service_id",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Exclusive(
+                    "service_name",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_stop_service,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_RESTART_SERVICE,
+        schema=vol.Schema(
+            {
+                vol.Exclusive(
+                    "service_id",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Exclusive(
+                    "service_name",
+                    "service_type",
+                    msg="Must use service_id or service_name but not both",
+                ): cv.string,
+                vol.Optional("only_if_running"): cv.boolean,
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_restart_service,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_SYSTEM_HALT,
+        schema=vol.Schema(
+            {
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_system_halt,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_SYSTEM_REBOOT,
+        schema=vol.Schema(
+            {
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_system_reboot,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_SEND_WOL,
+        schema=vol.Schema(
+            {
+                vol.Required("interface"): vol.Any(cv.string),
+                vol.Required("mac"): vol.Any(cv.string),
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=service_send_wol,
+    )

--- a/custom_components/opnsense/services.yaml
+++ b/custom_components/opnsense/services.yaml
@@ -1,119 +1,265 @@
 close_notice:
-  # Service name as shown in UI
   name: Close notice
-  # Description of the service
-  description: Closes a notice(s).
-  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area. If `target` is specified, `entity_id` should not be defined in the `fields` map. By default it shows only targets matching entities from the same domain as the service, but if further customization is required, target supports the entity, device, and area selectors (https://www.home-assistant.io/docs/blueprint/selectors/). Entity selector parameters will automatically be applied to device and area, and device selector parameters will automatically be applied to area. 
-  #target:
-  # Different fields that your service accepts
+  description: Closes one or all notices on OPNsense
   fields:
-    entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
-
-    # Key of the field
     id:
-      # Field name as shown in UI
       name: Notice ID
-      # Description of the field
-      description: The notice ID
-      # Whether or not field is required (default = false)
-      required: false
-      # Advanced fields are only shown when the advanced mode is enabled for the user (default = false)
+      description: "The notice ID to clear. Enter 'all' to clear all notices."
+      required: true
       advanced: false
-      # Example value that can be passed for this field
       example: "all"
-      # The default field value
       default: "all"
+      selector:
+        text:
+    multiple_opnsense:
+      name: Only needed if there is more than one OPNsense Router
+      collapsed: true
+      fields:
+        device_id:
+          name: OPNsense Device
+          description: Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          name: OPNsense Entity
+          description: Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor
 
 start_service:
   name: Start service
-  description: Starts a service.
+  description: Starts an OPNsense service
   fields:
-    entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
-    service_name:
-      name: Service Name
-      description: The name of the service.
-      required: true
+    service_id:
+      name: Service ID or Name
+      description: "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+      required: false
       advanced: false
-      example: "haproxy|dhcp|dpinger|.."
       default: ""
+      selector:
+        text:
+    multiple_opnsense:
+      name: Only needed if there is more than one OPNsense Router
+      collapsed: true
+      fields:
+        device_id:
+          name: OPNsense Device
+          description: Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          name: OPNsense Entity
+          description: Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor
 
 stop_service:
   name: Stop service
-  description: Stops a service.
+  description: Stops an OPNsense service
   fields:
-    entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
-    service_name:
-      name: Service Name
-      description: The name of the service.
-      required: true
+    service_id:
+      name: Service ID or Name
+      description: "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+      required: false
       advanced: false
-      example: "haproxy|dhcp|dpinger|.."
       default: ""
+      selector:
+        text:
+    multiple_opnsense:
+      name: Only needed if there is more than one OPNsense Router
+      collapsed: true
+      fields:
+        device_id:
+          name: OPNsense Device
+          description: Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          name: OPNsense Entity
+          description: Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor
 
 restart_service:
   name: Restart service
-  description: Restarts a service.
+  description: Restarts an OPNsense service
   fields:
-    entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
-    service_name:
-      name: Service Name
-      description: The name of the service.
+    service_id:
+      name: Service ID or Name
+      description: "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+      required: false
+      advanced: false
+      default: ""
+      selector:
+        text:
+    only_if_running:
+      name: Only if Running
+      description: Restart the service only if it is already running.
       required: true
       advanced: false
-      example: "haproxy|dhcp|dpinger|.."
-      default: ""
+      example: false
+      default: false
+      selector:
+        boolean:
+    multiple_opnsense:
+      name: Only needed if there is more than one OPNsense Router
+      collapsed: true
+      fields:
+        device_id:
+          name: OPNsense Device
+          description: Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          name: OPNsense Entity
+          description: Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor
 
 system_halt:
   name: Halt system
-  description: Halts the system.
+  description: Halts the OPNsense Router
   fields:
+    device_id:
+      name: OPNsense Device
+      description: Only needed if there is more than one OPNsense Router. Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+      required: false
+      selector:
+        device:
+          multiple: false
+          filter:
+            - integration: opnsense
+          entity:
+            - domain: sensor
     entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
+      name: OPNsense Entity
+      description: Only needed if there is more than one OPNsense Router. Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+      example: "sensor.opnsense_interface_lan_status"
+      required: false
+      selector:
+        entity:
+          multiple: false
+          filter:
+            - integration: opnsense
+              domain: sensor
 
 system_reboot:
   name: Reboot system
-  description: Reboots the system.
+  description: Reboots the OPNsense Router
   fields:
+    device_id:
+      name: OPNsense Device
+      description: Only needed if there is more than one OPNsense Router. Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+      required: false
+      selector:
+        device:
+          multiple: false
+          filter:
+            - integration: opnsense
+          entity:
+            - domain: sensor
     entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
+      name: OPNsense Entity
+      description: Only needed if there is more than one OPNsense Router. Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+      example: "sensor.opnsense_interface_lan_status"
+      required: false
+      selector:
+        entity:
+          multiple: false
+          filter:
+            - integration: opnsense
+              domain: sensor
 
 send_wol:
   name: Send WOL
-  description: Sends wake-on-lan magic packet.
+  description: Sends a wake-on-lan magic packet
   fields:
-    entity_id:
-      name: Entity ID
-      description: OPNsense entity id
-      example: "binary_sensor.opnsense_localdomain_pending_notices_present"
-
     interface:
       name: Interface Name
-      description: The name of the interface.
+      description: "The name of the interface. Like: wan|lan|opt1|opt2|.."
       required: true
       advanced: false
-      example: "wan|lan|opt1|opt2|..."
-      default: ""
-
+      example: ""
+      selector:
+        text:
     mac:
       name: MAC Address
       description: The target mac address.
       required: true
       advanced: false
-      example: ""
-      default: ""
+      selector:
+        text:
+    multiple_opnsense:
+      name: Only needed if there is more than one OPNsense Router
+      collapsed: true
+      fields:
+        device_id:
+          name: OPNsense Device
+          description: Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          name: OPNsense Entity
+          description: Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers.
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor


### PR DESCRIPTION
- Made it so that the entity is no longer needed if there is only 1 OPNsense Router
- Added UI details to all services
- Improved descriptions
- Stops using the deprecated `hass.helpers.service`
- For the OPNsense service actions (fka. services), will accept `service_id` or `service_name` (but not both in a single call). No matter which one is used, it will actually work if the item is a Service ID or a Service Name. `service_id` is now shown as the default, but `service_name` will continue to work so previous automations, etc. should continue to work.

Should be released with #206