### PR TITLE
Move OPNsense services functions to REST API

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -222,12 +222,12 @@ class CoordinatorEntityManager:
     @callback
     def process_entities(self):
         entities = self.process_entities_callback(self.hass, self.config_entry)
-        i_entity_unqiue_ids = set()
+        i_entity_unique_ids = set()
         for entity in entities:
             unique_id = entity.unique_id
             if unique_id is None:
-                raise Exception("unique_id is missing from entity")
-            i_entity_unqiue_ids.add(unique_id)
+                raise ValueError("unique_id is missing from entity")
+            i_entity_unique_ids.add(unique_id)
             if unique_id not in self.entity_unique_ids:
                 self.async_add_entities([entity])
                 self.entity_unique_ids.add(unique_id)
@@ -239,7 +239,7 @@ class CoordinatorEntityManager:
 
         # check for missing entities
         for entity_unique_id in self.entity_unique_ids:
-            if entity_unique_id not in i_entity_unqiue_ids:
+            if entity_unique_id not in i_entity_unique_ids:
                 pass
                 # print("should remove entity: " + str(self.entities[entity_unique_id].entry_id))
                 # print("candidate to remove entity: " + str(entity_unique_id))

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -179,7 +179,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     if previous_interface is None:
                         break
 
-                    for property in [
+                    for prop_name in [
                         "inbytes",
                         "outbytes",
                         # "inbytespass",
@@ -193,16 +193,16 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                         # "inpktsblock",
                         # "outpktsblock",
                     ]:
-                        current_parent_value = interface[property]
-                        previous_parent_value = previous_interface[property]
+                        current_parent_value = interface[prop_name]
+                        previous_parent_value = previous_interface[prop_name]
                         change = abs(current_parent_value - previous_parent_value)
                         rate = change / elapsed_time
 
                         value = 0
-                        if "pkts" in property:
+                        if "pkts" in prop_name:
                             label = "packets_per_second"
                             value = rate
-                        if "bytes" in property:
+                        if "bytes" in prop_name:
                             label = "kilobytes_per_second"
                             # 1 Byte = 8 bits
                             # 1 byte is equal to 0.001 kilobytes
@@ -210,7 +210,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                             # Kbs = KBs * 8
                             value = KBs
 
-                        new_property = f"{property}_{label}"
+                        new_property = f"{prop_name}_{label}"
                         interface[new_property] = int(round(value, 0))
 
                 for server_name in dict_get(
@@ -237,20 +237,20 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                         "openvpn"
                     ]["servers"][server_name]
 
-                    for property in [
+                    for prop_name in [
                         "total_bytes_recv",
                         "total_bytes_sent",
                     ]:
-                        current_parent_value = server[property]
-                        previous_parent_value = previous_server[property]
+                        current_parent_value = server[prop_name]
+                        previous_parent_value = previous_server[prop_name]
                         change = abs(current_parent_value - previous_parent_value)
                         rate = change / elapsed_time
 
                         value = 0
-                        if "pkts" in property:
+                        if "pkts" in prop_name:
                             label = "packets_per_second"
                             value = rate
-                        if "bytes" in property:
+                        if "bytes" in prop_name:
                             label = "kilobytes_per_second"
                             # 1 Byte = 8 bits
                             # 1 byte is equal to 0.001 kilobytes
@@ -258,6 +258,6 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                             # Kbs = KBs * 8
                             value = KBs
 
-                        new_property: str = f"{property}_{label}"
+                        new_property: str = f"{prop_name}_{label}"
                         server[new_property] = int(round(value, 0))
         return self._state

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -204,8 +204,8 @@ class OPNsenseScannerEntity(OPNsenseEntity, ScannerEntity):
         """Return extra state attributes."""
         entry = self._get_opnsense_arp_entry()
         if entry is not None:
-            for property in ["interface", "expires", "type"]:
-                self._extra_state[property] = entry.get(property)
+            for prop_name in ["interface", "expires", "type"]:
+                self._extra_state[prop_name] = entry.get(prop_name)
 
         if self._last_known_hostname is not None:
             self._extra_state["last_known_hostname"] = self._last_known_hostname

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -138,7 +138,7 @@ async def async_setup_entry(
         for interface_name, interface in dict_get(
             state, "telemetry.interfaces", {}
         ).items():
-            for property in [
+            for prop_name in [
                 "status",
                 "inerrs",
                 "outerrs",
@@ -175,7 +175,7 @@ async def async_setup_entry(
                 # entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
                 # enabled_default
-                if property in [
+                if prop_name in [
                     "status",
                     "inbytes_kilobytes_per_second",
                     "outbytes_kilobytes_per_second",
@@ -186,34 +186,34 @@ async def async_setup_entry(
 
                 # state class
                 if (
-                    "_packets_per_second" in property
-                    or "_kilobytes_per_second" in property
+                    "_packets_per_second" in prop_name
+                    or "_kilobytes_per_second" in prop_name
                 ):
                     state_class = SensorStateClass.MEASUREMENT
 
                 # native_unit_of_measurement
-                if "_packets_per_second" in property:
+                if "_packets_per_second" in prop_name:
                     native_unit_of_measurement = DATA_RATE_PACKETS_PER_SECOND
 
-                if "_kilobytes_per_second" in property:
+                if "_kilobytes_per_second" in prop_name:
                     native_unit_of_measurement = UnitOfDataRate.KILOBYTES_PER_SECOND
 
                 if native_unit_of_measurement is None:
-                    if "bytes" in property:
+                    if "bytes" in prop_name:
                         native_unit_of_measurement = UnitOfInformation.BYTES
                         state_class = SensorStateClass.TOTAL_INCREASING
-                    if "pkts" in property:
+                    if "pkts" in prop_name:
                         native_unit_of_measurement = DATA_PACKETS
                         state_class = SensorStateClass.TOTAL_INCREASING
 
-                if property in ["inerrs", "outerrs", "collisions"]:
+                if prop_name in ["inerrs", "outerrs", "collisions"]:
                     native_unit_of_measurement = COUNT
 
                 # icon
-                if "pkts" in property or "bytes" in property:
+                if "pkts" in prop_name or "bytes" in prop_name:
                     icon = "mdi:server-network"
 
-                if property == "status":
+                if prop_name == "status":
                     icon = "mdi:check-network-outline"
 
                 if icon is None:
@@ -223,8 +223,8 @@ async def async_setup_entry(
                     config_entry,
                     coordinator,
                     SensorEntityDescription(
-                        key=f"telemetry.interface.{interface_name}.{property}",
-                        name=f"Interface {interface_name} {property}",
+                        key=f"telemetry.interface.{interface_name}.{prop_name}",
+                        name=f"Interface {interface_name} {prop_name}",
                         native_unit_of_measurement=native_unit_of_measurement,
                         icon=icon,
                         state_class=state_class,
@@ -236,28 +236,28 @@ async def async_setup_entry(
 
         # gateways
         for gateway in dict_get(state, "telemetry.gateways", {}).values():
-            for property in ["status", "delay", "stddev", "loss"]:
+            for prop_name in ["status", "delay", "stddev", "loss"]:
                 state_class = None
                 native_unit_of_measurement = None
                 icon = "mdi:router-network"
                 enabled_default = True
                 # entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
-                if property == "loss":
+                if prop_name == "loss":
                     native_unit_of_measurement = PERCENTAGE
 
-                if property in ["delay", "stddev"]:
+                if prop_name in ["delay", "stddev"]:
                     native_unit_of_measurement = UnitOfTime.MILLISECONDS
 
-                if property == "status":
+                if prop_name == "status":
                     icon = "mdi:check-network-outline"
 
                 entity = OPNsenseGatewaySensor(
                     config_entry,
                     coordinator,
                     SensorEntityDescription(
-                        key=f"telemetry.gateway.{gateway["name"]}.{property}",
-                        name=f"Gateway {gateway["name"]} {property}",
+                        key=f"telemetry.gateway.{gateway["name"]}.{prop_name}",
+                        name=f"Gateway {gateway["name"]} {prop_name}",
                         native_unit_of_measurement=native_unit_of_measurement,
                         icon=icon,
                         state_class=state_class,
@@ -273,7 +273,7 @@ async def async_setup_entry(
             server: Mapping[str, Any] | None = servers.get(vpnid, None)
             if server is None or not isinstance(server, Mapping) or len(server) == 0:
                 continue
-            for property in [
+            for prop_name in [
                 "connected_client_count",
                 "total_bytes_recv",
                 "total_bytes_sent",
@@ -286,28 +286,28 @@ async def async_setup_entry(
                 enabled_default = False
 
                 # state class
-                if "_kilobytes_per_second" in property:
+                if "_kilobytes_per_second" in prop_name:
                     state_class = SensorStateClass.MEASUREMENT
 
-                if property == "connected_client_count":
+                if prop_name == "connected_client_count":
                     state_class = SensorStateClass.MEASUREMENT
 
                 # native_unit_of_measurement
-                if "_kilobytes_per_second" in property:
+                if "_kilobytes_per_second" in prop_name:
                     native_unit_of_measurement = UnitOfDataRate.KILOBYTES_PER_SECOND
 
                 if native_unit_of_measurement is None:
-                    if "bytes" in property:
+                    if "bytes" in prop_name:
                         native_unit_of_measurement = UnitOfInformation.BYTES
 
-                if property in ["connected_client_count"]:
+                if prop_name in ["connected_client_count"]:
                     native_unit_of_measurement = "clients"
 
                 # icon
-                if "bytes" in property:
+                if "bytes" in prop_name:
                     icon = "mdi:server-network"
 
-                if property == "connected_client_count":
+                if prop_name == "connected_client_count":
                     icon = "mdi:ip-network-outline"
 
                 if icon is None:
@@ -317,8 +317,8 @@ async def async_setup_entry(
                     config_entry,
                     coordinator,
                     SensorEntityDescription(
-                        key=f"telemetry.openvpn.servers.{vpnid}.{property}",
-                        name=f"OpenVPN Server {server["name"]} {property}",
+                        key=f"telemetry.openvpn.servers.{vpnid}.{prop_name}",
+                        name=f"OpenVPN Server {server["name"]} {prop_name}",
                         native_unit_of_measurement=native_unit_of_measurement,
                         icon=icon,
                         state_class=state_class,
@@ -503,8 +503,8 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
     @property
     def available(self) -> bool:
         interface = self._opnsense_get_interface()
-        property = self._opnsense_get_interface_property_name()
-        if interface is None or property not in interface.keys():
+        prop_name = self._opnsense_get_interface_property_name()
+        if interface is None or prop_name not in interface.keys():
             return False
 
         return super().available
@@ -521,17 +521,17 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
 
     @property
     def icon(self):
-        property = self._opnsense_get_interface_property_name()
-        if property == "status" and self.native_value != "up":
+        prop_name = self._opnsense_get_interface_property_name()
+        if prop_name == "status" and self.native_value != "up":
             return "mdi:close-network-outline"
         return super().icon
 
     @property
     def native_value(self):
         interface = self._opnsense_get_interface()
-        property: str = self._opnsense_get_interface_property_name()
+        prop_name: str = self._opnsense_get_interface_property_name()
         try:
-            return interface[property]
+            return interface[prop_name]
         except (KeyError, TypeError):
             return STATE_UNKNOWN
 
@@ -608,12 +608,12 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
     @property
     def available(self) -> bool:
         gateway = self._opnsense_get_gateway()
-        property: str = self._opnsense_get_gateway_property_name()
-        if gateway is None or property not in gateway.keys():
+        prop_name: str = self._opnsense_get_gateway_property_name()
+        if gateway is None or prop_name not in gateway.keys():
             return False
 
-        if property in ["stddev", "delay", "loss"]:
-            value = gateway[property]
+        if prop_name in ["stddev", "delay", "loss"]:
+            value = gateway[prop_name]
             if isinstance(value, str):
                 value = re.sub(r"[^0-9\.]*", "", value)
                 if len(value) < 1:
@@ -635,23 +635,23 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
 
     @property
     def icon(self):
-        property = self._opnsense_get_gateway_property_name()
-        if property == "status" and self.native_value != "online":
+        prop_name = self._opnsense_get_gateway_property_name()
+        if prop_name == "status" and self.native_value != "online":
             return "mdi:close-network-outline"
         return super().icon
 
     @property
     def native_value(self):
         gateway = self._opnsense_get_gateway()
-        property = self._opnsense_get_gateway_property_name()
+        prop_name = self._opnsense_get_gateway_property_name()
 
         if gateway is None:
             return STATE_UNKNOWN
 
         try:
-            value = gateway[property]
+            value = gateway[prop_name]
             # cleanse "ms", etc from values
-            if property in ["stddev", "delay", "loss"]:
+            if prop_name in ["stddev", "delay", "loss"]:
                 if isinstance(value, str):
                     value = re.sub(r"[^0-9\.]*", "", value)
                     if len(value) > 0:
@@ -683,8 +683,8 @@ class OPNsenseOpenVPNServerSensor(OPNsenseSensor):
     @property
     def available(self) -> bool:
         server = self._opnsense_get_server()
-        property = self._opnsense_get_server_property_name()
-        if server is None or property not in server.keys():
+        prop_name = self._opnsense_get_server_property_name()
+        if server is None or prop_name not in server.keys():
             return False
 
         return super().available
@@ -704,13 +704,13 @@ class OPNsenseOpenVPNServerSensor(OPNsenseSensor):
     @property
     def native_value(self):
         server = self._opnsense_get_server()
-        property = self._opnsense_get_server_property_name()
+        prop_name = self._opnsense_get_server_property_name()
 
         if server is None:
             return STATE_UNKNOWN
 
         try:
-            return server[property]
+            return server[prop_name]
         except KeyError:
             return STATE_UNKNOWN
 

--- a/function_method.md
+++ b/function_method.md
@@ -4,24 +4,19 @@
 | ----- | ----- | ----- | ----- |
 | Get Config | Yes | No as of 24.7 | Returns a __large__ dictionary of elements used for multiple functions. Some can be replaced, others cannot. More details in the other functions. |
 | Restore Config Section | No | No as of 24.7 | |
-| Get/List Services | No | Yes | |
-| Start Service | No | Yes | |
-| Stop Service | No | Yes | |
-| Restart Service | No | Yes | |
-| Restart Service if Running | No | Yes | |
 | Filter Configure | Yes | No as of 24.7 | Used by the Filter and NAT functions |
-| Get Device ID | Yes | Maybe | Used as Unique ID for device. It is just a random 10 digit number generated the first time it is requested. May be able to transition to using the Config Entry ID or something else as a Unique ID. |
-| Get Interfaces | Yes | Yes | Uses Get Config. Can use same function that is used for the Interface data for the Telemetry data. |
 | Enable Filter Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
 | Disable Filter Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
 | Enable NAT Port Forward Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
 | Disable NAT Port Forward Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
 | Enable NAT Outbound Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
 | Disable NAT Outbound Rule | Yes | No as of 24.7 | Uses Get Config, Filter Configure and Restore Config Section. |
-| Get Configured Interface Descriptions | Yes | | |
-| Get Gateways | Yes | Yes | Can use same function that is used for the Gateway data for the Telemetry data. |
-| Get Gateways Status | Yes | | |
+| Get Configured Interface Descriptions | Yes | | Doesn't appear to be used anymore. Probably just remove altogether. |
+| Get Gateways | Yes | Yes | Doesn't appear to be used anymore. Probably just remove altogether. |
+| Get Gateways Status | Yes | | Doesn't appear to be used anymore. Probably just remove altogether. |
 | Get DHCP Leases | Yes | Yes | Currently not in use, but desired feature. Will need to handle both the legacy DHCP and Kea endpoints. |
+| Get Device ID | Yes | Maybe | Used as Unique ID for device. It is just a random 10 digit number generated the first time it is requested. May be able to transition to using the Config Entry ID or something else as a Unique ID. |
+| Get Interfaces | Yes | Yes | Uses Get Config. Can use same function that is used for the Interface data for the Telemetry data. |
 | Get Carp Status | Yes | Yes | |
 | Get Carp Interfaces | Yes | Yes | |
 | Delete ARP Entry | Yes | | |
@@ -51,3 +46,7 @@
 | Get System Info | /api/diagnostics/system/systemInformation | 24.7 | Partial: Still using XMLRPC for Getting Device ID |
 | Get Notices | /api/core/system/status | 2022 | |
 | Close Notice | /api/core/system/status<br>/api/core/system/dismissStatus | 2022 | |
+| Get Services | /api/core/service/search | 2023 | |
+| Start Service | /api/core/service/start | 2023 | |
+| Stop Service | /api/core/service/stop | 2023 | |
+| Restart Service | /api/core/service/restart | 2023 | |


### PR DESCRIPTION
* Will create more detailed service switches than before. For example, I use udpbroadcastrelay. Previously, there would be a single switch to turn on/off the entire service. Now there will be a separate switch for each entry. 
  * The Service Name is more broad and the Service ID is specific to a single entry in a service (when applicable). Both will work in the HA Action (fka. Service) Calls
  * Shows the Service Name and Service ID as attributes of the Service Switches.
* Does not create switches for services that are unable to be stopped. These are listed as locked. ex. webgui, sysctl
* Renames the field property to prop_name to not conflict with the property decorator
* Fixes typo of unqiue to unique

Should be released with #204