### PR TITLE
Optimize switches with concurrency and update logic

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -11,7 +11,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
-from homeassistant.util import slugify
 
 from . import CoordinatorEntityManager, OPNsenseEntity
 from .const import COORDINATOR, DOMAIN
@@ -83,15 +82,14 @@ class OPNsenseBinarySensor(OPNsenseEntity, BinarySensorEntity):
         entity_description: BinarySensorEntityDescription,
         enabled_default: bool,
     ) -> None:
-        """Initialize the sensor."""
-        self.config_entry = config_entry
-        self.entity_description = entity_description
-        self.coordinator = coordinator
-        self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_name = f"{self.opnsense_device_name} {entity_description.name}"
-        self._attr_unique_id = slugify(
-            f"{self.opnsense_device_unique_id}_{entity_description.key}"
+        super().__init__(
+            config_entry,
+            coordinator,
+            unique_id_suffix=entity_description.key,
+            name_suffix=entity_description.name,
         )
+        self.entity_description = entity_description
+        self._attr_entity_registry_enabled_default = enabled_default
 
     @property
     def is_on(self):

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -53,6 +53,8 @@ DATA_RATE_PACKETS_PER_SECOND = f"{DATA_PACKETS}/{UnitOfTime.SECONDS}"
 ICON_MEMORY = "mdi:memory"
 
 ATTR_UNBOUND_BLOCKLIST = "unbound_blocklist"
+ATTR_NAT_PORT_FORWARD = "nat_port_forward"
+ATTR_NAT_OUTBOUND = "nat_outbound"
 
 SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     # pfstate

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -154,10 +154,8 @@ class OPNsenseScannerEntity(OPNsenseEntity, ScannerEntity):
         mac: str,
         mac_vendor: str,
     ) -> None:
-        """Set up the pfSense scanner entity."""
-        self.hass = hass
-        self.config_entry = config_entry
-        self.coordinator = coordinator
+        """Set up the OPNsense scanner entity."""
+        super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_address = mac
         self._mac_vendor = mac_vendor
         self._last_known_ip = None
@@ -166,9 +164,6 @@ class OPNsenseScannerEntity(OPNsenseEntity, ScannerEntity):
         self._extra_state = {}
 
         self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_unique_id = get_device_tracker_unique_id(
-            mac, self.opnsense_device_unique_id
-        )
 
     def _get_opnsense_arp_entry(self) -> dict[str, str]:
         state = self.coordinator.data

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -374,14 +374,9 @@ class OPNsenseSensor(OPNsenseEntity, SensorEntity):
         enabled_default: bool,
     ) -> None:
         """Initialize the sensor."""
-        self.config_entry = config_entry
+        super().__init__(config_entry, coordinator, unique_id_suffix=entity_description.key, name_suffix=entity_description.name)
         self.entity_description = entity_description
-        self.coordinator = coordinator
         self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_name: str = f"{self.opnsense_device_name} {entity_description.name}"
-        self._attr_unique_id: str = slugify(
-            f"{self.opnsense_device_unique_id}_{entity_description.key}"
-        )
         self._previous_value = None
 
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -11,15 +11,17 @@ from homeassistant.components.switch import (
     SwitchEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN  # ENTITY_CATEGORY_CONFIG,
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
-from homeassistant.util import slugify
-
-from custom_components.opnsense.pyopnsense import OPNsenseClient
 
 from . import OPNsenseEntity
-from .const import ATTR_UNBOUND_BLOCKLIST, COORDINATOR, DOMAIN
+from .const import (
+    ATTR_NAT_OUTBOUND,
+    ATTR_NAT_PORT_FORWARD,
+    ATTR_UNBOUND_BLOCKLIST,
+    COORDINATOR,
+    DOMAIN,
+)
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .helpers import dict_get
 
@@ -96,9 +98,6 @@ async def _compile_port_forward_switches(
                 # we use tracker as the unique id
                 if tracker is None or len(tracker) < 1:
                     continue
-
-                if "descr" not in rule.keys():
-                    rule["descr"] = ""
 
                 entity = OPNsenseNatSwitch(
                     config_entry=config_entry,
@@ -202,8 +201,8 @@ async def _compile_static_switches(
         config_entry=config_entry,
         coordinator=coordinator,
         entity_description=SwitchEntityDescription(
-            key=f"unbound_blocklist.switch",
-            name=f"Unbound Blocklist Switch",
+            key="unbound_blocklist.switch",
+            name="Unbound Blocklist Switch",
             # icon=icon,
             # entity_category=ENTITY_CATEGORY_CONFIG,
             device_class=SwitchDeviceClass.SWITCH,
@@ -226,12 +225,6 @@ async def async_setup_entry(
     ][COORDINATOR]
     state: Mapping[str, Any] = coordinator.data
 
-    _LOGGER.debug(f"[switch async_setup_entry] coordinator: {coordinator}")
-    _LOGGER.debug(f"[switch async_setup_entry] state length: {len(state)}")
-    _LOGGER.debug(f"[switch async_setup_entry] state keys: {state.keys()}")
-
-    # entities = await _compile_static_switches(config_entry, coordinator, state)
-
     results: list = await asyncio.gather(
         _compile_filter_switches(config_entry, coordinator, state),
         _compile_port_forward_switches(config_entry, coordinator, state),
@@ -240,6 +233,7 @@ async def async_setup_entry(
         _compile_static_switches(config_entry, coordinator, state),
         return_exceptions=True,
     )
+
     entities: list = []
     for result in results:
         if isinstance(result, list):
@@ -260,25 +254,46 @@ class OPNsenseSwitch(OPNsenseEntity, SwitchEntity):
         coordinator: OPNsenseDataUpdateCoordinator,
         entity_description: SwitchEntityDescription,
     ) -> None:
-        """Initialize the entity."""
-        self.config_entry = config_entry
-        self.entity_description = entity_description
-        self.coordinator: OPNsenseDataUpdateCoordinator = coordinator
-        self._attr_name = f"{self.opnsense_device_name} {entity_description.name}"
-        self._attr_unique_id = slugify(
-            f"{self.opnsense_device_unique_id}_{entity_description.key}"
+        super().__init__(
+            config_entry,
+            coordinator,
+            unique_id_suffix=entity_description.key,
+            name_suffix=entity_description.name,
         )
+        self.entity_description = entity_description
+        self._attr_is_on: bool = False
+        self._attr_extra_state_attributes: Mapping[str, Any] = {}
+        self._available: bool = False
 
-    # @property
-    # def is_on(self):
-    #     return False
+    @property
+    def available(self) -> bool:
+        return self._available
 
-    # @property
-    # def extra_state_attributes(self):
-    #     return None
+    # Move this to OPNsenseEntity once all entity-types are updated
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
 
 
 class OPNsenseFilterSwitch(OPNsenseSwitch):
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+        )
+        self._tracker: str = self._opnsense_get_tracker()
+        self._rule: Mapping[str, Any] | None = None
+        _LOGGER.debug(
+            f"[OPNsenseFilterSwitch init] Name: {self.name}, tracker: {self._tracker}"
+        )
+
     def _opnsense_get_tracker(self) -> str:
         parts = self.entity_description.key.split(".")
         parts.pop(0)
@@ -287,53 +302,60 @@ class OPNsenseFilterSwitch(OPNsenseSwitch):
     def _opnsense_get_rule(self):
         state: Mapping[str, Any] = self.coordinator.data
         tracker: str = self._opnsense_get_tracker()
-        for rule in state["config"]["filter"]["rule"]:
+        for rule in state.get("config", {}).get("filter", {}).get("rule", []):
             if dict_get(rule, "created.time") == tracker:
                 return rule
         return None
 
-    @property
-    def available(self) -> bool:
-        rule = self._opnsense_get_rule()
-        if rule is None:
-            return False
-
-        return super().available
-
-    @property
-    def is_on(self):
-        rule = self._opnsense_get_rule()
-        if rule is None:
-            return STATE_UNKNOWN
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._rule = self._opnsense_get_rule()
         try:
-            if "disabled" not in rule.keys():
-                return True
-            return bool(rule["disabled"] != "1")
-        except KeyError:
-            return STATE_UNKNOWN
+            self._attr_is_on = bool(self._rule.get("disabled", "0") != "1")
+        except (TypeError, KeyError):
+            self._available = False
+            return
+        self._available = True
+        self.async_write_ha_state()
+        _LOGGER.debug(
+            f"[OPNsenseFilterSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}"
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        rule = self._opnsense_get_rule()
-        if rule is None:
+        if self._rule is None:
             return
-        tracker: str = self._opnsense_get_tracker()
-        client: OPNsenseClient = self._get_opnsense_client()
-        await client.enable_filter_rule_by_created_time(tracker)
+        await self._client.enable_filter_rule_by_created_time(self._tracker)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        rule = self._opnsense_get_rule()
-        if rule is None:
+        if self._rule is None:
             return
-        tracker: str = self._opnsense_get_tracker()
-        client: OPNsenseClient = self._get_opnsense_client()
-        await client.disable_filter_rule_by_created_time(tracker)
+        await self._client.disable_filter_rule_by_created_time(self._tracker)
         await self.coordinator.async_refresh()
 
 
 class OPNsenseNatSwitch(OPNsenseSwitch):
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+        )
+        self._rule_type: str = self._opnsense_get_rule_type()
+        self._tracker: str = self._opnsense_get_tracker()
+        self._rule: Mapping[str, Any] | None = None
+        _LOGGER.debug(
+            f"[OPNsenseNatSwitch init] Name: {self.name}, tracker: {self._tracker}, rule_type: {self._rule_type}"
+        )
+
     def _opnsense_get_rule_type(self) -> str:
         return self.entity_description.key.split(".")[0]
 
@@ -344,71 +366,82 @@ class OPNsenseNatSwitch(OPNsenseSwitch):
 
     def _opnsense_get_rule(self):
         state: Mapping[str, Any] = self.coordinator.data
-        tracker: str = self._opnsense_get_tracker()
-        rule_type: str = self._opnsense_get_rule_type()
         rules: list = []
-        if rule_type == "nat_port_forward":
-            rules = state["config"]["nat"]["rule"]
-        if rule_type == "nat_outbound":
-            rules = state["config"]["nat"]["outbound"]["rule"]
+        if self._rule_type == ATTR_NAT_PORT_FORWARD:
+            rules = state.get("config", {}).get("nat", {}).get("rule", [])
+        if self._rule_type == ATTR_NAT_OUTBOUND:
+            rules = (
+                state.get("config", {})
+                .get("nat", {})
+                .get("outbound", {})
+                .get("rule", [])
+            )
 
         for rule in rules:
-            if dict_get(rule, "created.time") == tracker:
+            if dict_get(rule, "created.time") == self._tracker:
                 return rule
         return None
 
-    @property
-    def available(self) -> bool:
-        rule = self._opnsense_get_rule()
-        if rule is None:
-            return False
-
-        return super().available
-
-    @property
-    def is_on(self):
-        rule = self._opnsense_get_rule()
-        if rule is None:
-            return STATE_UNKNOWN
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._rule = self._opnsense_get_rule()
         try:
-            return "disabled" not in rule.keys()
-        except KeyError:
-            return STATE_UNKNOWN
+            self._attr_is_on = "disabled" not in self._rule
+        except (TypeError, KeyError):
+            self._available = False
+            return
+        self._available = True
+        self.async_write_ha_state()
+        _LOGGER.debug(
+            f"[OPNsenseNatSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}"
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        rule = self._opnsense_get_rule()
-        if rule is None:
+        if not isinstance(self._rule, Mapping):
             return
-        tracker: str = self._opnsense_get_tracker()
-        client: OPNsenseClient = self._get_opnsense_client()
-        rule_type: str = self._opnsense_get_rule_type()
-        if rule_type == "nat_port_forward":
-            method = client.enable_nat_port_forward_rule_by_created_time
-        if rule_type == "nat_outbound":
-            method = client.enable_nat_outbound_rule_by_created_time
-
-        await method(tracker)
+        if self._rule_type == ATTR_NAT_PORT_FORWARD:
+            method = self._client.enable_nat_port_forward_rule_by_created_time
+        elif self._rule_type == ATTR_NAT_OUTBOUND:
+            method = self._client.enable_nat_outbound_rule_by_created_time
+        else:
+            return
+        await method(self._tracker)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        rule = self._opnsense_get_rule()
-        if rule is None:
+        if not isinstance(self._rule, Mapping):
             return
-        tracker: str = self._opnsense_get_tracker()
-        client: OPNsenseClient = self._get_opnsense_client()
-        rule_type: str = self._opnsense_get_rule_type()
-        if rule_type == "nat_port_forward":
-            method = client.disable_nat_port_forward_rule_by_created_time
-        if rule_type == "nat_outbound":
-            method = client.disable_nat_outbound_rule_by_created_time
-
-        await method(tracker)
+        if self._rule_type == ATTR_NAT_PORT_FORWARD:
+            method = self._client.disable_nat_port_forward_rule_by_created_time
+        elif self._rule_type == ATTR_NAT_OUTBOUND:
+            method = self._client.disable_nat_outbound_rule_by_created_time
+        else:
+            return
+        await method(self._tracker)
         await self.coordinator.async_refresh()
 
 
 class OPNsenseServiceSwitch(OPNsenseSwitch):
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+        )
+        self._service: Mapping[str, Any] | None = None
+        self._prop_name: str = self._opnsense_get_property_name()
+        _LOGGER.debug(
+            f"[OPNsenseServiceSwitch init] Name: {self.name}, prop_name: {self._prop_name}"
+        )
+
     def _opnsense_get_property_name(self) -> str:
         return self.entity_description.key.split(".")[2]
 
@@ -418,87 +451,65 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
     def _opnsense_get_service(self) -> Mapping[str, Any] | None:
         state: Mapping[str, Any] = self.coordinator.data
         service_id: str = self._opnsense_get_service_id()
-        for service in state["services"]:
-            if service["id"] == service_id:
+        for service in state.get("services", []):
+            if service.get("id", None) == service_id:
                 return service
         return None
 
-    @property
-    def available(self) -> bool:
-        service: Mapping[str, Any] | None = self._opnsense_get_service()
-        prop_name: str = self._opnsense_get_property_name()
-        if service is None or prop_name not in service:
-            return False
-
-        return super().available
-
-    @property
-    def is_on(self):
-        service: Mapping[str, Any] | None = self._opnsense_get_service()
-        prop_name: str = self._opnsense_get_property_name()
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._service = self._opnsense_get_service()
         try:
-            return service[prop_name]
+            self._attr_is_on = self._service[self._prop_name]
         except (TypeError, KeyError):
-            return STATE_UNKNOWN
+            self._available = False
+            return
+        self._available = True
+        self._attr_extra_state_attributes = {}
+        for attr in ["id", "name"]:
+            self._attr_extra_state_attributes[f"service_{attr}"] = self._service.get(
+                attr, None
+            )
+        self.async_write_ha_state()
+        _LOGGER.debug(
+            f"[OPNsenseServiceSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}"
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        service: Mapping[str, Any] | None = self._opnsense_get_service()
-        if isinstance(service, Mapping):
-            client: OPNsenseClient = self._get_opnsense_client()
-            result: bool = await client.start_service(
-                service.get("id", service.get("name", None))
-            )
-            if result:
-                await self.coordinator.async_refresh()
+        if not isinstance(self._service, Mapping):
+            return
+
+        result: bool = await self._client.start_service(
+            self._service.get("id", self._service.get("name", None))
+        )
+        if result:
+            await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        service: Mapping[str, Any] | None = self._opnsense_get_service()
-        if isinstance(service, Mapping):
-            client: OPNsenseClient = self._get_opnsense_client()
-            result: bool = await client.stop_service(
-                service.get("id", service.get("name", None))
-            )
-            if result:
-                await self.coordinator.async_refresh()
+        if not isinstance(self._service, Mapping):
+            return
 
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any]:
-        service: Mapping[str, Any] | None = self._opnsense_get_service()
-        attributes = {}
-        for attr in ["id", "name"]:
-            attributes[f"service_{attr}"] = service.get(attr, None)
-        return attributes
+        result: bool = await self._client.stop_service(
+            self._service.get("id", self._service.get("name", None))
+        )
+        if result:
+            await self.coordinator.async_refresh()
 
 
 class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
-
-    def __init__(
-        self,
-        config_entry,
-        coordinator: OPNsenseDataUpdateCoordinator,
-        entity_description: SwitchEntityDescription,
-    ) -> None:
-        super().__init__(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=entity_description,
-        )
-        self._attr_is_on = STATE_UNKNOWN
-        self._attr_extra_state_attributes = {}
-        self._attr_available = False
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         dnsbl = self.coordinator.data.get(ATTR_UNBOUND_BLOCKLIST, {})
         if not isinstance(dnsbl, Mapping) or len(dnsbl) == 0:
-            self._attr_available = False
+            self._available = False
             return
-        self._attr_available = True
-        self._attr_is_on = True if dnsbl.get("enabled", "0") == "1" else False
-        self._attr_extra_state_attributes = {
+        self._available = True
+        self._attr_is_on = dnsbl.get("enabled", "0") == "1"
+        self._attr_extra_state_attributes: Mapping[str, Any] = {
             "Force SafeSearch": (
                 True if dnsbl.get("safesearch", "0") == "1" else False
             ),
@@ -511,17 +522,18 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
             "Return NXDOMAIN": (True if dnsbl.get("nxdomain", "0") == "1" else False),
         }
         self.async_write_ha_state()
+        _LOGGER.debug(
+            f"[OPNsenseUnboundBlocklistSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}"
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
-        client: OPNsenseClient = self._get_opnsense_client()
-        result: bool = await client.enable_unbound_blocklist()
+        result: bool = await self._client.enable_unbound_blocklist()
         if result:
             await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        client: OPNsenseClient = self._get_opnsense_client()
-        result: bool = await client.disable_unbound_blocklist()
+        result: bool = await self._client.disable_unbound_blocklist()
         if result:
             await self.coordinator.async_refresh()

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -69,16 +69,14 @@ class OPNsenseUpdate(OPNsenseEntity, UpdateEntity):
         entity_description: UpdateEntityDescription,
         enabled_default: bool,
     ) -> None:
-        """Initialize the sensor."""
-        self.config_entry = config_entry
-        self.entity_description = entity_description
-        self.coordinator = coordinator
-        self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_name = f"{self.opnsense_device_name} {entity_description.name}"
-        self._attr_unique_id = slugify(
-            f"{self.opnsense_device_unique_id}_{entity_description.key}"
+        super().__init__(
+            config_entry,
+            coordinator,
+            unique_id_suffix=entity_description.key,
+            name_suffix=entity_description.name,
         )
-
+        self.entity_description = entity_description
+        self._attr_entity_registry_enabled_default = enabled_default
         self._attr_supported_features |= (
             UpdateEntityFeature.INSTALL
             # | UpdateEntityFeature.BACKUP


### PR DESCRIPTION
Add concurrency to the initial switches setup
Optimize switch update logic
Some minimal changes to the other entity classes but those were to have them continue to work with the upstream changes. Will optimize the other entity classes in future PRs.