### PR TITLE
DHCP Leases sensors

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -87,7 +87,7 @@ class OPNsenseCarpStatusBinarySensor(OPNsenseBinarySensor):
         state = self.coordinator.data
         try:
             self._attr_is_on = state["carp_status"]
-        except (KeyError, TypeError):
+        except (TypeError, KeyError, ZeroDivisionError):
             self._available = False
             return
         self._available = True
@@ -99,7 +99,7 @@ class OPNsensePendingNoticesPresentBinarySensor(OPNsenseBinarySensor):
         state = self.coordinator.data
         try:
             self._attr_is_on = state["notices"]["pending_notices_present"]
-        except (KeyError, TypeError):
+        except (TypeError, KeyError, ZeroDivisionError):
             self._available = False
             return
         self._available = True

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -110,7 +110,6 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         self._state["previous_state"] = previous_state
 
         if self._device_tracker_coordinator:
-
             categories: list = [
                 {"function": "get_device_unique_id", "state_key": "device_unique_id"},
                 {"function": "get_system_info", "state_key": "system_info"},
@@ -136,6 +135,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 return {}
             return self._state
+
+        self._state["dhcp_leases"] = await self._client.get_dhcp_leases()
 
         categories: list = [
             {"function": "get_device_unique_id", "state_key": "device_unique_id"},


### PR DESCRIPTION
* Creates a `DHCP Leases All` sensor that shows the total number of leases and then the number of leases in each subnet
* For each subnet, creates a sensor (disabled by default) that shows the number of leases in the subnet and the details of each lease in the attributes. Details: ip address, hostname, mac, expiration

Includes ISC DHCPv4, ISC DHCPv6 and Kea DHCPv4 leases.

Fixes #167 