### PR TITLE
Move interfaces, gateways, and openvpn out of telemetry

### DIFF
--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -155,22 +155,6 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
-    # cpu
-    # "telemetry.cpu.frequency.current": SensorEntityDescription(
-    #     key="telemetry.cpu.frequency.current",
-    #     name="CPU Frequency Current",
-    #     native_unit_of_measurement=UnitOfFrequency.HERTZ,
-    #     icon="mdi:speedometer-medium",
-    #     state_class=SensorStateClass.MEASUREMENT,
-    #     # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
-    # "telemetry.cpu.frequency.max": SensorEntityDescription(
-    #     key="telemetry.cpu.frequency.max",
-    #     name="CPU Frequency Max",
-    #     native_unit_of_measurement=UnitOfFrequency.HERTZ,
-    #     icon="mdi:speedometer",
-    #     # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
     "telemetry.cpu.count": SensorEntityDescription(
         key="telemetry.cpu.count",
         name="CPU Count",

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -193,16 +193,6 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
-    # system
-    # "telemetry.system.temp": SensorEntityDescription(
-    #    key="telemetry.system.temp",
-    #    name="System Temperature",
-    #    native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    #    device_class=SensorDeviceClass.TEMPERATURE,
-    #    icon="mdi:thermometer",
-    #    state_class=SensorStateClass.MEASUREMENT,
-    #    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
     "telemetry.system.boottime": SensorEntityDescription(
         key="telemetry.system.boottime",
         name="System Boottime",
@@ -211,31 +201,6 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         icon="mdi:clock-outline",
         # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
-    # dhcp
-    # "dhcp_stats.leases.total": SensorEntityDescription(
-    #    key="dhcp_stats.leases.total",
-    #    name="DHCP Leases Total",
-    #    native_unit_of_measurement="clients",
-    #    icon="mdi:ip-network-outline",
-    #    state_class=SensorStateClass.MEASUREMENT,
-    #    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
-    # "dhcp_stats.leases.online": SensorEntityDescription(
-    #    key="dhcp_stats.leases.online",
-    #    name="DHCP Leases Online",
-    #    native_unit_of_measurement="clients",
-    #    icon="mdi:ip-network-outline",
-    #    state_class=SensorStateClass.MEASUREMENT,
-    #    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
-    # "dhcp_stats.leases.offline": SensorEntityDescription(
-    #    key="dhcp_stats.leases.offline",
-    #    name="DHCP Leases Offline",
-    #    native_unit_of_measurement="clients",
-    #    icon="mdi:ip-network-outline",
-    #    state_class=SensorStateClass.MEASUREMENT,
-    #    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    # ),
 }
 
 SERVICE_CLOSE_NOTICE = "close_notice"

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -136,6 +136,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             },
             {"function": "get_telemetry", "state_key": "telemetry"},
             {"function": "get_interfaces", "state_key": "interfaces"},
+            {"function": "get_openvpn", "state_key": "openvpn"},
             {"function": "get_config", "state_key": "config"},
             {"function": "get_services", "state_key": "services"},
             {"function": "get_carp_interfaces", "state_key": "carp_interfaces"},
@@ -221,22 +222,20 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     new_property = f"{prop_name}_{label}"
                     interface[new_property] = int(round(value, 0))
 
-            for server_name in dict_get(self._state, "telemetry.openvpn.servers", {}):
+            for server_name in dict_get(self._state, "openvpn.servers", {}):
 
                 if server_name not in dict_get(
-                    self._state, "previous_state.telemetry.openvpn.servers", {}
+                    self._state, "previous_state.openvpn.servers", {}
                 ):
                     continue
 
                 server: Mapping[str, Any] = (
-                    self._state.get("telemetry", {})
-                    .get("openvpn", {})
+                    self._state.get("openvpn", {})
                     .get("servers", {})
                     .get(server_name, {})
                 )
                 previous_server: Mapping[str, Any] = (
                     self._state.get("previous_state", {})
-                    .get("telemetry", {})
                     .get("openvpn", {})
                     .get("servers", {})
                     .get(server_name, {})

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -135,6 +135,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                 "state_key": "firmware_update_info",
             },
             {"function": "get_telemetry", "state_key": "telemetry"},
+            {"function": "get_interfaces", "state_key": "interfaces"},
             {"function": "get_config", "state_key": "config"},
             {"function": "get_services", "state_key": "services"},
             {"function": "get_carp_interfaces", "state_key": "carp_interfaces"},
@@ -170,11 +171,11 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             elapsed_time = update_time - previous_update_time
 
             for interface_name, interface in dict_get(
-                self._state, "telemetry.interfaces", {}
+                self._state, "interfaces", {}
             ).items():
                 previous_interface = dict_get(
                     self._state,
-                    f"previous_state.telemetry.interfaces.{interface_name}",
+                    f"previous_state.interfaces.{interface_name}",
                 )
                 if previous_interface is None:
                     continue

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1492,10 +1492,6 @@ $toreturn = [
     ],
 
     "cpu" => [
-        "frequency" => [
-            "current" => (int) stripalpha($system_api_data["cpu"]["cur.freq"]),
-            "max" => (int) stripalpha($system_api_data["cpu"]["max.freq"]),
-        ],
         "count" => (int) $system_api_data["cpu"]["cur.freq"],
     ],
 

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -388,19 +388,9 @@ clear_subsystem_dirty('filter');
         script: str = r"""
 global $config;
 
-$file = "/conf/hassid";
-$id;
-if (!file_exists($file)) {
-    $id = bin2hex(openssl_random_pseudo_bytes(10));
-    file_put_contents($file, $id);
-} else {
-    $id = file_get_contents($file);
-}
-
 $toreturn = [
   "hostname" => $config["system"]["hostname"],
   "domain" => $config["system"]["domain"],
-  "device_id" => $id,
 ];
 """
         response: Mapping[str, Any] = await self._exec_php(script)
@@ -1434,7 +1424,6 @@ $toreturn = [
     async def _get_telemetry_legacy(self) -> Mapping[str, Any]:
         script: str = r"""
 require_once '/usr/local/www/widgets/api/plugins/system.inc';
-require_once '/usr/local/www/widgets/api/plugins/temperature.inc';
 
 global $config;
 global $g;
@@ -1444,7 +1433,6 @@ function stripalpha($s) {
 }
 
 $system_api_data = system_api();
-$temperature_api_data = temperature_api();
 
 // OPNsense 23.1.1: replaced single exec_command() with new shell_safe() wrapper
 if (function_exists('exec_command')) {

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -291,7 +291,7 @@ async def _compile_openvpn_server_sensors(
         return []
     entities: list = []
 
-    for vpnid, server in dict_get(state, "telemetry.openvpn.servers", {}).items():
+    for vpnid, server in dict_get(state, "openvpn.servers", {}).items():
         if not isinstance(server, Mapping) or len(server) == 0:
             continue
         for prop_name in [
@@ -333,7 +333,7 @@ async def _compile_openvpn_server_sensors(
                 config_entry=config_entry,
                 coordinator=coordinator,
                 entity_description=SensorEntityDescription(
-                    key=f"telemetry.openvpn.servers.{vpnid}.{prop_name}",
+                    key=f"telemetry.openvpn.servers.{vpnid}.{prop_name}",  # TODO: Migrate and remove telemetry from key
                     name=f"OpenVPN Server {server['name']} {prop_name}",
                     native_unit_of_measurement=native_unit_of_measurement,
                     icon=icon,
@@ -722,9 +722,7 @@ class OPNsenseOpenVPNServerSensor(OPNsenseSensor):
         if not isinstance(state, Mapping):
             return {}
         vpnid: str = self._opnsense_get_server_vpnid()
-        for server_vpnid, server in dict_get(
-            state, "telemetry.openvpn.servers", {}
-        ).items():
+        for server_vpnid, server in dict_get(state, "openvpn.servers", {}).items():
             if vpnid == server_vpnid:
                 return server
         return {}

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -57,11 +57,7 @@ async def _compile_static_sensors(
             "telemetry.system.load_average.one_minute",
             "telemetry.system.load_average.five_minute",
             "telemetry.system.load_average.fifteen_minute",
-            "telemetry.system.temp",
             "telemetry.system.boottime",
-            # "dhcp_stats.leases.total",
-            # "dhcp_stats.leases.online",
-            # "dhcp_stats.leases.offline",
         ]:
             enabled_default = True
 
@@ -492,10 +488,6 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
     def _handle_coordinator_update(self) -> None:
         value = self._get_opnsense_state_value(self.entity_description.key)
         if value is None:
-            self._available = False
-            return
-
-        if value == 0 and self.entity_description.key == "telemetry.system.temp":
             self._available = False
             return
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -53,7 +53,6 @@ async def _compile_static_sensors(
             "telemetry.mbuf.used_percent",
             "telemetry.memory.swap_used_percent",
             "telemetry.memory.used_percent",
-            "telemetry.cpu.frequency.current",
             "telemetry.cpu.usage_total",
             "telemetry.system.load_average.one_minute",
             "telemetry.system.load_average.five_minute",
@@ -503,11 +502,7 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
         if (
             value == 0
             and self._previous_value is None
-            and self.entity_description.key
-            in (
-                "telemetry.cpu.frequency.current",
-                "telemetry.cpu.usage_total",
-            )
+            and self.entity_description.key in ("telemetry.cpu.usage_total",)
         ):
             self._available = False
             return
@@ -515,10 +510,7 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
         if self.entity_description.key == "telemetry.system.boottime":
             value = utc_from_timestamp(value) if value else None
 
-        elif self.entity_description.key in (
-            "telemetry.cpu.frequency.current",
-            "telemetry.cpu.usage_total",
-        ):
+        elif self.entity_description.key in ("telemetry.cpu.usage_total",):
             if value == 0 and self._previous_value is not None:
                 value = self._previous_value
 


### PR DESCRIPTION
* Doing this both for clarity and to reduce the XMLRPC query
* Cleaned up and removed some old code
* Also in preparation to add Wireguard VPN info and to utilize the same Sensor and Switch classes as OpenVPN