### PR TITLE
Fixed OpenVPN related sensors (#264)

### DIFF
--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1355,22 +1355,21 @@ $toreturn = [
             vpn["name"] = vpn_info.get("name", "")
             total_bytes_recv = 0
             total_bytes_sent = 0
-            connected_clients = 0
             for connect in connection_info.get("rows", {}):
                 id = connect.get("id", None)
                 vpn_id = vpn.get("vpnid", None)
-                if id and (id == vpn_id or (isinstance(id, str) and id.startswith(vpn_id + "_"))):
+                if id and (
+                    id == vpn_id
+                    or (isinstance(id, str) and id.startswith(vpn_id + "_"))
+                ):
                     total_bytes_recv += self._try_to_int(
                         connect.get("bytes_received", 0), 0
                     )
                     total_bytes_sent += self._try_to_int(
                         connect.get("bytes_sent", 0), 0
                     )
-                    if connect.get("connected_since", None):
-                        connected_clients += 1
             vpn["total_bytes_recv"] = total_bytes_recv
             vpn["total_bytes_sent"] = total_bytes_sent
-            vpn["connected_client_count"] = connected_clients
             openvpn["servers"][vpnid] = vpn
         # _LOGGER.debug(f"[get_openvpn] openvpn: {openvpn}")
         return openvpn

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1359,7 +1359,7 @@ $toreturn = [
             for connect in connection_info.get("rows", {}):
                 id = connect.get("id", None)
                 vpn_id = vpn.get("vpnid", None)
-                if id and ((isinstance(id, int) and id == vpn_id) or (isinstance(id, str) and id.startswith(vpn_id + "_"))):
+                if id and (id == vpn_id or (isinstance(id, str) and id.startswith(vpn_id + "_"))):
                     total_bytes_recv += self._try_to_int(
                         connect.get("bytes_received", 0), 0
                     )

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1355,20 +1355,22 @@ $toreturn = [
             vpn["name"] = vpn_info.get("name", "")
             total_bytes_recv = 0
             total_bytes_sent = 0
+            connected_clients = 0
             for connect in connection_info.get("rows", {}):
-                if connect.get("id", None) and connect.get("id", None) == vpn.get(
-                    "vpnid", None
-                ):
+                id = connect.get("id", None)
+                vpn_id = vpn.get("vpnid", None)
+                if id and ((isinstance(id, int) and id == vpn_id) or (isinstance(id, str) and id.startswith(vpn_id + "_"))):
                     total_bytes_recv += self._try_to_int(
                         connect.get("bytes_received", 0), 0
                     )
                     total_bytes_sent += self._try_to_int(
                         connect.get("bytes_sent", 0), 0
                     )
+                    if connect.get("connected_since", None):
+                        connected_clients += 1
             vpn["total_bytes_recv"] = total_bytes_recv
             vpn["total_bytes_sent"] = total_bytes_sent
-            # Missing connected_client_count
-            # vpn["connected_client_count"] =
+            vpn["connected_client_count"] = connected_clients
             openvpn["servers"][vpnid] = vpn
         # _LOGGER.debug(f"[get_openvpn] openvpn: {openvpn}")
         return openvpn


### PR DESCRIPTION
Fixed the ID check in get_openvpn function. Did some debugging and it seems that the id-values retrieved from /api/openvpn/service/searchSessions are integers when the VPN-connection is not active. However, when the connection is live, the id-value is in format "ID_IP-ADDRESS:PORT". Modified the id check to work for both scenarios. Also enabled/fixed the connected client count by counting sessions that have a value in connected_since field.