### PR TITLE
Add Wireguard. OpenVPN Sensor Enhancements. VPN Switches.

### DIFF
--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -193,10 +193,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     interface[new_property] = value
 
             for vpn_type in ["openvpn", "wireguard"]:
-                cs: list[str] = ["servers"]
-                if vpn_type == "wireguard":
-                    cs = ["clients", "servers"]
-                for clients_servers in cs:
+                for clients_servers in ["clients", "servers"]:
                     for instance_name in dict_get(
                         self._state, f"{vpn_type}.{clients_servers}", {}
                     ):

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -183,7 +183,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     # "outpktsblock",
                 ]:
                     if "pkts" in prop_name or "bytes" in prop_name:
-                        new_property, value = self._calculate_speed(
+                        new_property, value = await self._calculate_speed(
                             prop_name=prop_name,
                             elapsed_time=elapsed_time,
                             current_parent_value=interface[prop_name],
@@ -216,7 +216,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     "total_bytes_sent",
                 ]:
                     if "pkts" in prop_name or "bytes" in prop_name:
-                        new_property, value = self._calculate_speed(
+                        new_property, value = await self._calculate_speed(
                             prop_name=prop_name,
                             elapsed_time=elapsed_time,
                             current_parent_value=server[prop_name],
@@ -249,7 +249,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     "total_bytes_sent",
                 ]:
                     if "pkts" in prop_name or "bytes" in prop_name:
-                        new_property, value = self._calculate_speed(
+                        new_property, value = await self._calculate_speed(
                             prop_name=prop_name,
                             elapsed_time=elapsed_time,
                             current_parent_value=server[prop_name],
@@ -259,6 +259,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     server[new_property] = value
 
         restapi_count, xmlrpc_count = await self._client.get_query_counts()
+        _LOGGER.debug(f"[async_update_data] wireguard: {self._state.get('wireguard')}")
         _LOGGER.debug(
             f"Update Complete. REST API Queries: {restapi_count}. XMLRPC Queries: {xmlrpc_count}"
         )
@@ -270,7 +271,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         elapsed_time,
         current_parent_value: float,
         previous_parent_value: float,
-    ):
+    ) -> tuple[str, int]:
         try:
             change: float = abs(current_parent_value - previous_parent_value)
             rate: float = change / elapsed_time

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -135,6 +135,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                 "state_key": ATTR_UNBOUND_BLOCKLIST,
             },
             {"function": "get_dhcp_leases", "state_key": "dhcp_leases"},
+            {"function": "get_wireguard", "state_key": "wireguard"},
         ]
 
         self._state.update(await self._get_states(categories))

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1383,7 +1383,7 @@ $toreturn = [
             vpn["total_bytes_recv"] = total_bytes_recv
             vpn["total_bytes_sent"] = total_bytes_sent
             openvpn["servers"][vpnid] = vpn
-        # _LOGGER.debug(f"[get_openvpn] openvpn: {openvpn}")
+        _LOGGER.debug(f"[get_openvpn] openvpn: {openvpn}")
         return openvpn
 
     @_log_errors
@@ -1664,18 +1664,19 @@ $toreturn = [
             or not isinstance(server_summ, Mapping)
         ):
             return {}
-        servers = {}
-        clients = {}
+        servers: Mapping[str, Any] = {}
+        clients: Mapping[str, Any] = {}
 
         for uid, srv in server_summ.items():
             if not isinstance(srv, Mapping):
                 continue
-            server = {}
+            server: Mapping[str, Any] = {}
             for attr in ["name", "pubkey", "port", "endpoint", "peer_dns"]:
                 if srv.get(attr, None):
-                    server.update({attr: srv.get(attr)})
-            server.update({"enabled": bool(srv.get("enabled", "") == "1")})
-            server.update({"interface": f"wg{srv.get('instance','')}"})
+                    server[attr] = srv.get(attr)
+            server["vpnid"] = uid
+            server["enabled"] = bool(srv.get("enabled", "") == "1")
+            server["interface"] = f"wg{srv.get('instance','')}"
             server["tunnel_addresses"] = []
             for addr in srv.get("tunneladdress", {}).values():
                 if addr.get("selected", 0) == 1 and addr.get("value", None):
@@ -1691,10 +1692,11 @@ $toreturn = [
         for uid, clnt in client_summ.items():
             if not isinstance(clnt, Mapping):
                 continue
-            client = {}
+            client: Mapping[str, Any] = {}
             for attr in ["name", "pubkey"]:
                 if clnt.get(attr, None):
                     client[attr] = clnt.get(attr, None)
+            client["vpnid"] = uid
             client["enabled"] = bool(clnt.get("enabled", "0") == "1")
             client["tunnel_addresses"] = []
             for addr in clnt.get("tunneladdress", {}).values():

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1426,7 +1426,12 @@ $toreturn = [
                 openvpn["servers"][id]["total_bytes_sent"] = self._try_to_int(
                     connect.get("bytes_sent", 0), 0
                 )
-        for vpnid, server in openvpn["servers"]:
+
+        for vpnid, server in openvpn["servers"].items():
+            if server.get("total_bytes_sent", None) is None:
+                server["total_bytes_sent"] = 0
+            if server.get("total_bytes_recv", None) is None:
+                server["total_bytes_recv"] = 0
             details_info: Mapping[str, Any] = await self._get(
                 f"/api/openvpn/instances/get/{vpnid}"
             )
@@ -1461,13 +1466,18 @@ $toreturn = [
             if isinstance(id, str) and "_" in id:
                 id = id.split("_")[0]
             if id and id in openvpn["clients"]:
-                openvpn["clientss"][id]["total_bytes_recv"] = self._try_to_int(
+                openvpn["clients"][id]["total_bytes_recv"] = self._try_to_int(
                     connect.get("bytes_received", 0), 0
                 )
-                openvpn["clientss"][id]["total_bytes_sent"] = self._try_to_int(
+                openvpn["clients"][id]["total_bytes_sent"] = self._try_to_int(
                     connect.get("bytes_sent", 0), 0
                 )
 
+        for vpnid, client in openvpn["clients"].items():
+            if client.get("total_bytes_sent", None) is None:
+                client["total_bytes_sent"] = 0
+            if client.get("total_bytes_recv", None) is None:
+                client["total_bytes_recv"] = 0
         _LOGGER.debug(f"[get_openvpn] openvpn: {openvpn}")
         return openvpn
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -366,10 +366,7 @@ async def _compile_vpn_sensors(
     entities: list = []
 
     for vpn_type in ["openvpn", "wireguard"]:
-        cs: list[str] = ["servers"]
-        if vpn_type == "wireguard":
-            cs = ["clients", "servers"]
-        for clients_servers in cs:
+        for clients_servers in ["clients", "servers"]:
             for vpnid, instance in dict_get(
                 state, f"{vpn_type}.{clients_servers}", {}
             ).items():

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -367,7 +367,7 @@ async def _compile_vpn_sensors(
 
     for vpn_type in ["openvpn", "wireguard"]:
         for clients_servers in ["clients", "servers"]:
-            for vpnid, instance in dict_get(
+            for uuid, instance in dict_get(
                 state, f"{vpn_type}.{clients_servers}", {}
             ).items():
                 if not isinstance(instance, Mapping) or len(instance) == 0:
@@ -413,7 +413,7 @@ async def _compile_vpn_sensors(
                         config_entry=config_entry,
                         coordinator=coordinator,
                         entity_description=SensorEntityDescription(
-                            key=f"{vpn_type}.{clients_servers}.{vpnid}.{prop_name}",
+                            key=f"{vpn_type}.{clients_servers}.{uuid}.{prop_name}",
                             name=f"{"OpenVPN" if vpn_type == "openvpn" else vpn_type.title()} {clients_servers.title().rstrip('s')} {instance['name']} {prop_name}",
                             native_unit_of_measurement=native_unit_of_measurement,
                             device_class=device_class,
@@ -733,12 +733,12 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             self._available = False
             self.async_write_ha_state()
             return
-        vpnid: str = self.entity_description.key.split(".")[2]
+        uuid: str = self.entity_description.key.split(".")[2]
         instance: Mapping[str, Any] = {}
-        for instance_vpnid, ins in dict_get(
+        for instance_uuid, ins in dict_get(
             state, f"{vpn_type}.{clients_servers}", {}
         ).items():
-            if vpnid == instance_vpnid:
+            if uuid == instance_uuid:
                 instance = ins
                 break
         prop_name: str = self._get_property_name()
@@ -773,7 +773,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             and prop_name == "status"
         ):
             properties: list = [
-                "vpnid",
+                "uuid",
                 "name",
                 "enabled",
                 "endpoint",
@@ -789,7 +789,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             and prop_name == "status"
         ):
             properties: list = [
-                "vpnid",
+                "uuid",
                 "name",
                 "enabled",
                 "endpoint",
@@ -798,7 +798,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                 "dns_servers",
             ]
         else:
-            properties: list = ["vpnid", "name"]
+            properties: list = ["uuid", "name"]
         for attr in properties:
             if instance.get(attr, None):
                 self._attr_extra_state_attributes[attr] = instance.get(attr)

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -381,7 +381,7 @@ async def _compile_vpn_sensors(
                     "total_bytes_recv_kilobytes_per_second",
                     "total_bytes_sent_kilobytes_per_second",
                 ]
-                if vpn_type == "wireguard" and clients_servers == "servers":
+                if clients_servers == "servers":
                     properties.append("status")
                 for prop_name in properties:
                     state_class = None
@@ -770,12 +770,28 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                 "interface",
                 "pubkey",
                 "tunnel_addresses",
+                "dns_servers",
                 "clients",
+            ]
+        elif (
+            vpn_type == "openvpn"
+            and clients_servers == "servers"
+            and prop_name == "status"
+        ):
+            properties: list = [
+                "vpnid",
+                "name",
+                "enabled",
+                "endpoint",
+                "dev_type",
+                "tunnel_addresses",
+                "dns_servers",
             ]
         else:
             properties: list = ["vpnid", "name"]
         for attr in properties:
-            self._attr_extra_state_attributes[attr] = server.get(attr)
+            if server.get(attr, None):
+                self._attr_extra_state_attributes[attr] = server.get(attr)
         self.async_write_ha_state()
 
     @property

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -191,7 +191,7 @@ async def _compile_vpn_switches(
     entities: list = []
     for vpn_type in ["openvpn", "wireguard"]:
         for clients_servers in ["clients", "servers"]:
-            for vpnid, instance in (
+            for uuid, instance in (
                 state.get(vpn_type, {}).get(clients_servers, {}) or {}
             ).items():
                 if (
@@ -204,7 +204,7 @@ async def _compile_vpn_switches(
                     config_entry=config_entry,
                     coordinator=coordinator,
                     entity_description=SwitchEntityDescription(
-                        key=f"{vpn_type}.{clients_servers}.{vpnid}",
+                        key=f"{vpn_type}.{clients_servers}.{uuid}",
                         name=f"{"OpenVPN" if vpn_type == "openvpn" else vpn_type.title()} {clients_servers.title().rstrip('s')} {instance['name']}",
                         icon="mdi:folder-key-network-outline",
                         # entity_category=ENTITY_CATEGORY_CONFIG,
@@ -595,7 +595,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         )
         self._vpn_type = self.entity_description.key.split(".")[0]
         self._clients_servers = self.entity_description.key.split(".")[1]
-        self._vpnid = self.entity_description.key.split(".")[2]
+        self._uuid = self.entity_description.key.split(".")[2]
         # _LOGGER.debug(f"[OPNsenseVPNSwitch init] Name: {self.name}")
 
     @callback
@@ -608,7 +608,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         instance: Mapping[str, Any] = (
             state.get(self._vpn_type, {})
             .get(self._clients_servers, {})
-            .get(self._vpnid, {})
+            .get(self._uuid, {})
         )
         if not isinstance(instance, Mapping):
             self._available = False
@@ -624,7 +624,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         self._attr_extra_state_attributes = {}
         if self._vpn_type == "wireguard" and self._clients_servers == "servers":
             properties: list = [
-                "vpnid",
+                "uuid",
                 "name",
                 "endpoint",
                 "interface",
@@ -635,7 +635,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             ]
         elif self._vpn_type == "openvpn" and self._clients_servers == "servers":
             properties: list = [
-                "vpnid",
+                "uuid",
                 "name",
                 "endpoint",
                 "dev_type",
@@ -643,7 +643,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
                 "dns_servers",
             ]
         else:
-            properties: list = ["vpnid", "name"]
+            properties: list = ["uuid", "name"]
 
         for attr in properties:
             if instance.get(attr, None):
@@ -658,7 +658,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             return
 
         result: bool = await self._client.toggle_vpn_instance(
-            self._vpn_type, self._clients_servers, self._vpnid
+            self._vpn_type, self._clients_servers, self._uuid
         )
         if result:
             await self.coordinator.async_refresh()
@@ -670,7 +670,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             return
 
         result: bool = await self._client.toggle_vpn_instance(
-            self._vpn_type, self._clients_servers, self._vpnid
+            self._vpn_type, self._clients_servers, self._uuid
         )
         if result:
             await self.coordinator.async_refresh()

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -181,6 +181,43 @@ async def _compile_service_switches(
     return entities
 
 
+async def _compile_vpn_switches(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: Mapping[str, Any],
+) -> list:
+    if not isinstance(state, Mapping):
+        return []
+    entities: list = []
+    for vpn_type in ["openvpn", "wireguard"]:
+        for clients_servers in ["clients", "servers"]:
+            for vpnid, instance in (
+                state.get(vpn_type, {}).get(clients_servers, {}).items()
+            ):
+                if (
+                    not isinstance(instance, Mapping)
+                    or instance.get("enabled", None) is None
+                ):
+                    continue
+
+                icon = "mdi:application-cog-outline"
+
+                entity = OPNsenseVPNSwitch(
+                    config_entry=config_entry,
+                    coordinator=coordinator,
+                    entity_description=SwitchEntityDescription(
+                        key=f"{vpn_type}.{clients_servers}.{vpnid}",
+                        name=f"{"OpenVPN" if vpn_type == "openvpn" else vpn_type.title()} {clients_servers.title().rstrip('s')} {instance['name']}",
+                        icon=icon,
+                        # entity_category=ENTITY_CATEGORY_CONFIG,
+                        device_class=SwitchDeviceClass.SWITCH,
+                        entity_registry_enabled_default=False,
+                    ),
+                )
+                entities.append(entity)
+    return entities
+
+
 async def _compile_static_switches(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -224,6 +261,7 @@ async def async_setup_entry(
         _compile_port_forward_switches(config_entry, coordinator, state),
         _compile_nat_outbound_switches(config_entry, coordinator, state),
         _compile_service_switches(config_entry, coordinator, state),
+        _compile_vpn_switches(config_entry, coordinator, state),
         _compile_static_switches(config_entry, coordinator, state),
         return_exceptions=True,
     )
@@ -540,5 +578,100 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
         result: bool = await self._client.disable_unbound_blocklist()
+        if result:
+            await self.coordinator.async_refresh()
+
+
+class OPNsenseVPNSwitch(OPNsenseSwitch):
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+        )
+        self._vpn_type = self.entity_description.key.split(".")[0]
+        self._clients_servers = self.entity_description.key.split(".")[1]
+        self._vpnid = self.entity_description.key.split(".")[2]
+        # _LOGGER.debug(f"[OPNsenseVPNSwitch init] Name: {self.name}")
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        state: Mapping[str, Any] = self.coordinator.data
+        if not isinstance(state, Mapping):
+            self._available = False
+            return
+        instance = (
+            state.get(self._vpn_type, {})
+            .get(self._clients_servers, {})
+            .get(self._vpnid, {})
+        )
+        if not isinstance(instance, Mapping):
+            self._available = False
+            return
+        try:
+            self._attr_is_on = instance["enabled"]
+        except (TypeError, KeyError, AttributeError):
+            self._available = False
+            return
+        self._available = True
+        self._attr_extra_state_attributes = {}
+        if self._vpn_type == "wireguard" and self._clients_servers == "servers":
+            properties: list = [
+                "vpnid",
+                "name",
+                "endpoint",
+                "interface",
+                "pubkey",
+                "tunnel_addresses",
+                "dns_servers",
+                "clients",
+            ]
+        elif self._vpn_type == "openvpn" and self._clients_servers == "servers":
+            properties: list = [
+                "vpnid",
+                "name",
+                "endpoint",
+                "dev_type",
+                "tunnel_addresses",
+                "dns_servers",
+            ]
+        else:
+            properties: list = ["vpnid", "name"]
+
+        for attr in properties:
+            if instance.get(attr, None):
+                self._attr_extra_state_attributes[attr] = instance.get(attr)
+        self.async_write_ha_state()
+        _LOGGER.debug(
+            f"[OPNsenseVPNSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}"
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the entity on."""
+
+        if self.is_on:
+            return
+
+        result: bool = await self._client.toggle_vpn_instance(
+            self._vpn_type, self._clients_servers, self._vpnid
+        )
+        if result:
+            await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the entity off."""
+
+        if not self.is_on:
+            return
+
+        result: bool = await self._client.toggle_vpn_instance(
+            self._vpn_type, self._clients_servers, self._vpnid
+        )
         if result:
             await self.coordinator.async_refresh()


### PR DESCRIPTION
* Adds Wireguard data
* Creates Wireguard sensors for both Servers and Clients _(Only the Server Status is enabled by default)_
* Creates Wireguard switches for both Servers and Clients _(All disabled by default)_
* Redid OpenVPN data logic to get Clients and to better handle new OpenVPN interfaces, especially when they are disabled.
* Enhances OpenVPN Sensors _(Some attributes may only be available with the new OpenVPN interface. Only the Server Status is enabled by default)_
* Adds OpenVPN Switches for both Servers and Clients if using the new OpenVPN interface _(All disabled by default)_

Fixes #233 
Fixes #212 
Fixes #40 
Fixes #109 