### PR TITLE
VPN connected instance indicators and fixing OpenVPN server logic

### DIFF
--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -193,7 +193,10 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     interface[new_property] = value
 
             for vpn_type in ["openvpn", "wireguard"]:
-                for clients_servers in ["clients", "servers"]:
+                cs = ["servers"]
+                if vpn_type == "wireguard":
+                    cs = ["clients", "servers"]
+                for clients_servers in cs:
                     for instance_name in dict_get(
                         self._state, f"{vpn_type}.{clients_servers}", {}
                     ):

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -380,6 +380,11 @@ async def _compile_vpn_sensors(
                 ]
                 if clients_servers == "servers":
                     properties.append("status")
+                if vpn_type == "wireguard":
+                    if clients_servers == "servers":
+                        properties.append("connected_clients")
+                    elif clients_servers == "clients":
+                        properties.append("connected_servers")
                 for prop_name in properties:
                     state_class = None
                     native_unit_of_measurement = None
@@ -400,12 +405,19 @@ async def _compile_vpn_sensors(
                         suggested_display_precision = 1
                         suggested_unit_of_measurement = UnitOfInformation.MEGABYTES
 
+                    if prop_name in ["connected_clients", "connected_servers"]:
+                        state_class = SensorStateClass.MEASUREMENT
+
                     # icon
                     if "bytes" in prop_name:
                         icon = "mdi:server-network"
                     elif prop_name == "status":
                         icon = "mdi:check-network"
                         enabled_default = True
+                    elif prop_name == "connected_servers":
+                        icon = "mdi:router-network"
+                    elif prop_name == "connected_clients":
+                        icon = "mdi:account-network"
                     else:
                         icon = "mdi:gauge"
 
@@ -790,12 +802,14 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             properties: list = [
                 "uuid",
                 "name",
+                "connected_clients",
                 "enabled",
                 "endpoint",
                 "interface",
                 "pubkey",
                 "tunnel_addresses",
                 "dns_servers",
+                "latest-handshake",
                 "clients",
             ]
         elif (
@@ -811,6 +825,30 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                 "dev_type",
                 "tunnel_addresses",
                 "dns_servers",
+            ]
+        elif prop_name == "connected_clients":
+            properties: list = [
+                "uuid",
+                "name",
+                "status",
+                "enabled",
+                "endpoint",
+                "interface",
+                "pubkey",
+                "tunnel_addresses",
+                "dns_servers",
+                "latest-handshake",
+                "clients",
+            ]
+        elif prop_name == "connected_servers":
+            properties: list = [
+                "uuid",
+                "name",
+                "enabled",
+                "pubkey",
+                "tunnel_addresses",
+                "latest-handshake",
+                "servers",
             ]
         else:
             properties: list = ["uuid", "name"]

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -622,25 +622,32 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             return
         self._available = True
         self._attr_extra_state_attributes = {}
-        if self._vpn_type == "wireguard" and self._clients_servers == "servers":
+        if self._clients_servers == "servers":
             properties: list = [
                 "uuid",
                 "name",
+                "status",
+                "connected_clients",
                 "endpoint",
                 "interface",
+                "dev_type",
                 "pubkey",
                 "tunnel_addresses",
                 "dns_servers",
+                "latest_handshake",
                 "clients",
             ]
-        elif self._vpn_type == "openvpn" and self._clients_servers == "servers":
+        elif self._clients_servers == "clients":
             properties: list = [
                 "uuid",
                 "name",
+                "connected_servers",
                 "endpoint",
-                "dev_type",
+                "iterface",
+                "pubkey",
                 "tunnel_addresses",
-                "dns_servers",
+                "latest_handshake",
+                "servers",
             ]
         else:
             properties: list = ["uuid", "name"]


### PR DESCRIPTION
* For Wireguard Servers, adds Connected Clients sensor
* For Wireguard Clients, adds Connected Servers sensor
* For OpenVPN Servers, adds Connected Clients sensor
* Fix OpenVPN server statistics

Fixes #285 
#290 

ToDo in a different PR:
* Can the connected OpenVPN clients be somehow linked to the actual clients?
  * Related, can we show when a client is connected or not