### PR TITLE
Show repair and shutdown integration if new device id detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Discord server to discuss the integration is available, please click the Disco
   - [Switch](#switch)
   - [Services](#services)
 - [Known Issues](#known-issues)
+  - [Hardware Changes](#hardware-changes)
   - [AdGuardHome](#adguardhome)
 
 # Installation
@@ -223,10 +224,20 @@ data:
   vouchergroup: Home Assistant
   voucher_server: Voucher Server # Only needed if more than 1 Voucher Server
 # Returns the vouchers as action response data
+
+action: opnsense.toggle_alias
+data:
+  alias: "iphones"
+  toggle_on_off: "toggle"
+
 ```
 ### [How to use `action response data` in an HA script or automation](https://www.home-assistant.io/docs/scripts/perform-actions/#use-templates-to-handle-response-data)
 
 # Known Issues
+
+## Hardware Changes
+
+If you partially or fully change the OPNsense Hardware, it will require a removal and reinstall of this integration. This is to ensure changed interfaces, services, gateways, etc. are accounted for and don't leave duplicate or non-functioning entities. 
 
 ## AdGuardHome
 

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -412,7 +412,7 @@ clear_subsystem_dirty('filter');
 
     @_log_errors
     async def get_device_unique_id(self) -> str | None:
-        instances: Mapping[str, Any] | list = await self._post(
+        instances: Mapping[str, Any] | list = await self._get(
             "/api/interfaces/overview/export"
         )
         if not isinstance(instances, list):
@@ -429,7 +429,12 @@ clear_subsystem_dirty('filter');
             unique_mac_addresses[0] if unique_mac_addresses else None
         )
         if device_unique_id:
-            return device_unique_id.replace(":", "_").strip()
+            device_unique_id_fmt = device_unique_id.replace(":", "_").strip()
+            _LOGGER.debug(
+                f"[get_device_unique_id] device_unique_id: {device_unique_id_fmt}"
+            )
+            return device_unique_id_fmt
+        _LOGGER.debug("[get_device_unique_id] device_unique_id: None")
         return None
 
     @_log_errors

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -65,6 +65,10 @@
     "below_ltd_firmware": {
       "title": "OPNsense Firmware below Recommended Version",
       "description": "Some hass-opnsense {version} functions require OPNsense firmware {ltd_firmware} or later. With firmware {firmware}, some functions may not work and there may be errors in the logs."
+    },
+    "device_id_mismatched": {
+      "title": "OPNsense Hardware Has Changed",
+      "description": "OPNsense Device ID has changed which indicates new or changed hardware. In order to accomodate this, hass-opnsense needs to be removed and reinstalled for this router. hass-opnsense is shutting down."
     }
   },  
   "title": "OPNsense"


### PR DESCRIPTION

<img width="561" alt="2024-11-24_18-58-43 466" src="https://github.com/user-attachments/assets/a7cc076a-0e5d-479c-850b-7006247ef1de">

This does not fix these issues but rather gives instructions about the need for removal and reinstall of the integration when the device id changes.
#313 
#316
