### PR TITLE
Allow unsafe cookies

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -50,6 +50,7 @@ from .const import (
     VERSION,
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
+from .helpers import is_private_ip
 from .pyopnsense import OPNsenseClient
 from .services import async_setup_services
 
@@ -90,7 +91,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         username=username,
         password=password,
         session=async_create_clientsession(
-            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+            hass=hass,
+            raise_for_status=False,
+            cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(url)),
         ),
         opts={"verify_ssl": verify_ssl},
         name=entry.title,
@@ -296,7 +299,9 @@ async def _migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
         username=username,
         password=password,
         session=async_create_clientsession(
-            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+            hass=hass,
+            raise_for_status=False,
+            cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(url)),
         ),
         opts={"verify_ssl": verify_ssl},
     )
@@ -405,7 +410,9 @@ async def _migrate_3_to_4(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
         username=username,
         password=password,
         session=async_create_clientsession(
-            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+            hass=hass,
+            raise_for_status=False,
+            cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(url)),
         ),
         opts={"verify_ssl": verify_ssl},
     )

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+import aiohttp
 import awesomeversion
 
 from homeassistant.config_entries import ConfigEntry
@@ -88,7 +89,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         url=url,
         username=username,
         password=password,
-        session=async_create_clientsession(hass, raise_for_status=False),
+        session=async_create_clientsession(
+            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        ),
         opts={"verify_ssl": verify_ssl},
         name=entry.title,
     )
@@ -292,7 +295,9 @@ async def _migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
         url=url,
         username=username,
         password=password,
-        session=async_create_clientsession(hass, raise_for_status=False),
+        session=async_create_clientsession(
+            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        ),
         opts={"verify_ssl": verify_ssl},
     )
     new_device_unique_id: str | None = await client.get_device_unique_id()
@@ -399,7 +404,9 @@ async def _migrate_3_to_4(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
         url=url,
         username=username,
         password=password,
-        session=async_create_clientsession(hass, raise_for_status=False),
+        session=async_create_clientsession(
+            hass=hass, raise_for_status=False, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        ),
         opts={"verify_ssl": verify_ssl},
     )
     telemetry = await client.get_telemetry()

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -48,6 +48,7 @@ from .const import (
     DOMAIN,
     OPNSENSE_MIN_FIRMWARE,
 )
+from .helpers import is_private_ip
 from .pyopnsense import OPNsenseClient
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -226,7 +227,9 @@ async def _get_client(
         username=user_input[CONF_USERNAME],
         password=user_input[CONF_PASSWORD],
         session=async_create_clientsession(
-            hass=hass, raise_for_status=True, cookie_jar=aiohttp.CookieJar(unsafe=True)
+            hass=hass,
+            raise_for_status=True,
+            cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(user_input[CONF_URL])),
         ),
         opts={"verify_ssl": user_input.get(CONF_VERIFY_SSL)},
         initial=True,
@@ -497,7 +500,7 @@ class OPNsenseOptionsFlow(OptionsFlow):
             session=async_create_clientsession(
                 hass=self.hass,
                 raise_for_status=False,
-                cookie_jar=aiohttp.CookieJar(unsafe=True),
+                cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(url)),
             ),
             opts={"verify_ssl": verify_ssl},
         )

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -225,7 +225,9 @@ async def _get_client(
         url=user_input[CONF_URL],
         username=user_input[CONF_USERNAME],
         password=user_input[CONF_PASSWORD],
-        session=async_create_clientsession(hass, raise_for_status=True),
+        session=async_create_clientsession(
+            hass=hass, raise_for_status=True, cookie_jar=aiohttp.CookieJar(unsafe=True)
+        ),
         opts={"verify_ssl": user_input.get(CONF_VERIFY_SSL)},
         initial=True,
     )
@@ -492,7 +494,11 @@ class OPNsenseOptionsFlow(OptionsFlow):
             url=url,
             username=username,
             password=password,
-            session=async_create_clientsession(self.hass, raise_for_status=False),
+            session=async_create_clientsession(
+                hass=self.hass,
+                raise_for_status=False,
+                cookie_jar=aiohttp.CookieJar(unsafe=True),
+            ),
             opts={"verify_ssl": verify_ssl},
         )
         if user_input is None and (arp_table := await client.get_arp_table(True)):

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -1,8 +1,10 @@
 """Helper methods for OPNsense."""
 
 from collections.abc import MutableMapping
+import ipaddress
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 
 def dict_get(data: MutableMapping[str, Any], path: str, default=None) -> Any | None:
@@ -20,3 +22,18 @@ def dict_get(data: MutableMapping[str, Any], path: str, default=None) -> Any | N
             break
 
     return result
+
+
+def is_private_ip(url: str) -> bool:
+    """Check if the address in the given URL is a private IP address."""
+    parsed_url = urlparse(url)
+    addr = parsed_url.hostname
+    if not addr:
+        return False
+
+    try:
+        ip_obj = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    else:
+        return ip_obj.is_private


### PR DESCRIPTION
Uses "[unsafe cookies](https://docs.aiohttp.org/en/stable/client_advanced.html#cookie-safety)" if the Address of the OPNsense router uses a private IP:
* 10.0.0.0 to 10.255.255.255
* 172.16.0.0 to 172.31.255.255
* 192.168.0.0 to 192.168.255.255
* fd00::/8

Allows retaining PHP Cookies to prevent the creation of a ton of separate cookies for all of the REST API queries.

Fixes #339 