### PR TITLE
Fix system boot time calculation

### DIFF
--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1282,7 +1282,7 @@ $toreturn = [
             seconds = OPNsenseClient._try_to_int(seconds_str, 0) or 0
             system["uptime"] = days * 86400 + hours * 3600 + minutes * 60 + seconds
 
-            boottime: datetime = datetime.now() - timedelta(seconds=system["uptime"])
+            boottime: datetime = datetime.now().replace(microsecond=0) - timedelta(seconds=system["uptime"])
             system["boottime"] = boottime.timestamp()
         else:
             _LOGGER.warning("Invalid uptime format")


### PR DESCRIPTION
Fix #378 - When calculating the systems boot time, the uptime was subtracted from the current timestamp. The timestamp included milliseconds, the uptime not. This resulted in the calculated boot time's milliseconds being purely dependent on the exact timing of the request. The timestamp seems to be rounded afterwards, resulting in it switching between two second values depending on the request taking place in the first half or the second half of a second.

This PR set's the current timestamps milliseconds to zero, resulting in the calculated boot times ms always being zero as well. Rounding should therefore always result in the same value. 