### PR TITLE
Implement queueing for switches

### DIFF
--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -43,6 +43,7 @@ CONF_FIRMWARE_VERSION = "firmware_version"
 
 CONF_DEVICES = "devices"
 CONF_MANUAL_DEVICES = "manual_devices"
+QUEUE_TASK = "queue_task"
 
 COUNT = "count"
 

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1306,7 +1306,7 @@ $toreturn = [
         if "boottime" in time_info:
             try:
                 boottime = parse(time_info["boottime"], tzinfos=AMBIGUOUS_TZINFOS)
-                if boottime.tzinfo is None:
+                if boottime and boottime.tzinfo is None:
                     boottime = boottime.replace(
                         tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
                     )

--- a/custom_components/opnsense/queue.py
+++ b/custom_components/opnsense/queue.py
@@ -1,0 +1,31 @@
+"""Queue to ensure commands are done in order."""
+
+import asyncio
+import logging
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+
+
+async def handle_queue():
+    """Asyncio queue handler."""
+    while True:
+        func = None
+        try:
+            func = await queue.get()
+            if callable(func):
+                _LOGGER.warning("Handling queue item: %s", func)
+                await func()
+        except asyncio.CancelledError:
+            raise
+        except (TimeoutError, aiohttp.ClientError) as e:
+            _LOGGER.error(
+                "Network or client error handling queue item. %s: %s", type(e).__name__, e
+            )
+        finally:
+            if func:
+                queue.task_done()
+        await asyncio.sleep(0)

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -21,6 +21,7 @@ from .const import (
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
+from .queue import queue
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -352,19 +353,31 @@ class OPNsenseFilterSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseFilterSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""
-        if self._rule is None or not self._client:
+        if self._rule is None:
             return
-        await self._client.enable_filter_rule_by_created_time(self._tracker)
-        await self.coordinator.async_refresh()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+        _LOGGER.warning("Turning On Filter Rule: %s", self.name)
+
+        async def enable_filter_rule():
+            await self._client.enable_filter_rule_by_created_time(self._tracker)
+            await self.coordinator.async_refresh()
+
+        await queue.put(enable_filter_rule)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the entity off."""
-        if self._rule is None or not self._client:
+        if self._rule is None:
             return
-        await self._client.disable_filter_rule_by_created_time(self._tracker)
-        await self.coordinator.async_refresh()
+
+        _LOGGER.warning("Turning Off Filter Rule: %s", self.name)
+
+        async def disable_filter_rule():
+            await self._client.disable_filter_rule_by_created_time(self._tracker)
+            await self.coordinator.async_refresh()
+
+        await queue.put(disable_filter_rule)
 
     @property
     def icon(self) -> str | None:
@@ -432,31 +445,45 @@ class OPNsenseNatSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseNatSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""
-        if not isinstance(self._rule, MutableMapping) or not self._client:
+        if not isinstance(self._rule, MutableMapping):
             return
+
         if self._rule_type == ATTR_NAT_PORT_FORWARD:
             method = self._client.enable_nat_port_forward_rule_by_created_time
         elif self._rule_type == ATTR_NAT_OUTBOUND:
             method = self._client.enable_nat_outbound_rule_by_created_time
         else:
             return
-        await method(self._tracker)
-        await self.coordinator.async_refresh()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+        _LOGGER.warning("Turning On NAT Rule: %s", self.name)
+
+        async def enable_nat_rule():
+            await method(self._tracker)
+            await self.coordinator.async_refresh()
+
+        await queue.put(enable_nat_rule)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the entity off."""
-        if not isinstance(self._rule, MutableMapping) or not self._client:
+        if not isinstance(self._rule, MutableMapping):
             return
+
         if self._rule_type == ATTR_NAT_PORT_FORWARD:
             method = self._client.disable_nat_port_forward_rule_by_created_time
         elif self._rule_type == ATTR_NAT_OUTBOUND:
             method = self._client.disable_nat_outbound_rule_by_created_time
         else:
             return
-        await method(self._tracker)
-        await self.coordinator.async_refresh()
+
+        _LOGGER.warning("Turning Off NAT Rule: %s", self.name)
+
+        async def disable_nat_rule():
+            await method(self._tracker)
+            await self.coordinator.async_refresh()
+
+        await queue.put(disable_nat_rule)
 
     @property
     def icon(self) -> str | None:
@@ -519,27 +546,39 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseServiceSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""
-        if not isinstance(self._service, MutableMapping) or not self._client:
+        if not isinstance(self._service, MutableMapping):
             return
 
-        result: bool = await self._client.start_service(
-            self._service.get("id", self._service.get("name", None))
-        )
-        if result:
-            await self.coordinator.async_refresh()
+        _LOGGER.warning("Turning On Service: %s", self.name)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+        async def start_service():
+            if self._service is not None:
+                result: bool = await self._client.start_service(
+                    self._service.get("id", self._service.get("name", None))
+                )
+                if result:
+                    await self.coordinator.async_refresh()
+
+        await queue.put(start_service)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the entity off."""
-        if not isinstance(self._service, MutableMapping) or not self._client:
+        if not isinstance(self._service, MutableMapping):
             return
 
-        result: bool = await self._client.stop_service(
-            self._service.get("id", self._service.get("name", None))
-        )
-        if result:
-            await self.coordinator.async_refresh()
+        _LOGGER.warning("Turning Off Service: %s", self.name)
+
+        async def stop_service():
+            if self._service is not None:
+                result: bool = await self._client.stop_service(
+                    self._service.get("id", self._service.get("name", None))
+                )
+                if result:
+                    await self.coordinator.async_refresh()
+
+        await queue.put(stop_service)
 
     @property
     def icon(self) -> str | None:
@@ -575,21 +614,29 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseUnboundBlocklistSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""
-        if not self._client:
-            return
-        result: bool = await self._client.enable_unbound_blocklist()
-        if result:
-            await self.coordinator.async_refresh()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+        _LOGGER.warning("Turning On Unbound Blocklist Switch: %s", self.name)
+
+        async def enable_unbound_blocklist():
+            result: bool = await self._client.enable_unbound_blocklist()
+            if result:
+                await self.coordinator.async_refresh()
+
+        await queue.put(enable_unbound_blocklist)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the entity off."""
-        if not self._client:
-            return
-        result: bool = await self._client.disable_unbound_blocklist()
-        if result:
-            await self.coordinator.async_refresh()
+
+        _LOGGER.warning("Turning Off Unbound Blocklist Switch: %s", self.name)
+
+        async def disable_unbound_blocklist():
+            result: bool = await self._client.disable_unbound_blocklist()
+            if result:
+                await self.coordinator.async_refresh()
+
+        await queue.put(disable_unbound_blocklist)
 
 
 class OPNsenseVPNSwitch(OPNsenseSwitch):
@@ -670,29 +717,39 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseVPNSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **_kwargs: Any) -> None:
         """Turn the entity on."""
 
-        if self.is_on or not self._client:
+        if self.is_on:
             return
 
-        result: bool = await self._client.toggle_vpn_instance(
-            self._vpn_type, self._clients_servers, self._uuid
-        )
-        if result:
-            await self.coordinator.async_refresh()
+        _LOGGER.warning("Turning On VPN Instance: %s", self.name)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+        async def toggle_vpn_instance():
+            result: bool = await self._client.toggle_vpn_instance(
+                self._vpn_type, self._clients_servers, self._uuid
+            )
+            if result:
+                await self.coordinator.async_refresh()
+
+        await queue.put(toggle_vpn_instance)
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
         """Turn the entity off."""
 
-        if not self.is_on or not self._client:
+        if not self.is_on:
             return
 
-        result: bool = await self._client.toggle_vpn_instance(
-            self._vpn_type, self._clients_servers, self._uuid
-        )
-        if result:
-            await self.coordinator.async_refresh()
+        _LOGGER.warning("Turning Off VPN Instance: %s", self.name)
+
+        async def toggle_vpn_instance():
+            result: bool = await self._client.toggle_vpn_instance(
+                self._vpn_type, self._clients_servers, self._uuid
+            )
+            if result:
+                await self.coordinator.async_refresh()
+
+        await queue.put(toggle_vpn_instance)
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -280,7 +280,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
             _LOGGER.error("Cannot update firmware, state data is missing")
             return
         upgrade_type = dict_get(state, "firmware_update_info.status")
-        if upgrade_type not in {"update", "upgrade"} or not self._client:
+        if upgrade_type not in {"update", "upgrade"}:
             return
 
         upgrade_details = await self._client.upgrade_firmware(upgrade_type)


### PR DESCRIPTION
Implement asyncio.Queue for switches. Should ensure all switch commands occur even if multiple are flipped together (manually or in automation). Won't necessarily speed up the action but will prevent loss of commands.

Also updated the self._client entity to satisfy the linting gods.