### PR TITLE
Implement queueing

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -250,7 +250,10 @@ async def async_remove_config_entry_device(
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     platforms = hass.data[DOMAIN][entry.entry_id][LOADED_PLATFORMS]
+    client: OPNsenseClient = hass.data[DOMAIN][entry.entry_id][OPNSENSE_CLIENT]
     unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
+
+    await client.async_close()
 
     for listener in hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENER]:
         listener()


### PR DESCRIPTION
* Adds asyncio.Queue to pyopnsense to prevent flooding OPNsense with too many concurrent API calls. Limits to 2 parallel workers
* Prevents the coordinator from running again if it is still running
* Fixes the toggling back and forth of switches especially when multiple are switched quickly
* Delay updating a switch with data from the coordinator after a toggle to allow the change to propagate to OPNsense

Fixes #345 
Fixes #375 