### PR TITLE
Change from hass.data to runtime_data

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 
-from .const import COORDINATOR, DOMAIN
+from .const import COORDINATOR
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
@@ -28,9 +28,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the OPNsense binary sensors."""
 
-    coordinator: OPNsenseDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
 
     entities: list = []
     entities.extend(

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfInformation, UnitOfTime
+from homeassistant.const import PERCENTAGE, Platform, UnitOfInformation, UnitOfTime
 
 VERSION = "v0.4.2"
 DOMAIN = "opnsense"
@@ -16,7 +16,13 @@ OPNSENSE_MIN_FIRMWARE = "24.7"  # If less than this, don't allow install. It wil
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"
 
-PLATFORMS: list = ["sensor", "switch", "device_tracker", "binary_sensor", "update"]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.DEVICE_TRACKER,
+    Platform.BINARY_SENSOR,
+    Platform.UPDATE,
+]
 LOADED_PLATFORMS = "loaded_platforms"
 
 OPNSENSE_CLIENT = "opnsense_client"

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -24,7 +24,6 @@ from .const import (
     DEFAULT_DEVICE_TRACKER_CONSIDER_HOME,
     DEFAULT_DEVICE_TRACKER_ENABLED,
     DEVICE_TRACKER_COORDINATOR,
-    DOMAIN,
     SHOULD_RELOAD,
     TRACKED_MACS,
 )
@@ -44,9 +43,10 @@ async def async_setup_entry(
 
     dev_reg = async_get_dev_reg(hass)
 
-    data = hass.data[DOMAIN][config_entry.entry_id]
     previous_mac_addresses: list = config_entry.data.get(TRACKED_MACS, [])
-    coordinator: OPNsenseDataUpdateCoordinator = data[DEVICE_TRACKER_COORDINATOR]
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(
+        config_entry.runtime_data, DEVICE_TRACKER_COORDINATOR
+    )
     state: MutableMapping[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in device tracker async_setup_entry")
@@ -118,7 +118,7 @@ async def async_setup_entry(
             dev_reg.async_remove_device(rem_device.id)
 
     if set(mac_addresses) != set(previous_mac_addresses):
-        data[SHOULD_RELOAD] = False
+        setattr(config_entry.runtime_data, SHOULD_RELOAD, False)
         new_data = config_entry.data.copy()
         new_data[TRACKED_MACS] = mac_addresses.copy()
         hass.config_entries.async_update_entry(config_entry, data=new_data)

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -56,16 +56,11 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         state = self.coordinator.data
         return dict_get(state, path)
 
-    def _get_opnsense_client(self) -> OPNsenseClient | None:
-        if self.hass is None:
-            return None
-        return self.hass.data[DOMAIN][self.config_entry.entry_id][OPNSENSE_CLIENT]
-
     async def async_added_to_hass(self) -> None:
         """Run once integration has been added to HA."""
         await super().async_added_to_hass()
         if self._client is None:
-            self._client = self._get_opnsense_client()
+            self._client = getattr(self.config_entry.runtime_data, OPNSENSE_CLIENT)
         if self._client is None:
             _LOGGER.error("Unable to get client in async_added_to_hass.")
         assert self._client is not None

--- a/custom_components/opnsense/models.py
+++ b/custom_components/opnsense/models.py
@@ -1,0 +1,24 @@
+"""OPNsense integration models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.const import Platform
+
+from .coordinator import OPNsenseDataUpdateCoordinator
+from .pyopnsense import OPNsenseClient
+
+
+@dataclass
+class OPNsenseData:
+    """Runtime data for the OPNsense integration."""
+
+    coordinator: OPNsenseDataUpdateCoordinator
+    device_tracker_coordinator: OPNsenseDataUpdateCoordinator | None
+    opnsense_client: OPNsenseClient
+    undo_update_listener: Callable[[], None]
+    loaded_platforms: list[Platform]
+    device_unique_id: str | None
+    should_reload: bool = True

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -26,14 +26,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.util import slugify
 from homeassistant.util.dt import utc_from_timestamp
 
-from .const import (
-    COORDINATOR,
-    COUNT,
-    DATA_PACKETS,
-    DATA_RATE_PACKETS_PER_SECOND,
-    DOMAIN,
-    STATIC_SENSORS,
-)
+from .const import COORDINATOR, COUNT, DATA_PACKETS, DATA_RATE_PACKETS_PER_SECOND, STATIC_SENSORS
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
@@ -445,9 +438,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the OPNsense sensors."""
 
-    coordinator: OPNsenseDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     state: MutableMapping[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in sensor async_setup_entry")

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -17,7 +17,6 @@ from homeassistant.helpers import (
 
 from .const import (
     DOMAIN,
-    OPNSENSE_CLIENT,
     SERVICE_CLOSE_NOTICE,
     SERVICE_GENERATE_VOUCHERS,
     SERVICE_KILL_STATES,
@@ -235,10 +234,8 @@ async def _get_clients(
         return []
     first_entry_id = next(iter(hass.data[DOMAIN]))
     if len(hass.data[DOMAIN]) == 1:
-        if OPNSENSE_CLIENT in hass.data[DOMAIN][first_entry_id]:
-            # _LOGGER.debug(f"[get_clients] Only 1 entry. entry_id: {first_entry_id}")
-            return [hass.data[DOMAIN][first_entry_id][OPNSENSE_CLIENT]]
-        return []
+        # _LOGGER.debug(f"[get_clients] Only 1 entry. entry_id: {first_entry_id}")
+        return [hass.data[DOMAIN][first_entry_id]]
 
     entry_ids: list = []
     if opndevice_id:
@@ -261,9 +258,9 @@ async def _get_clients(
                 entry_ids.append(entity_entry.config_entry_id)
     clients: list = []
     # _LOGGER.debug(f"[get_clients] entry_ids: {entry_ids}")
-    for entry_id, entry in hass.data[DOMAIN].items():
-        if (len(entry_ids) == 0 or entry_id in entry_ids) and OPNSENSE_CLIENT in entry:
-            clients.append(entry[OPNSENSE_CLIENT])
+    for entry_id, opnsense_client in hass.data[DOMAIN].items():
+        if len(entry_ids) == 0 or entry_id in entry_ids:
+            clients.append(opnsense_client)
     _LOGGER.debug("[get_clients] clients: %s", clients)
     return clients
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -12,13 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.event import async_call_later
 
-from .const import (
-    ATTR_NAT_OUTBOUND,
-    ATTR_NAT_PORT_FORWARD,
-    ATTR_UNBOUND_BLOCKLIST,
-    COORDINATOR,
-    DOMAIN,
-)
+from .const import ATTR_NAT_OUTBOUND, ATTR_NAT_PORT_FORWARD, ATTR_UNBOUND_BLOCKLIST, COORDINATOR
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
@@ -244,9 +238,7 @@ async def async_setup_entry(
     async_add_entities: entity_platform.AddEntitiesCallback,
 ) -> None:
     """Set up the OPNsense switches."""
-    coordinator: OPNsenseDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     state: MutableMapping[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in switch async_setup_entry")

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.util import slugify
 
-from .const import COORDINATOR, DOMAIN
+from .const import COORDINATOR
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
@@ -27,9 +27,7 @@ async def async_setup_entry(
     async_add_entities: entity_platform.AddEntitiesCallback,
 ) -> None:
     """Set up the OPNsense update entities."""
-    coordinator: OPNsenseDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        COORDINATOR
-    ]
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     entities: list = []
     entity = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=config_entry,


### PR DESCRIPTION
https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data/

Still keeping config_entry_id in hass.data in order for services to run on multiple OPNsense instances