### PR TITLE
Don't check Dnsmasq leases if < 25.1.7

### DIFF
--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1002,6 +1002,11 @@ $toreturn = [
             ) < awesomeversion.AwesomeVersion("25.1"):
                 _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1")
                 return []
+            if awesomeversion.AwesomeVersion(
+                self._firmware_version
+            ) < awesomeversion.AwesomeVersion("25.1.7"):
+                _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1.7")
+                return []
         except awesomeversion.exceptions.AwesomeVersionCompareException:
             pass
 


### PR DESCRIPTION
Ensure Dnsmasq leases are only fetched for firmware versions 25.1.7 and above, preventing errors on older versions.

Fixes #411 