### PR TITLE
Replace deprecated asyncio.get_event_loop()

### DIFF
--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -354,7 +354,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             caller = inspect.stack()[1].function
         except (IndexError, AttributeError):
             caller = "Unknown"
-        future = asyncio.get_event_loop().create_future()
+        future = self._loop.create_future()
         await self._request_queue.put(("get_from_stream", path, None, future, caller))
         return await future
 
@@ -363,7 +363,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             caller = inspect.stack()[1].function
         except (IndexError, AttributeError):
             caller = "Unknown"
-        future = asyncio.get_event_loop().create_future()
+        future = self._loop.create_future()
         await self._request_queue.put(("get", path, None, future, caller))
         return await future
 
@@ -374,7 +374,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             caller = inspect.stack()[1].function
         except (IndexError, AttributeError):
             caller = "Unknown"
-        future = asyncio.get_event_loop().create_future()
+        future = self._loop.create_future()
         await self._request_queue.put(("post", path, payload, future, caller))
         return await future
 


### PR DESCRIPTION
This pull request updates the way event loops are accessed and futures are created in both the main integration code and the test suite. The changes improve compatibility with modern asyncio practices and help avoid potential issues when running in different async contexts.

**Asyncio event loop handling improvements:**

* Replaced `asyncio.get_event_loop().create_future()` with `self._loop.create_future()` in the `_get_from_stream`, `_get`, and `_post` methods of `custom_components/opnsense/pyopnsense/__init__.py` to ensure futures are created on the correct event loop. [[1]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L357-R357) [[2]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L366-R366) [[3]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L377-R377)

**Test suite robustness:**

* Updated `pytest_runtest_teardown` in `tests/conftest.py` to prefer `asyncio.get_running_loop()` when available, falling back to the recommended `asyncio.get_event_loop_policy().get_event_loop()` for synchronous contexts, improving compatibility with modern asyncio usage patterns.

Fixes #430