### PR TITLE
Update pytest CI checkout

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -15,12 +15,19 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5.0.0
+        with:
+          # For pull_request_target we must manually checkout the PR's head commit;
+          # fall back to the current SHA for push / manual dispatch events.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Debug GitHub Variables
         run: |
             echo "github.event_name: ${{ github.event_name }}"
             echo "github.ref_name: ${{ github.ref_name }}"
             echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
+            echo "github.event.pull_request.head.sha: ${{ github.event.pull_request.head.sha }}"
+            echo "github.sha: ${{ github.sha }}"
 
       - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6.0.0


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for running pytest coverage, specifically improving how the repository is checked out and adding debugging output for GitHub variables.

Workflow improvements:

* Updated the `actions/checkout` step to explicitly check out the pull request's head commit when using `pull_request_target`, falling back to the current SHA for other event types, and set `fetch-depth: 0` to ensure the full history is available.

Debugging enhancements:

* Added additional debug output to print the pull request's head SHA and the current SHA to help diagnose issues with workflow runs.