### PR TITLE
Refine pytest CI comment

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -87,10 +87,13 @@ jobs:
 
       - name: PR coverage comment
         if: ${{ github.event_name == 'pull_request_target' && steps.check_cov.outputs.exists == 'true' }}
-        # uses: MishaKav/pytest-coverage-comment@main
-        uses: eltoder/pytest-coverage-comment@feature/branch-coverage
+        uses: MishaKav/pytest-coverage-comment@v1.1.57
+        # uses: eltoder/pytest-coverage-comment@feature/branch-coverage
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml
           remove-link-from-badge: true
-          badge-title: Branch Coverage
+          # xml-skip-covered: true
+          remove-links-to-lines: true
+          report-only-changed-files: true
+          # badge-title: Branch Coverage


### PR DESCRIPTION
This pull request updates the configuration for the PR coverage comment workflow in `.github/workflows/pytest_coverage.yml`. The main change is switching back to the standard `MishaKav/pytest-coverage-comment` action and adjusting its options to improve the clarity and relevance of coverage reports on pull requests.

Workflow configuration updates:

* Switched from the custom `eltoder/pytest-coverage-comment@feature/branch-coverage` action back to the standard `MishaKav/pytest-coverage-comment@main` for posting coverage comments on PRs.
* Updated action options to remove links to lines, report only changed files, and commented out some previously used options for badge title and skipping covered lines.