### PR TITLE
Show coverage on Readme

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -52,7 +52,8 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3.37
         with:
           GITHUB_TOKEN: ${{ github.token }}
-
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70
       - name: Store PR Comment to be Posted
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         uses: actions/upload-artifact@v4.6.2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Release Date][release-date-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
+[![Coverage][coverage-shield]][coverage]
 [![License][license-shield]](LICENSE)
 [![hacs][hacsbadge]][hacs]
 [![discord][discord-shield]][discord]
@@ -287,3 +288,5 @@ As mentioned [here](https://github.com/travisghansen/hass-opnsense/issues/22) us
 [releases]: https://github.com/travisghansen/hass-opnsense/releases
 [discord]: https://discord.gg/bfF47sBw6A
 [discord-shield]: https://img.shields.io/discord/1283169313653526559?style=for-the-badge&label=Discord&logo=discord&&logoColor=lightcyan&logoSize=auto&color=white
+[coverage]: https://htmlpreview.github.io/?https://github.com/travisghansen/hass-opnsense/blob/python-coverage-comment-action-data/htmlcov/index.html
+[coverage-shield]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftravisghansen%2Fhass-opnsense%2Fpython-coverage-comment-action-data%2Fendpoint.json&style=for-the-badge


### PR DESCRIPTION
This pull request introduces code coverage reporting to the project by updating the workflow and documentation. The main changes are the addition of a coverage badge to the `README.md` and configuration of coverage thresholds in the GitHub Actions workflow.

Coverage reporting and documentation:

* Added a coverage badge to the `README.md` that links to the HTML coverage report, and defined the badge and report URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R291-R292)

Workflow configuration:

* Updated `.github/workflows/pytest_coverage.yml` to set minimum coverage thresholds for green (90%) and orange (70%) status in the coverage comment action.