### PR TITLE
Update pre-commit

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,8 @@ name: Linters
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -35,8 +37,7 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
-      - name: Run pre-commit.ci
-        uses: pre-commit-ci/lite-action@v1.1.0
+      - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
 
       - name: Run mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '.*\.md$'
@@ -12,32 +12,37 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.4
+    rev: v1.7.7
     hooks:
       - id: actionlint
-  # Note: shellcheck cannot directly parse YAML; actionlint extracts workflow
-  # shell blocks and calls shellcheck when available.
+    # Note: shellcheck cannot directly parse YAML; actionlint extracts workflow
+    # shell blocks and calls shellcheck when available.
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         # Match by detected shell file type (extensions or shebang)
         types: [shell]
         args: ['-x']
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.12.12
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.8.0
+    hooks:
+      - id: pre-commit-update
+
 ci:
   autofix_commit_msg: |
     [pre-commit.ci] auto fixes from pre-commit hooks

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -485,9 +485,9 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is True
     # verify the LTD deprecation/warning issue was created
-    assert (
-        create_issue_mock.called
-    ), "async_create_issue should have been called for firmware between min and LTD"
+    assert create_issue_mock.called, (
+        "async_create_issue should have been called for firmware between min and LTD"
+    )
     call_args = create_issue_mock.call_args
     # args: (hass, domain, issue_id, ...)
     assert call_args[0][1] == init_mod.DOMAIN


### PR DESCRIPTION
This pull request updates and improves the project's linting and pre-commit configuration. The main changes include updating several pre-commit hooks to their latest versions, adding a new hook for keeping pre-commit hooks up-to-date, and making minor improvements to the GitHub Actions workflow for linters. Additionally, it includes a small code style improvement in the test suite.

Pre-commit hook updates and improvements:

* Updated the following pre-commit hooks to their latest versions: `pre-commit-hooks` (v6.0.0), `actionlint` (v1.7.7), `shellcheck-py` (v0.11.0.1), `codespell` (v2.4.1), and `ruff-pre-commit` (v0.12.12). [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L5-R5) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L15-R45)
* Added the `pre-commit-update` hook to help automatically update pre-commit hooks in the future.

GitHub Actions workflow improvements:

* Modified the `linters` workflow to also run on pushes to the `main` branch, not just on pull requests.
* Simplified the usage of `pre-commit-ci/lite-action` in the workflow for clarity.

Testing code style:

* Refactored an assertion in `tests/test_init.py` for clarity and consistency with code style guidelines.