### PR TITLE
Refine pre-commit, labels and pytest github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,43 +1,30 @@
 version: 1
 appendOnly: true
 labels:
-  - label: "bugfix"
-    title: "(?i).*fix.*"
-  - label: "bugfix"
-    branch: "(?i).*fix.*"
-  - label: "feature"
-    title: "(?i).*feat.*"
-  - label: "feature"
-    branch: "(?i).*feat.*"
-  - label: "breaking-change"
-    title: "(?i).*breaking[ -_]change.*"
-  - label: "breaking-change"
-    branch: "(?i).*breaking[ -_]change.*"
-  - label: "github_actions"
-    title: "(?i).*github[ -_]action.*"
-  - label: "github_actions"
-    branch: "(?i).*github[ -_]action.*"
-  - label: "enhancement"
-    title: "(?i).*enhance.*"
-  - label: "enhancement"
-    branch: "(?i).*enhance.*"
-  - label: "enhancement"
-    title: "(?i).*improve.*"
-  - label: "enhancement"
-    branch: "(?i).*improve.*"
-  - label: "documentation"
-    title: "(?i).*document.*"
-  - label: "documentation"
-    branch: "(?i).*document.*"
-  - label: "documentation"
-    title: "(?i).*readme.*"
-  - label: "documentation"
-    branch: "(?i).*readme.*"
-  - label: "code-quality"
-    title: "(?i).*lint.*"
-  - label: "code-quality"
-    title: "(?i).*ruff.*"
-  - label: "code-quality"
-    title: "(?i).*mypy.*"
-  - label: "code-quality"
-    title: "(?i).*pre[ -_]commit.*"
+  - label: 'dependencies'
+    type: 'pull_request'
+    authors:
+      - 'pre-commit-ci[bot]'
+      - 'dependabot[bot]'
+      - 'renovate[bot]'
+  - label: 'bugfix'
+    type: 'pull_request'
+    title: '(?i).*fix.*'
+  - label: 'feature'
+    type: 'pull_request'
+    title: '(?i).*feat.*'
+  - label: 'breaking-change'
+    type: 'pull_request'
+    title: '(?i).*breaking[ -_]change.*'
+  - label: 'github_actions'
+    type: 'pull_request'
+    title: '(?i).*(github[ -_]?actions?|workflow(s)?).*'
+  - label: 'enhancement'
+    type: 'pull_request'
+    title: '(?i).*(enhance|improv(e|ement)).*'
+  - label: 'documentation'
+    type: 'pull_request'
+    title: '(?i).*(docs|document|readme).*'
+  - label: 'code-quality'
+    type: 'pull_request'
+    title: '(?i).*(lint|ruff|mypy|pytest|coverage|type-?check|pre[ -_]?commit).*'

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     name: pytest and coverage report
+    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
     runs-on: ubuntu-latest
     permissions:
       # Gives the action the necessary permissions for publishing new
@@ -29,6 +30,8 @@ jobs:
             echo "github.event_name: ${{ github.event_name }}"
             echo "github.ref_name: ${{ github.ref_name }}"
             echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
+            echo "github.event.pull_request.user.type: ${{ github.event.pull_request.user.type }}"
+            echo "PR labels: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '' }}"
 
       - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6.0.0
@@ -51,9 +54,10 @@ jobs:
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3.37
         with:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINIMUM_GREEN: 90
           MINIMUM_ORANGE: 70
+
       - name: Store PR Comment to be Posted
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         uses: actions/upload-artifact@v4.6.2
@@ -62,3 +66,4 @@ jobs:
           name: python-coverage-comment-action
           # If you use a different name, update COMMENT_FILENAME accordingly
           path: python-coverage-comment-action.txt
+          retention-days: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,10 +38,6 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
-    hooks:
-      - id: pre-commit-update
 
 ci:
   autofix_commit_msg: |


### PR DESCRIPTION
This pull request updates the repository’s GitHub workflow and configuration files to improve automation around labeling, test execution, and reporting for pull requests. The changes primarily focus on refining label assignment, optimizing CI runs for dependency updates and bots, and making minor improvements to workflow steps.

**Labeling and CI workflow improvements:**

* Updated `.github/labeler.yml` to simplify and enhance label assignment rules, including better matching for documentation, code quality, and dependency-related pull requests, and added author-based labeling for dependency bots.
* Modified `.github/workflows/pytest_coverage.yml` to skip test and coverage jobs for pull requests labeled as dependencies or submitted by bots, reducing unnecessary CI runs.

**Workflow and reporting enhancements:**

* Changed the coverage report step in `.github/workflows/pytest_coverage.yml` to use `secrets.GITHUB_TOKEN` instead of `github.token` for improved security and compatibility.
* Set artifact retention to 1 day for coverage comments in `.github/workflows/pytest_coverage.yml` to minimize storage usage.
* Added debug output for PR labels and user type to help diagnose workflow conditions in `.github/workflows/pytest_coverage.yml`.

**Pre-commit configuration cleanup:**

* Removed the `pre-commit-update` hook from `.pre-commit-config.yaml` to streamline pre-commit checks.