### PR TITLE
Fix pytest errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Coding standards
 - Follow existing repository style; run `pre-commit` and `ruff` where available.
 
 Local tooling note
-- Use `pre-commit` and `pytest` configured in the repo. Prefer running these inside `./.venv`.
+- Use `pre-commit` and `pytest` configured in the repo. You must run these inside `./.venv`.
 - By default, run the full pytest suite. If running targeted tests, explain why.
 - Avoid recommending `tox`, it is not in use by this repo.
 

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -630,8 +630,23 @@ class OPNsenseOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
+        # Store the config entry passed by the ConfigFlow helper so tests and
+        # runtime code can access it. Some test harnesses assign directly to
+        # `config_entry` on the flow; provide a backing attribute and a
+        # property with a setter to maintain compatibility.
+        self._config_entry: ConfigEntry = config_entry
         self._config: MutableMapping[str, Any] = {}
         self._options: MutableMapping[str, Any] = {}
+
+    @property
+    def config_entry(self) -> ConfigEntry:
+        """Return the config entry associated with this options flow."""
+        return self._config_entry
+
+    @config_entry.setter
+    def config_entry(self, entry: ConfigEntry) -> None:
+        """Allow assigning the config entry."""
+        self._config_entry = entry
 
     async def async_step_init(
         self, user_input: MutableMapping[str, Any] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -880,10 +880,10 @@ def pytest_runtest_teardown(item: Any, nextitem: Any) -> None:
         # Prefer the running loop when called from a running async context.
         event_loop = asyncio.get_running_loop()
     except RuntimeError:
-        # No running loop; fall back to the event loop from the current
-        # policy. This mirrors the recommended replacement for
-        # asyncio.get_event_loop() in synchronous code.
-        event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        # No running loop; create a new event loop as a safe fallback.
+        # This avoids using the deprecated `get_event_loop` path and mirrors
+        # the recommended pattern for synchronous code needing a loop.
+        event_loop = asyncio.new_event_loop()
     # If some integration code created and closed the global loop, we may
     # need to replace it with a fresh loop to allow the PHCC plugin to
     # perform teardown. However, this repository opts in to that behavior


### PR DESCRIPTION
This pull request introduces improvements to configuration flow handling, test infrastructure, and documentation. The most significant change is the enhancement of the options flow class to allow better access and compatibility for the `config_entry` attribute, which supports both runtime and testing scenarios. Additionally, the test teardown logic is updated to use a safer event loop creation pattern, and the documentation clarifies the required use of the virtual environment for running tests and pre-commit hooks.

**Configuration flow improvements:**

* Added a private backing attribute and property with a setter for `config_entry` in the `OPNsenseOptionsFlow` class to ensure compatibility with test harnesses and runtime code that may directly assign to this attribute. (`custom_components/opnsense/config_flow.py`)

**Test infrastructure updates:**

* Updated event loop handling in `pytest_runtest_teardown` to use `asyncio.new_event_loop()` as a safe fallback when no running loop is found, avoiding deprecated patterns and ensuring robust teardown in synchronous contexts. (`tests/conftest.py`)

**Documentation updates:**

* Clarified in `AGENTS.md` that `pre-commit` and `pytest` must be run inside `./.venv` to ensure consistent local development practices. (`AGENTS.md`)