### PR TITLE
Increase Device Tracker Consider Home max from 600 to 3600 seconds

### DIFF
--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -432,7 +432,7 @@ def _build_options_init_schema(
                         CONF_DEVICE_TRACKER_CONSIDER_HOME, DEFAULT_DEVICE_TRACKER_CONSIDER_HOME
                     ),
                 ),
-            ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=600)),
+            ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=3600)),
             vol.Optional(
                 CONF_GRANULAR_SYNC_OPTIONS,
                 default=user_input.get(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -239,6 +239,24 @@ def test_options_scan_interval_clamp(input_value, expected):
     assert validated.get(cf_mod.CONF_SCAN_INTERVAL) == expected
 
 
+@pytest.mark.parametrize(
+    "input_value,expected",
+    [
+        (-10, 0),  # below minimum -> clamped to 0
+        (300, 300),  # within range -> unchanged
+        (1200, 1200),  # within new range (20 minutes) -> unchanged
+        (3600, 3600),  # at maximum (1 hour) -> unchanged
+        (5000, 3600),  # above maximum -> clamped to 3600
+    ],
+)
+def test_options_device_tracker_consider_home_clamp(input_value, expected):
+    """_build_options_init_schema should clamp CONF_DEVICE_TRACKER_CONSIDER_HOME to min/max values."""
+    oschema = cf_mod._build_options_init_schema(user_input=None)
+    # pass a dict with the consider_home value set to the test value
+    validated = oschema({cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
+    assert validated.get(cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME) == expected
+
+
 def test_async_get_options_flow_returns_options_flow():
     """async_get_options_flow should return an OPNsenseOptionsFlow instance."""
     cfg = MagicMock()


### PR DESCRIPTION
Fixes #451 

-----

This pull request increases the maximum allowed value for the `CONF_DEVICE_TRACKER_CONSIDER_HOME` configuration option and adds corresponding test coverage to ensure proper clamping behavior. The main changes include updating the schema validation logic and introducing new parameterized tests.

Configuration validation update:

* Increased the upper limit for `CONF_DEVICE_TRACKER_CONSIDER_HOME` from 600 seconds (10 minutes) to 3600 seconds (1 hour) in the `_build_options_init_schema` function within `custom_components/opnsense/config_flow.py`.

Test coverage improvements:

* Added a new parameterized test `test_options_device_tracker_consider_home_clamp` in `tests/test_config_flow.py` to verify that input values for `CONF_DEVICE_TRACKER_CONSIDER_HOME` are correctly clamped between 0 and 3600 seconds. This ensures both minimum and maximum boundaries are enforced.