### PR TITLE
Fix VPN Connected Client count

### DIFF
--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1924,7 +1924,7 @@ $toreturn = [
             return {}
 
         servers = {
-            uid: await OPNsenseClient._process_wireguard_server(uid, srv)
+            uid: await OPNsenseClient._process_wireguard_server(uid, srv, client_summ)
             for uid, srv in server_summ.items()
             if isinstance(srv, MutableMapping)
         }
@@ -1942,7 +1942,7 @@ $toreturn = [
 
     @staticmethod
     async def _process_wireguard_server(
-        uid: str, srv: MutableMapping[str, Any]
+        uid: str, srv: MutableMapping[str, Any], client_summ: MutableMapping[str, Any]
     ) -> MutableMapping[str, Any]:
         """Process a single WireGuard server entry."""
         return {
@@ -1961,6 +1961,7 @@ $toreturn = [
                 {
                     "name": peer.get("value"),
                     "uuid": peer_id,
+                    "pubkey": client_summ.get(peer_id, {}).get("pubkey"),
                     "connected": False,
                 }
                 for peer_id, peer in srv.get("peers", {}).items()


### PR DESCRIPTION
Fixes #462

------

This pull request updates the WireGuard server processing logic to include client public keys when retrieving server information. The main changes involve passing client summary data to the server processing function and ensuring each peer entry includes its public key.

WireGuard server processing improvements:

* The `get_wireguard` method now passes `client_summ` to `_process_wireguard_server` to provide client summary data for each server.
* The `_process_wireguard_server` method signature is updated to accept `client_summ` as an argument.
* Each peer dictionary in the processed server data now includes the `pubkey` field, sourced from `client_summ` using the peer's UUID.