### PR TITLE
Update Documentation for Deprecating Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@
 
 Join `OPNsense` with `Home Assistant`!
 
-`hass-opnsense` uses the OPNsense [REST API](https://docs.opnsense.org/development/api.html) and built-in `xmlrpc` service to integrate OPNsense with Home Assistant. 
+`hass-opnsense` uses the OPNsense [REST API](https://docs.opnsense.org/development/api.html) to integrate OPNsense with Home Assistant. 
 
-__In most cases, a [plugin](#opnsense-plugin) is currently required to be installed on the <ins>OPNsense</ins> router for this to work properly.__
+**With OPNsense Firmware 26.1.1+, a plugin is no longer needed on the OPNsense Router.**
+
 
 A Discord server to discuss the integration is available, please click the Discord badge at the beginning of the page for the invite link.
 
 ## Table of Contents
 
 * [Installation](#installation)
-  * [OPNsense Plugin](#opnsense-plugin)
+  * [OPNsense Plugin (deprecated)](#opnsense-plugin)
   * [Home Assistant Integration](#homeassistant-integration)
     * [HACS Installation](#hacs-installation)
     * [Manual Installation](#manual-installation)
@@ -48,9 +49,12 @@ A Discord server to discuss the integration is available, please click the Disco
 
 This integration **replaces** the built-in OPNsense integration which only provides `device_tracker` functionality. Be sure to remove any associated configuration for the built-in integration **before** installing this replacement.
 
-In most cases, use of the integration requires a plugin installed on <ins>OPNsense</ins>.
+### OPNsense Plugin *(deprecated)*
 
-### OPNsense Plugin
+With OPNsense Firmware 26.1.1+, a plugin is **no longer needed** on the OPNsense Router.
+
+<details>
+<summary><h4>OPNsense Firmware < 26.1.1</h4></summary>
 
 In most cases, use of the integration requires an <ins>OPNsense</ins> plugin made available on mimugmail repository: `https://www.routerperformance.net/opnsense-repo/`. See [Granular Sync Options](#granular-sync-options) below for more details.
 
@@ -72,6 +76,8 @@ There are two ways to do it:
 OR
 
 2. In an <ins>OPNsense</ins> SSH session: `pkg install os-homeassistant-maxit`
+
+</details>
 
 ### HomeAssistant Integration
 
@@ -116,19 +122,17 @@ In <ins>OPNsense</ins>, create a new admin role user (or choose an existing admi
 
 ### Granular Sync Options
 
-Either at the time of install or in the integration options, Granular Sync Options can be enabled. There, choose the categories to sync with HA as desired. If enabled:
+Either at the time of install or in the integration options, Granular Sync Options can be enabled. There, choose the categories to sync with HA as desired. If enabled, the <ins>OPNsense</ins> user can have more narrow permissions.
 
-* The <ins>OPNsense</ins> user can have more narrow permissions
-
-* If a category that requires the <ins>OPNsense</ins> plugin isn't selected, the plugin on the <ins>OPNsense</ins> router isn't needed
-
-At minimum, the following permissions are required. [The list of what other permissions are needed for the Granular Sync Options and for the Actions can be reviewed here.](granular_permissions.md)
+At minimum, the following permissions are required:
 
 * Lobby: Dashboard
 
 * Status: Interfaces
 
 * System: Firmware
+
+[The list of what other permissions are needed for the Granular Sync Options and for the Actions can be reviewed here.](granular_permissions.md)
 
 ### Basic Configuration
 
@@ -192,11 +196,9 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 
 All of the switches are disabled by default
 
-* Filter Rules - enable/disable rules
+* Firewall Rules - enable/disable rules
 
-* NAT Port Forward Rules - enable/disable rules
-
-* NAT Outbound Rules - enable/disable rules
+* NAT Rules - enable/disable rules
 
 * Services - start/stop services (services must be enabled before they can be started)
 

--- a/granular_permissions.md
+++ b/granular_permissions.md
@@ -54,12 +54,28 @@
 | Interfaces: Virtual IPs: Status | /api/diagnostics/interface/get_vip_status |
 | Interfaces: Virtual IPs: Settings | /api/interfaces/vip_settings/get |
 
-## Firewall filter and NAT switches
+## Firewall rules and NAT rules switches
+
+### OPNsense Firmware 26.1.1+
+
+| OPNsense Permission | API Endpoints |
+| ----- | ----- |
+| Firewall: Rules [New] | /api/firewall/filter/search_rule<br>/api/firewall/filter/toggle_rule |
+| Firewall: NAT: Destination NAT | /api/firewall/d_nat/search_rule<br>/api/firewall/d_nat/toggle_rule |
+| Firewall: NAT: 1:1 | /api/firewall/one_to_one/search_rule<br>/api/firewall/one_to_one/toggle_rule |
+| Firewall: NAT: Source NAT | /api/firewall/source_nat/search_rule<br>/api/firewall/source_nat/toggle_rule |
+| Firewall: NAT: NPTv6 | /api/firewall/npt/search_rule<br>/api/firewall/npt/toggle_rule |
+
+<details>
+<summary><h3>OPNsense Firmware < 26.1.1</h3></summary>
+
 > **\*\*OPNsense plugin required\*\***
 
 | OPNsense Permission | API Endpoints |
 | ----- | ----- |
 | XMLRPC Library | _N/A – Operations are executed using the XMLRPC interface and OPNsense plugin_ |
+
+</details>
 
 ## Service switches
 


### PR DESCRIPTION
This pull request updates the documentation to clarify that, starting with OPNsense Firmware 26.1.1, the integration no longer requires a plugin on the OPNsense router. The README and granular permissions documentation have been revised to reflect this change, deprecate the plugin requirement, and improve clarity around permissions and switch functionality.

**Documentation updates for plugin deprecation and permissions:**

* Updated `README.md` to state that as of OPNsense Firmware 26.1.1+, a plugin is no longer needed, and marked the plugin as deprecated. Added clear sectioning to distinguish requirements for older firmware versions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R81)
* Clarified the minimum permissions required for granular sync options, and improved the explanation for when the plugin is still needed on older firmware.
* Updated switch descriptions to use consistent terminology ("Firewall Rules" and "NAT Rules") and simplified the list of available switches.
* Enhanced `granular_permissions.md` to document new permissions and API endpoints available with OPNsense Firmware 26.1.1+, and clarified the plugin requirement for older versions.

Partially addresses #488 