### PR TITLE
Rename granular sync options

### DIFF
--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -85,13 +85,12 @@
           "sync_gateways": "Gateway information",
           "sync_services": "Service switches",
           "sync_notices": "Notice information",
-          "sync_filters_and_nat": "Firewall filter and NAT switches*",
+          "sync_filters_and_nat": "Firewall and NAT rules switches",
           "sync_unbound": "Unbound blocklist switch",
           "sync_interfaces": "Interface information",
           "sync_certificates": "Security certificate information"
         },
-        "title": "Choose what items to sync",
-        "description": "* requires the OPNsense plugin"
+        "title": "Choose what items to sync"
       },
       "device_tracker": {
         "description": "Choose which devices you want to track. If you don't select any devices, all devices will be tracked but will be disabled by default. If you do select any devices, only those devices will be tracked and will be enabled by default.",


### PR DESCRIPTION
This pull request makes a minor update to the English translation file, clarifying the description of the "Firewall and NAT rules switches" option and removing an outdated note about plugin requirements.

- Translation improvements:
  * Updated the label for `sync_filters_and_nat` to "Firewall and NAT rules switches" for clarity.
  * Removed the description note "* requires the OPNsense plugin" as it's no longer relevant.

Partially addresses #488 