### PR TITLE
Relax Unique ID logic

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -211,7 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Trigger repair task and shutdown if device id has changed
-    router_device_id: str = await client.get_device_unique_id()
+    router_device_id: str | None = await client.get_device_unique_id(expected_id=config_device_id)
     _LOGGER.debug(
         "[init async_setup_entry]: config device id: %s, router device id: %s",
         config_device_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -561,7 +561,7 @@ def fake_client():
                 self._query_counts_reset = False
                 self._query_counts = (1, 1)
 
-            async def get_device_unique_id(self):
+            async def get_device_unique_id(self, expected_id: str | None = None):
                 return self._device_id
 
             async def get_host_firmware_version(self):
@@ -682,7 +682,7 @@ def fake_flow_client():
             async def get_system_info(self) -> dict:
                 return {"name": "OPNsense"}
 
-            async def get_device_unique_id(self) -> str:
+            async def get_device_unique_id(self, expected_id: str | None = None) -> str:
                 return self._device_id
 
             async def is_plugin_installed(self) -> bool:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,7 +61,7 @@ class _FakeFlowClient:
     async def get_system_info(self) -> MutableMapping[str, Any]:
         return {"name": "OPNsenseTest"}
 
-    async def get_device_unique_id(self) -> str:
+    async def get_device_unique_id(self, expected_id: str | None = None) -> str:
         return self._device_id
 
     async def get_arp_table(self, resolve_hostnames: bool = False) -> list[dict[str, Any]]:
@@ -80,7 +80,9 @@ class _FakeRuntimeClient:
         self._firmware = firmware
         self._closed = False
 
-    async def get_device_unique_id(self) -> str:  # used by setup & coordinator
+    async def get_device_unique_id(
+        self, expected_id: str | None = None
+    ) -> str:  # used by setup & coordinator
         return self._device_id
 
     async def get_host_firmware_version(self) -> str:  # used by setup & coordinator


### PR DESCRIPTION
This pull request enhances the handling and validation of device unique IDs throughout the OPNsense Home Assistant integration. The main improvement is the addition of an `expected_id` parameter to the `get_device_unique_id` method, allowing the system to prefer a specific device ID if present. This change is propagated across the core integration logic, configuration flow, coordinator, and test suite to ensure consistent device identification and smoother configuration updates.

**Device Unique ID Handling and Validation:**

* [`custom_components/opnsense/pyopnsense/__init__.py`](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L687-R709): Updated `get_device_unique_id` to accept an `expected_id` parameter. If the expected ID is present among physical MAC addresses, it is returned; otherwise, the first MAC address is used.
* `custom_components/opnsense/__init__.py`, `custom_components/opnsense/config_flow.py`, `custom_components/opnsense/coordinator.py`: Propagated the `expected_id` parameter through setup, validation, and coordinator logic to ensure the correct device ID is used during configuration and runtime. [[1]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL214-R214) [[2]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542R91-R100) [[3]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L261-R267) [[4]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L308-R314) [[5]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L565-R575) [[6]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L595-R609) [[7]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L704-R722) [[8]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL86-R92)

**Test Suite Updates:**

* `tests/conftest.py`, `tests/test_integration.py`: Updated test client mocks to support the new `expected_id` parameter in `get_device_unique_id`. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L564-R564) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L685-R685) [[3]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL64-R64) [[4]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL83-R85)
* [`tests/test_pyopnsense.py`](diffhunk://#diff-3f98ae8b69a4cc9463d5a2db5646de2e30e27e5475d08f3ae9939cb6fbc26061R3299-R3321): Added a new test to verify that `get_device_unique_id` returns the expected ID when present, and falls back to the default when not.

**Code Quality Improvements:**

* [`custom_components/opnsense/coordinator.py`](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL3-R3): Improved type annotations and variable naming for clarity when dynamically invoking client methods. [[1]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL3-R3) [[2]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL86-R92)

Fixes #480 