### PR TITLE
Fix excessive firmware checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.10
+    rev: v1.7.11
     hooks:
       - id: actionlint
     # Note: shellcheck cannot directly parse YAML; actionlint extracts workflow
@@ -31,7 +31,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.4
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -462,6 +462,22 @@ $toreturn["real"] = json_encode($toreturn_real);
             )
         return {}
 
+    async def _store_host_firmware_version(self) -> None:
+        firmware_info = await self._safe_dict_get("/api/core/firmware/status")
+        firmware: str | None = dict_get(firmware_info, "product.product_version")
+        if not firmware or not awesomeversion.AwesomeVersion(firmware).valid:
+            old = firmware
+            firmware = dict_get(firmware_info, "product.product_series", old)
+            if firmware != old:
+                _LOGGER.debug(
+                    "[get_host_firmware_version] firmware: %s not valid SemVer, using %s",
+                    old,
+                    firmware,
+                )
+        else:
+            _LOGGER.debug("[get_host_firmware_version] firmware: %s", firmware)
+        self._firmware_version = firmware
+
     @_log_errors
     async def get_host_firmware_version(self) -> None | str:
         """Return the OPNsense Firmware version.
@@ -473,21 +489,9 @@ $toreturn["real"] = json_encode($toreturn_real);
 
 
         """
-        firmware_info = await self._safe_dict_get("/api/core/firmware/status")
-        firmware: str | None = firmware_info.get("product", {}).get("product_version")
-        if not firmware or not awesomeversion.AwesomeVersion(firmware).valid:
-            old = firmware
-            firmware = firmware_info.get("product", {}).get("product_series", old)
-            if firmware != old:
-                _LOGGER.debug(
-                    "[get_host_firmware_version] firmware: %s not valid SemVer, using %s",
-                    old,
-                    firmware,
-                )
-        else:
-            _LOGGER.debug("[get_host_firmware_version] firmware: %s", firmware)
-        self._firmware_version = firmware
-        return firmware
+        if self._firmware_version is None:
+            await self._store_host_firmware_version()
+        return self._firmware_version
 
     async def set_use_snake_case(self, initial: bool = False) -> None:
         """Set whether to use snake_case or camelCase for API calls.
@@ -498,14 +502,11 @@ $toreturn["real"] = json_encode($toreturn_real);
             Whether the call runs during initial setup/validation. Defaults to False.
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
 
         self._use_snake_case = True
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.7"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.7"):
                 _LOGGER.debug("Using camelCase for OPNsense < 25.7")
                 self._use_snake_case = False
             else:
@@ -517,7 +518,7 @@ $toreturn["real"] = json_encode($toreturn_real);
         ) as e:
             _LOGGER.error(
                 "Error comparing firmware version %s. Using snake_case by default",
-                self._firmware_version,
+                firmware,
             )
             if initial:
                 raise UnknownFirmware from e
@@ -1395,13 +1396,10 @@ $toreturn = [
 
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
 
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("26.1.1"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("26.1.1"):
                 _LOGGER.debug("Using legacy plugin for firewall filters for OPNsense < 26.1.1")
                 return {"config": await self.get_config()}
         except (awesomeversion.exceptions.AwesomeVersionCompareException, TypeError, ValueError):
@@ -2002,18 +2000,13 @@ $toreturn = [
 
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
 
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.1"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.1"):
                 _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1")
                 return []
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.1.7"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.1.7"):
                 _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1.7")
                 return []
         except (awesomeversion.exceptions.AwesomeVersionCompareException, TypeError, ValueError):
@@ -3121,12 +3114,9 @@ $toreturn = [
 
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.7.8"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.7.8"):
                 _LOGGER.debug("Getting Unbound Regular Blocklists for OPNsense < 25.7.8")
                 return {"legacy": await self.get_unbound_blocklist_legacy()}
         except (
@@ -3136,7 +3126,7 @@ $toreturn = [
         ) as e:
             _LOGGER.error(
                 "Error comparing firmware version %s when determining which Unbound Blocklist method to use. %s: %s",
-                self._firmware_version,
+                firmware,
                 type(e).__name__,
                 e,
             )
@@ -3222,12 +3212,9 @@ $toreturn = [
 
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.7.8"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.7.8"):
                 _LOGGER.debug("Using Unbound Regular Blocklists for OPNsense < 25.7.8")
                 return await self._set_unbound_blocklist_legacy(set_state=True)
             _LOGGER.debug("Using Unbound Extended Blocklists for OPNsense >= 25.7.8")
@@ -3239,7 +3226,7 @@ $toreturn = [
         ) as e:
             _LOGGER.error(
                 "Error comparing firmware version %s when determining which Unbound Blocklist method to use. %s: %s",
-                self._firmware_version,
+                firmware,
                 type(e).__name__,
                 e,
             )
@@ -3263,12 +3250,9 @@ $toreturn = [
 
 
         """
-        if self._firmware_version is None:
-            await self.get_host_firmware_version()
+        firmware = await self.get_host_firmware_version()
         try:
-            if awesomeversion.AwesomeVersion(
-                self._firmware_version
-            ) < awesomeversion.AwesomeVersion("25.7.8"):
+            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.7.8"):
                 _LOGGER.debug("Using Unbound Regular Blocklists for OPNsense < 25.7.8")
                 return await self._set_unbound_blocklist_legacy(set_state=False)
             _LOGGER.debug("Using Unbound Extended Blocklists for OPNsense >= 25.7.8")
@@ -3280,7 +3264,7 @@ $toreturn = [
         ) as e:
             _LOGGER.error(
                 "Error comparing firmware version %s when determining which Unbound Blocklist method to use. %s: %s",
-                self._firmware_version,
+                firmware,
                 type(e).__name__,
                 e,
             )

--- a/tests/test_pyopnsense.py
+++ b/tests/test_pyopnsense.py
@@ -265,7 +265,7 @@ async def test_opnsenseclient_async_close(make_client) -> None:
 
 @pytest.mark.asyncio
 async def test_get_host_firmware_version_and_fallback(make_client) -> None:
-    """Verify get_host_firmware_version returns product_version when valid and falls back to product_series."""
+    """Verify firmware resolution uses version when valid and series fallback when invalid."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
 
@@ -273,14 +273,16 @@ async def test_get_host_firmware_version_and_fallback(make_client) -> None:
     client._safe_dict_get = AsyncMock(return_value={"product": {"product_version": "25.8.0"}})
     fw = await client.get_host_firmware_version()
     assert fw == "25.8.0"
+    await client.async_close()
 
-    # invalid semver -> fallback to product_series
-    client._safe_dict_get = AsyncMock(
+    # use a fresh client to validate fallback resolution (version is cached after first call)
+    fallback_client = make_client(session=session)
+    fallback_client._safe_dict_get = AsyncMock(
         return_value={"product": {"product_version": "weird", "product_series": "seriesX"}}
     )
-    fw2 = await client.get_host_firmware_version()
+    fw2 = await fallback_client.get_host_firmware_version()
     assert fw2 == "seriesX"
-    await client.async_close()
+    await fallback_client.async_close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request refactors how the OPNsense firmware version is retrieved and cached in the `pyopnsense` client, improving efficiency and reliability. It also updates pre-commit hooks to newer versions and enhances the corresponding test to better verify fallback logic. The most important changes are as follows:

**Core logic and caching improvements:**

* Refactored firmware version retrieval: The logic for getting and caching the firmware version was moved to a new internal method `_store_host_firmware_version`, which is now called only when needed. This ensures the firmware version is fetched once and reused, improving efficiency and reducing redundant API calls. (`custom_components/opnsense/pyopnsense/__init__.py`) [[1]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L465-R470) [[2]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L490-R494)
* Updated all internal references to the firmware version: All methods that previously accessed `self._firmware_version` directly now use the cached value via `get_host_firmware_version()`, ensuring consistency and reliability. (`custom_components/opnsense/pyopnsense/__init__.py`) [[1]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L501-R509) [[2]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L520-R521) [[3]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L1398-R1402) [[4]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L2005-R2009) [[5]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3124-R3119) [[6]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3139-R3129) [[7]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3225-R3217) [[8]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3242-R3229) [[9]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3266-R3255) [[10]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L3283-R3267)

**Testing improvements:**

* Enhanced firmware version fallback test: The test for firmware version retrieval now ensures that the fallback to `product_series` is properly validated by using a fresh client instance, preventing cached values from interfering with the test. (`tests/test_pyopnsense.py`)

**Tooling updates:**

* Upgraded pre-commit hooks: Updated the `actionlint` hook to v1.7.11 and the `ruff-pre-commit` hook to v0.15.4 in `.pre-commit-config.yaml`, ensuring the latest linting and workflow checks are used. (`.pre-commit-config.yaml`) [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L15-R15) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L34-R34)

Fixes #504 