### PR TITLE
refactor/Move from MutableMapping to dict

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -5,7 +5,7 @@ including system information, network interfaces, firewall rules, DHCP leases,
 and various other OPNsense features through the Home Assistant interface.
 """
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from datetime import timedelta
 import logging
 from typing import Any
@@ -537,7 +537,7 @@ async def _migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
 
     """
     tls_insecure = config_entry.data.get(CONF_TLS_INSECURE, DEFAULT_TLS_INSECURE)
-    data: MutableMapping[str, Any] = dict(config_entry.data)
+    data: dict[str, Any] = dict(config_entry.data)
 
     # remove tls_insecure
     if CONF_TLS_INSECURE in data:
@@ -575,7 +575,7 @@ async def _migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
-    config: MutableMapping[str, Any] = dict(config_entry.data)
+    config: dict[str, Any] = dict(config_entry.data)
     url: str = config[CONF_URL]
     username: str = config[CONF_USERNAME]
     password: str = config[CONF_PASSWORD]
@@ -659,7 +659,7 @@ async def _migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
                 e,
             )
 
-    new_data: MutableMapping[str, Any] = dict(config_entry.data)
+    new_data: dict[str, Any] = dict(config_entry.data)
     new_data.update({CONF_DEVICE_UNIQUE_ID: new_device_unique_id})
     _LOGGER.debug(
         "[migrate_2_to_3] data: %s, new_data: %s, unique_id: %s, new_unique_id: %s",
@@ -702,7 +702,7 @@ async def _migrate_3_to_4(hass: HomeAssistant, config_entry: ConfigEntry) -> boo
     _LOGGER.debug("[migrate_3_to_4] Initial Version: %s", config_entry.version)
     entity_registry = er.async_get(hass)
 
-    config: MutableMapping[str, Any] = dict(config_entry.data)
+    config: dict[str, Any] = dict(config_entry.data)
     url: str = config[CONF_URL]
     username: str = config[CONF_USERNAME]
     password: str = config[CONF_PASSWORD]

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -96,7 +96,7 @@ class OPNsenseCarpStatusBinarySensor(OPNsenseBinarySensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
@@ -117,7 +117,7 @@ class OPNsensePendingNoticesPresentBinarySensor(OPNsenseBinarySensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -305,7 +305,7 @@ async def _handle_user_input(
     if require_plugin_check and not await client.is_plugin_installed():
         raise PluginMissing
 
-    system_info: MutableMapping[str, Any] = await client.get_system_info()
+    system_info: dict[str, Any] = await client.get_system_info()
     _LOGGER.debug("[handle_user_input] system_info: %s", system_info)
 
     if not user_input.get(CONF_NAME):
@@ -382,7 +382,7 @@ def _build_granular_sync_schema(
     if fallback is None:
         fallback = {}
 
-    schema_dict: MutableMapping[Any, Any] = {}
+    schema_dict: dict[Any, Any] = {}
 
     for conf in GRANULAR_SYNC_ITEMS:
         schema_dict[
@@ -459,7 +459,7 @@ def _build_options_init_schema(
 
 async def _get_dt_entries(
     hass: HomeAssistant, config: Mapping[str, Any], selected_devices: list
-) -> MutableMapping[str, Any]:
+) -> dict[str, Any]:
     url = config[CONF_URL].strip()
     username: str = config[CONF_USERNAME]
     password: str = config[CONF_PASSWORD]
@@ -476,9 +476,7 @@ async def _get_dt_entries(
         opts={"verify_ssl": verify_ssl},
     )
     # dicts are ordered so put all previously selected items at the top
-    entries: MutableMapping[str, Any] = {}
-    for device in selected_devices:
-        entries[device] = device
+    entries: dict[str, Any] = {device: device for device in selected_devices}
     arp_table: list = await client.get_arp_table(resolve_hostnames=True)
     if arp_table:
         # follow with all arp table entries
@@ -492,7 +490,7 @@ async def _get_dt_entries(
             entries[mac] = label
 
         # Sort entries: MAC-only labels first, then by IP address (ascending)
-        sorted_entries: MutableMapping[str, Any] = dict(
+        sorted_entries: dict[str, Any] = dict(
             sorted(
                 entries.items(),
                 key=lambda item: (
@@ -517,7 +515,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self._config: MutableMapping[str, Any] = {}
+        self._config: dict[str, Any] = {}
 
     # gets invoked without user input initially
     # when user submits has user_input
@@ -536,7 +534,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 if user_input[CONF_GRANULAR_SYNC_OPTIONS]:
-                    self._config = user_input
+                    self._config = dict(user_input)
                     return await self.async_step_granular_sync()
 
                 return self.async_create_entry(
@@ -656,8 +654,8 @@ class OPNsenseOptionsFlow(OptionsFlow):
         # `config_entry` on the flow; provide a backing attribute and a
         # property with a setter to maintain compatibility.
         self._config_entry: ConfigEntry = config_entry
-        self._config: MutableMapping[str, Any] = {}
-        self._options: MutableMapping[str, Any] = {}
+        self._config: dict[str, Any] = {}
+        self._options: dict[str, Any] = {}
 
     @property
     def config_entry(self) -> ConfigEntry:
@@ -775,7 +773,7 @@ class OPNsenseOptionsFlow(OptionsFlow):
                 return self.async_create_entry(data=self._options)
 
         selected_devices: list = self.config_entry.options.get(CONF_DEVICES, [])
-        dt_entries: MutableMapping[str, Any] = await _get_dt_entries(
+        dt_entries: dict[str, Any] = await _get_dt_entries(
             hass=self.hass, config=self.config_entry.data, selected_devices=selected_devices
         )
 

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -79,8 +79,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         # await self._client.get_host_firmware_version() # Already triggered in __init__.py async_setup_entry
         await self._client.set_use_snake_case()
 
-    async def _get_states(self, categories: list) -> MutableMapping[str, Any]:
-        state: MutableMapping[str, Any] = {}
+    async def _get_states(self, categories: list) -> dict[str, Any]:
+        state: dict[str, Any] = {}
         total_time: float = 0
         for cat in categories:
             method_name: str = cat.get("function", "")
@@ -105,13 +105,13 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
 
         return state
 
-    def _build_categories(self) -> list[MutableMapping[str, str]]:
+    def _build_categories(self) -> list[dict[str, str]]:
         """Build the categories for fetching data."""
         if not self.config_entry:
             _LOGGER.error("Coordinator build_categories failed. No config entry found.")
             return []
         config: Mapping[str, Any] = self.config_entry.data
-        categories: list[MutableMapping[str, str]] = [
+        categories: list[dict[str, str]] = [
             {"function": "get_device_unique_id", "state_key": "device_unique_id"},
             {"function": "get_system_info", "state_key": "system_info"},
             {
@@ -267,12 +267,12 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     ):
                         continue
 
-                    instance: MutableMapping[str, Any] = (
+                    instance: dict[str, Any] = (
                         self._state.get(vpn_type, {})
                         .get(clients_servers, {})
                         .get(instance_name, {})
                     )
-                    previous_instance: MutableMapping[str, Any] = (
+                    previous_instance: dict[str, Any] = (
                         self._state.get("previous_state", {})
                         .get(vpn_type, {})
                         .get(clients_servers, {})
@@ -357,7 +357,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             )
             await self._client.reset_query_counts()
 
-            previous_state: MutableMapping[str, Any] = copy.deepcopy(self._state)
+            previous_state: dict[str, Any] = copy.deepcopy(self._state)
             if "previous_state" in previous_state:
                 del previous_state["previous_state"]
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     coordinator: OPNsenseDataUpdateCoordinator = getattr(
         config_entry.runtime_data, DEVICE_TRACKER_COORDINATOR
     )
-    state: MutableMapping[str, Any] = coordinator.data
+    state: dict[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in device tracker async_setup_entry")
         return
@@ -74,7 +74,7 @@ async def async_setup_entry(
         enabled_default = True
         mac_addresses = configured_mac_addresses
         for mac_address in mac_addresses:
-            device: MutableMapping[str, Any] = {"mac": mac_address}
+            device: dict[str, Any] = {"mac": mac_address}
             for arp_entry in arp_entries:
                 if mac_address == arp_entry.get("mac", ""):
                     try:
@@ -103,11 +103,14 @@ async def async_setup_entry(
                 devices.append(device)
 
     for device in devices:
+        mac = device.get("mac")
+        if not isinstance(mac, str):
+            continue
         entity = OPNsenseScannerEntity(
             config_entry=config_entry,
             coordinator=coordinator,
             enabled_default=enabled_default,
-            mac=device.get("mac", None),
+            mac=mac,
             mac_vendor=device.get("manufacturer", None),
             hostname=device.get("hostname", None),
         )
@@ -197,14 +200,14 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         arp_table = dict_get(state, "arp_table")
         if not isinstance(arp_table, list) or not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
         self._available = True
-        entry: MutableMapping[str, Any] | None = None
+        entry: dict[str, Any] | None = None
         for arp_entry in arp_table:
             if arp_entry.get("mac", "").lower() == self._attr_mac_address:
                 entry = arp_entry
@@ -251,7 +254,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         else:
             # TODO: clear cache under certain scenarios?
 
-            update_time = state.get("update_time", None)
+            update_time = state.get("update_time")
             if isinstance(update_time, float):
                 self._last_known_connected_time = datetime.fromtimestamp(
                     int(update_time),
@@ -259,7 +262,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                 )
             self._is_connected = True
 
-        ha_to_opnsense: MutableMapping[str, Any] = {
+        ha_to_opnsense: dict[str, Any] = {
             "interface": "intf_description",
             "expires": "expires",
             "type": "type",

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -1,6 +1,5 @@
 """Define the base entities for OPNsense."""
 
-from collections.abc import MutableMapping
 import logging
 from typing import Any
 
@@ -73,13 +72,13 @@ class OPNsenseEntity(OPNsenseBaseEntity):
     @property
     def device_info(self) -> DeviceInfo | None:
         """Device info for the firewall."""
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         model: str = "OPNsense"
         manufacturer: str = "Deciso B.V."
         if state is None:
             firmware: str | None = None
         else:
-            firmware = state.get("host_firmware_version", None)
+            firmware = state.get("host_firmware_version")
 
         device_info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._device_unique_id)},

--- a/custom_components/opnsense/pyopnsense/_typing.py
+++ b/custom_components/opnsense/pyopnsense/_typing.py
@@ -52,7 +52,7 @@ class PyOPNsenseClientProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def _get_from_stream(self, path: str) -> MutableMapping[str, Any]:
+    async def _get_from_stream(self, path: str) -> dict[str, Any]:
         """Queue a streaming GET request and parse the first data payload.
 
         Parameters
@@ -62,7 +62,7 @@ class PyOPNsenseClientProtocol(Protocol):
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
             Parsed stream payload.
 
         """
@@ -86,7 +86,7 @@ class PyOPNsenseClientProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def _safe_dict_get(self, path: str) -> MutableMapping[str, Any]:
+    async def _safe_dict_get(self, path: str) -> dict[str, Any]:
         """Fetch a GET payload and coerce non-mapping values to an empty mapping.
 
         Parameters
@@ -96,8 +96,8 @@ class PyOPNsenseClientProtocol(Protocol):
 
         Returns
         -------
-        MutableMapping[str, Any]
-            Mapping payload.
+        dict[str, Any]
+            Dictionary payload.
 
         """
         ...
@@ -122,7 +122,7 @@ class PyOPNsenseClientProtocol(Protocol):
     @abstractmethod
     async def _safe_dict_post(
         self, path: str, payload: MutableMapping[str, Any] | None = None
-    ) -> MutableMapping[str, Any]:
+    ) -> dict[str, Any]:
         """Fetch a POST payload and coerce non-mapping values to an empty mapping.
 
         Parameters
@@ -134,8 +134,8 @@ class PyOPNsenseClientProtocol(Protocol):
 
         Returns
         -------
-        MutableMapping[str, Any]
-            Mapping payload.
+        dict[str, Any]
+            Dictionary payload.
 
         """
         ...
@@ -162,7 +162,7 @@ class PyOPNsenseClientProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def _exec_php(self, script: str) -> MutableMapping[str, Any]:
+    async def _exec_php(self, script: str) -> dict[str, Any]:
         """Execute a PHP script via XMLRPC and decode the JSON payload.
 
         Parameters
@@ -172,8 +172,8 @@ class PyOPNsenseClientProtocol(Protocol):
 
         Returns
         -------
-        MutableMapping[str, Any]
-            Decoded mapping payload.
+        dict[str, Any]
+            Decoded dictionary payload.
 
         """
         ...
@@ -210,13 +210,13 @@ class PyOPNsenseClientProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def get_config(self) -> MutableMapping[str, Any]:
+    async def get_config(self) -> dict[str, Any]:
         """Return full OPNsense configuration payload.
 
         Returns
         -------
-        MutableMapping[str, Any]
-            Full configuration mapping.
+        dict[str, Any]
+            Full configuration dictionary.
 
         """
         ...

--- a/custom_components/opnsense/pyopnsense/client_base.py
+++ b/custom_components/opnsense/pyopnsense/client_base.py
@@ -64,7 +64,7 @@ class ClientBaseMixin:
         self._password: str = password
         self._name: str = name
 
-        self._opts: MutableMapping[str, Any] = opts or {}
+        self._opts: dict[str, Any] = dict(opts or {})
         self._verify_ssl: bool = self._opts.get("verify_ssl", True)
         parts = urlparse(url.rstrip("/"))
         self._url: str = f"{parts.scheme}://{parts.netloc}"
@@ -185,7 +185,7 @@ class ClientBaseMixin:
         await loop.run_in_executor(None, proxy_method)
 
     @_xmlrpc_timeout
-    async def _exec_php(self, script: str) -> MutableMapping[str, Any]:
+    async def _exec_php(self, script: str) -> dict[str, Any]:
         """Execute a PHP snippet through XMLRPC and decode the JSON payload.
 
         Parameters
@@ -195,8 +195,8 @@ class ClientBaseMixin:
 
         Returns
         -------
-        MutableMapping[str, Any]
-        JSON-decoded response mapping returned by the PHP helper, or an empty mapping on failure.
+        dict[str, Any]
+        JSON-decoded response payload, or an empty dictionary on failure.
 
 
         """
@@ -218,7 +218,8 @@ $toreturn["real"] = json_encode($toreturn_real);
             if not isinstance(response, MutableMapping):
                 return {}
             if response.get("real"):
-                return json.loads(response.get("real", ""))
+                response_json = json.loads(response.get("real", ""))
+                return dict(response_json) if isinstance(response_json, MutableMapping) else {}
         except TypeError as e:
             stack = inspect.stack()
             calling_function = stack[1].function.strip("_") if len(stack) > 1 else "Unknown"
@@ -288,7 +289,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             if initial:
                 raise UnknownFirmware from e
 
-    async def _get_from_stream(self, path: str) -> MutableMapping[str, Any]:
+    async def _get_from_stream(self, path: str) -> dict[str, Any]:
         """Queue a streaming GET request and return the parsed payload.
 
         Parameters
@@ -298,8 +299,8 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         Returns
         -------
-        MutableMapping[str, Any]
-        Queued streaming-response payload parsed into a mapping.
+        dict[str, Any]
+        Queued streaming-response payload parsed into a dictionary.
 
 
         """
@@ -369,7 +370,7 @@ $toreturn["real"] = json_encode($toreturn_real);
         while True:
             method: str | None = None
             path: str | None = None
-            payload: MutableMapping[str, Any] | None = None
+            payload: dict[str, Any] | None = None
             future: asyncio.Future[Any] | None = None
             caller = "Unknown"
             try:
@@ -419,9 +420,7 @@ $toreturn["real"] = json_encode($toreturn_real);
                 _LOGGER.error("Error monitoring queue size. %s: %s", type(e).__name__, e)
             await asyncio.sleep(10)
 
-    async def _do_get_from_stream(
-        self, path: str, caller: str = "Unknown"
-    ) -> MutableMapping[str, Any]:
+    async def _do_get_from_stream(self, path: str, caller: str = "Unknown") -> dict[str, Any]:
         """Execute a streaming GET request immediately.
 
         Parameters
@@ -433,7 +432,7 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed JSON object extracted from the stream payload.
 
 
@@ -477,7 +476,7 @@ $toreturn["real"] = json_encode($toreturn_real);
                                             response_json,
                                         )
                                         return (
-                                            response_json
+                                            dict(response_json)
                                             if isinstance(response_json, MutableMapping)
                                             else {}
                                         )  # Exit after processing the second message
@@ -580,7 +579,7 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         return None
 
-    async def _safe_dict_get(self, path: str) -> MutableMapping[str, Any]:
+    async def _safe_dict_get(self, path: str) -> dict[str, Any]:
         """Fetch data from the given path, ensuring the result is a dict.
 
         Parameters
@@ -590,13 +589,13 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         Returns
         -------
-        MutableMapping[str, Any]
-        Dictionary payload from the GET request, or an empty mapping if the response is not a dictionary.
+        dict[str, Any]
+        Dictionary payload from the GET request, or an empty dictionary if the response is not a mapping.
 
 
         """
         result = await self._get(path=path)
-        return result if isinstance(result, MutableMapping) else {}
+        return dict(result) if isinstance(result, MutableMapping) else {}
 
     async def _safe_list_get(self, path: str) -> list:
         """Fetch data from the given path, ensuring the result is a list.
@@ -651,9 +650,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             ) as response:
                 _LOGGER.debug("[post] Response %s: %s", response.status, response.reason)
                 if response.ok:
-                    response_json: MutableMapping[str, Any] | list = await response.json(
-                        content_type=None
-                    )
+                    response_json: dict[str, Any] | list = await response.json(content_type=None)
                     return response_json
                 if response.status == 403:
                     _LOGGER.error(
@@ -686,7 +683,7 @@ $toreturn["real"] = json_encode($toreturn_real);
 
     async def _safe_dict_post(
         self, path: str, payload: MutableMapping[str, Any] | None = None
-    ) -> MutableMapping[str, Any]:
+    ) -> dict[str, Any]:
         """Fetch data from the given path, ensuring the result is a dict.
 
         Parameters
@@ -698,13 +695,13 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         Returns
         -------
-        MutableMapping[str, Any]
-        Dictionary payload from the POST request, or an empty mapping if the response is not a dictionary.
+        dict[str, Any]
+        Dictionary payload from the POST request, or an empty dictionary if the response is not a mapping.
 
 
         """
         result = await self._post(path=path, payload=payload)
-        return result if isinstance(result, MutableMapping) else {}
+        return dict(result) if isinstance(result, MutableMapping) else {}
 
     async def _safe_list_post(
         self, path: str, payload: MutableMapping[str, Any] | None = None

--- a/custom_components/opnsense/pyopnsense/const.py
+++ b/custom_components/opnsense/pyopnsense/const.py
@@ -1,13 +1,12 @@
 """Constants for pyopnsense."""
 
-from collections.abc import MutableMapping
 from typing import Any
 
 from dateutil.tz import gettz
 
 DEFAULT_TIMEOUT = 60
 
-AMBIGUOUS_TZINFOS: MutableMapping[str, Any] = {
+AMBIGUOUS_TZINFOS: dict[str, Any] = {
     "ACST": gettz("Australia/Darwin"),  # Australian Central Standard Time
     "ACT": gettz("America/Rio_Branco"),  # Acre Time (Brazil)
     "AEST": gettz("Australia/Sydney"),  # Australian Eastern Standard Time

--- a/custom_components/opnsense/pyopnsense/dhcp.py
+++ b/custom_components/opnsense/pyopnsense/dhcp.py
@@ -30,7 +30,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
         """
         # [{'hostname': '?', 'ip-address': '<ip>', 'mac-address': '<mac>', 'interface': 'em0', 'expires': 1199, 'type': 'ethernet'}, ...]
-        request_body: MutableMapping[str, Any] = {"resolve": "yes" if resolve_hostnames else "no"}
+        request_body: dict[str, Any] = {"resolve": "yes" if resolve_hostnames else "no"}
         arp_table_info = await self._safe_dict_post(
             "/api/diagnostics/interface/search_arp", payload=request_body
         )
@@ -40,12 +40,12 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         return arp_table
 
     @_log_errors
-    async def get_dhcp_leases(self) -> MutableMapping[str, Any]:
+    async def get_dhcp_leases(self) -> dict[str, Any]:
         """Return list of DHCP leases.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed dhcp leases payload returned by OPNsense APIs.
 
 
@@ -59,8 +59,8 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         # TODO: Add Kea dhcpv6 leases if API ever gets added
 
         # _LOGGER.debug(f"[get_dhcp_leases] leases_raw: {leases_raw}")
-        leases: MutableMapping[str, Any] = {}
-        lease_interfaces: MutableMapping[str, Any] = await self._get_kea_interfaces()
+        leases: dict[str, Any] = {}
+        lease_interfaces: dict[str, Any] = await self._get_kea_interfaces()
         for lease in leases_raw:
             if (
                 not isinstance(lease, MutableMapping)
@@ -75,15 +75,15 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                 leases[if_name] = []
             leases[if_name].append(lease)
 
-        sorted_lease_interfaces: MutableMapping[str, Any] = {
+        sorted_lease_interfaces: dict[str, Any] = {
             key: lease_interfaces[key] for key in sorted(lease_interfaces)
         }
-        sorted_leases: MutableMapping[str, Any] = {}
+        sorted_leases: dict[str, Any] = {}
         for if_name in sorted(leases):
             if_subnet = leases[if_name]
             sorted_leases[if_name] = sorted(if_subnet, key=get_ip_key)
 
-        dhcp_leases: MutableMapping[str, Any] = {
+        dhcp_leases: dict[str, Any] = {
             "lease_interfaces": sorted_lease_interfaces,
             "leases": sorted_leases,
         }
@@ -91,19 +91,19 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
         return dhcp_leases
 
-    async def _get_kea_interfaces(self) -> MutableMapping[str, Any]:
+    async def _get_kea_interfaces(self) -> dict[str, Any]:
         """Return interfaces setup for Kea.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed kea interfaces payload returned by OPNsense APIs.
 
 
         """
         response = await self._safe_dict_get("/api/kea/dhcpv4/get")
-        lease_interfaces: MutableMapping[str, Any] = {}
-        general: MutableMapping[str, Any] = response.get("dhcpv4", {}).get("general", {})
+        lease_interfaces: dict[str, Any] = {}
+        general: dict[str, Any] = response.get("dhcpv4", {}).get("general", {})
         if general.get("enabled", "0") != "1":
             return {}
         for if_name, iface in general.get("interfaces", {}).items():
@@ -153,7 +153,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                 or not lease_info.get("hwaddr", None)
             ):
                 continue
-            lease: MutableMapping[str, Any] = {}
+            lease: dict[str, Any] = {}
             lease["address"] = lease_info.get("address", None)
             lease["hostname"] = (
                 lease_info.get("hostname", None).strip(".")
@@ -254,7 +254,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
             # _LOGGER.debug("[get_dnsmasq_leases] lease_info: %s", lease_info)
             if not isinstance(lease_info, MutableMapping):
                 continue
-            lease: MutableMapping[str, Any] = {}
+            lease: dict[str, Any] = {}
             lease["address"] = lease_info.get("address", None)
             lease["hostname"] = (
                 lease_info.get("hostname", None)
@@ -318,7 +318,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                 or not lease_info.get("mac", None)
             ):
                 continue
-            lease: MutableMapping[str, Any] = {}
+            lease: dict[str, Any] = {}
             lease["address"] = lease_info.get("address", None)
             lease["hostname"] = (
                 lease_info.get("hostname", None)
@@ -378,7 +378,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                 or not lease_info.get("mac", None)
             ):
                 continue
-            lease: MutableMapping[str, Any] = {}
+            lease: dict[str, Any] = {}
             lease["address"] = lease_info.get("address", None)
             lease["hostname"] = (
                 lease_info.get("hostname", None)

--- a/custom_components/opnsense/pyopnsense/firewall.py
+++ b/custom_components/opnsense/pyopnsense/firewall.py
@@ -22,7 +22,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
         for rule in config.get("filter", {}).get("rule", []):
             if "created" not in rule:
                 continue
@@ -46,7 +46,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
 
         for rule in config.get("filter", {}).get("rule", []):
             if "created" not in rule:
@@ -71,7 +71,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
         for rule in config.get("nat", {}).get("rule", []):
             if "created" not in rule:
                 continue
@@ -95,7 +95,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
         for rule in config.get("nat", {}).get("rule", []):
             if "created" not in rule:
                 continue
@@ -119,7 +119,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
         for rule in config.get("nat", {}).get("outbound", {}).get("rule", []):
             if "created" not in rule:
                 continue
@@ -143,7 +143,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
             Rule creation timestamp used as a legacy unique identifier.
 
         """
-        config: MutableMapping[str, Any] = await self.get_config()
+        config: dict[str, Any] = await self.get_config()
         for rule in config.get("nat", {}).get("outbound", {}).get("rule", []):
             if "created" not in rule or "time" not in rule["created"]:
                 continue
@@ -197,7 +197,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        request_body: MutableMapping[str, Any] = {"current": 1, "sort": {}}
+        request_body: dict[str, Any] = {"current": 1, "sort": {}}
         response = await self._safe_dict_post(
             "/api/firewall/filter/search_rule", payload=request_body
         )
@@ -228,7 +228,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        request_body: MutableMapping[str, Any] = {"current": 1, "sort": {}}
+        request_body: dict[str, Any] = {"current": 1, "sort": {}}
         response = await self._safe_dict_post(
             "/api/firewall/d_nat/search_rule", payload=request_body
         )
@@ -260,7 +260,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        request_body: MutableMapping[str, Any] = {"current": 1, "sort": {}}
+        request_body: dict[str, Any] = {"current": 1, "sort": {}}
         response = await self._safe_dict_post(
             "/api/firewall/one_to_one/search_rule", payload=request_body
         )
@@ -291,7 +291,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        request_body: MutableMapping[str, Any] = {"current": 1, "sort": {}}
+        request_body: dict[str, Any] = {"current": 1, "sort": {}}
         response = await self._safe_dict_post(
             "/api/firewall/source_nat/search_rule", payload=request_body
         )
@@ -322,7 +322,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        request_body: MutableMapping[str, Any] = {"current": 1, "sort": {}}
+        request_body: dict[str, Any] = {"current": 1, "sort": {}}
         response = await self._safe_dict_post("/api/firewall/npt/search_rule", payload=request_body)
         # _LOGGER.debug("[get_nat_npt_rules] response: %s", response)
         rules: list = response.get("rows", [])
@@ -357,7 +357,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        payload: MutableMapping[str, Any] = {}
+        payload: dict[str, Any] = {}
         url = f"/api/firewall/filter/toggle_rule/{uuid}"
         if toggle_on_off == "on":
             url = f"{url}/1"
@@ -404,7 +404,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        payload: MutableMapping[str, Any] = {}
+        payload: dict[str, Any] = {}
         url = f"/api/firewall/{nat_rule_type}/toggle_rule/{uuid}"
         # d_nat uses opposite logic for on/off
         if nat_rule_type == "d_nat" and toggle_on_off is not None:
@@ -451,7 +451,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
 
 
         """
-        payload: MutableMapping[str, Any] = {"filter": ip_addr}
+        payload: dict[str, Any] = {"filter": ip_addr}
         response = await self._safe_dict_post(
             "/api/diagnostics/firewall/kill_states/",
             payload=payload,
@@ -495,7 +495,7 @@ class FirewallMixin(PyOPNsenseClientProtocol):
                 break
         if not uuid:
             return False
-        payload: MutableMapping[str, Any] = {}
+        payload: dict[str, Any] = {}
         if self._use_snake_case:
             url: str = f"/api/firewall/alias/toggle_item/{uuid}"
         else:

--- a/custom_components/opnsense/pyopnsense/system.py
+++ b/custom_components/opnsense/pyopnsense/system.py
@@ -60,17 +60,17 @@ clear_subsystem_dirty('filter');
         return device_unique_id
 
     @_log_errors
-    async def get_system_info(self) -> MutableMapping[str, Any]:
+    async def get_system_info(self) -> dict[str, Any]:
         """Return the system info from OPNsense.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed system info payload returned by OPNsense APIs.
 
 
         """
-        system_info: MutableMapping[str, Any] = {}
+        system_info: dict[str, Any] = {}
         if self._use_snake_case:
             response = await self._safe_dict_get("/api/diagnostics/system/system_information")
         else:
@@ -79,12 +79,12 @@ clear_subsystem_dirty('filter');
         return system_info
 
     @_log_errors
-    async def get_config(self) -> MutableMapping[str, Any]:
+    async def get_config(self) -> dict[str, Any]:
         """XMLRPC call to return all the config settings.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed config payload returned by OPNsense APIs.
 
 
@@ -96,13 +96,11 @@ $toreturn = [
   "data" => $config,
 ];
 """
-        response: MutableMapping[str, Any] = await self._exec_php(script)
-        if not isinstance(response, MutableMapping):
-            return {}
+        response: dict[str, Any] = await self._exec_php(script)
         ret_data = response.get("data", {})
         if not isinstance(ret_data, MutableMapping):
             return {}
-        return ret_data
+        return dict(ret_data)
 
     @_log_errors
     async def get_carp_status(self) -> bool:
@@ -203,7 +201,7 @@ $toreturn = [
 
 
         """
-        payload: MutableMapping[str, Any] = {"wake": {"interface": interface, "mac": mac}}
+        payload: dict[str, Any] = {"wake": {"interface": interface, "mac": mac}}
         _LOGGER.debug("[send_wol] payload: %s", payload)
         response = await self._safe_dict_post("/api/wol/wol/set", payload)
         _LOGGER.debug("[send_wol] response: %s", response)
@@ -212,12 +210,12 @@ $toreturn = [
         return False
 
     @_log_errors
-    async def get_notices(self) -> MutableMapping[str, Any]:
+    async def get_notices(self) -> dict[str, Any]:
         """Get active OPNsense notices.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed notices payload returned by OPNsense APIs.
 
 
@@ -315,21 +313,22 @@ $toreturn = [
         return reload.get("message", "").startswith("OK")
 
     @_log_errors
-    async def get_certificates(self) -> MutableMapping[str, Any]:
+    async def get_certificates(self) -> dict[str, Any]:
         """Return the active encryption certificates.
 
         Returns
         -------
-        MutableMapping[str, Any]
+        dict[str, Any]
         Parsed certificates payload returned by OPNsense APIs.
 
 
         """
         certs_raw = await self._safe_dict_get("/api/trust/cert/search")
-        if not isinstance(certs_raw.get("rows", None), list):
+        cert_rows = certs_raw.get("rows")
+        if not isinstance(cert_rows, list):
             return {}
-        certs: MutableMapping[str, Any] = {}
-        for cert in certs_raw.get("rows", None):
+        certs: dict[str, Any] = {}
+        for cert in cert_rows:
             if cert.get("descr", None):
                 certs[cert.get("descr")] = {
                     "uuid": cert.get("uuid", None),

--- a/custom_components/opnsense/pyopnsense/telemetry.py
+++ b/custom_components/opnsense/pyopnsense/telemetry.py
@@ -26,7 +26,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
 
 
         """
-        telemetry: MutableMapping[str, Any] = {}
+        telemetry: dict[str, Any] = {}
         telemetry["mbuf"] = await self._get_telemetry_mbuf()
         telemetry["pfstate"] = await self._get_telemetry_pfstate()
         telemetry["memory"] = await self._get_telemetry_memory()
@@ -52,9 +52,9 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug(f"[get_interfaces] interface_info: {interface_info}")
         if not len(interface_info) > 0:
             return {}
-        interfaces: MutableMapping[str, Any] = {}
+        interfaces: dict[str, Any] = {}
         for ifinfo in interface_info:
-            interface: MutableMapping[str, Any] = {}
+            interface: dict[str, Any] = {}
             if not isinstance(ifinfo, MutableMapping) or ifinfo.get("identifier", "") == "":
                 continue
             interface["inpkts"] = try_to_int(
@@ -116,7 +116,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         """
         mbuf_info = await self._safe_dict_post("/api/diagnostics/system/system_mbuf")
         # _LOGGER.debug(f"[get_telemetry_mbuf] mbuf_info: {mbuf_info}")
-        mbuf: MutableMapping[str, Any] = {}
+        mbuf: dict[str, Any] = {}
         mbuf["used"] = try_to_int(mbuf_info.get("mbuf-statistics", {}).get("mbuf-current", None))
         mbuf["total"] = try_to_int(mbuf_info.get("mbuf-statistics", {}).get("mbuf-total", None))
         mbuf["used_percent"] = (
@@ -142,7 +142,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         """
         pfstate_info = await self._safe_dict_post("/api/diagnostics/firewall/pf_states")
         # _LOGGER.debug(f"[get_telemetry_pfstate] pfstate_info: {pfstate_info}")
-        pfstate: MutableMapping[str, Any] = {}
+        pfstate: dict[str, Any] = {}
         pfstate["used"] = try_to_int(pfstate_info.get("current", None))
         pfstate["total"] = try_to_int(pfstate_info.get("limit", None))
         pfstate["used_percent"] = (
@@ -171,7 +171,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         else:
             memory_info = await self._safe_dict_post("/api/diagnostics/system/systemResources")
         # _LOGGER.debug(f"[get_telemetry_memory] memory_info: {memory_info}")
-        memory: MutableMapping[str, Any] = {}
+        memory: dict[str, Any] = {}
         memory["physmem"] = try_to_int(memory_info.get("memory", {}).get("total", None))
         memory["used"] = try_to_int(memory_info.get("memory", {}).get("used", None))
         memory["used_percent"] = (
@@ -217,7 +217,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         else:
             time_info = await self._safe_dict_post("/api/diagnostics/system/systemTime")
         # _LOGGER.debug("[get_telemetry_system] time_info: %s", time_info)
-        system: MutableMapping[str, Any] = {}
+        system: dict[str, Any] = {}
 
         try:
             systemtime: datetime = parse(time_info["datetime"], tzinfos=AMBIGUOUS_TZINFOS)
@@ -309,7 +309,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug(f"[get_telemetry_cpu] cputype_info: {cputype_info}")
         if not len(cputype_info) > 0:
             return {}
-        cpu: MutableMapping[str, Any] = {}
+        cpu: dict[str, Any] = {}
         cores_match = re.search(r"\((\d+) cores", cputype_info[0])
         cpu["count"] = try_to_int(cores_match.group(1)) if cores_match else 0
 
@@ -358,7 +358,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         """
         gateways_info = await self._safe_dict_get("/api/routes/gateway/status")
         # _LOGGER.debug(f"[get_gateways] gateways_info: {gateways_info}")
-        gateways: MutableMapping[str, Any] = {}
+        gateways: dict[str, Any] = {}
         for gw_info in gateways_info.get("items", []):
             if isinstance(gw_info, MutableMapping) and "name" in gw_info:
                 gateways[gw_info["name"]] = gw_info
@@ -385,9 +385,9 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug(f"[get_telemetry_temps] temps_info: {temps_info}")
         if not len(temps_info) > 0:
             return {}
-        temps: MutableMapping[str, Any] = {}
+        temps: dict[str, Any] = {}
         for i, temp_info in enumerate(temps_info):
-            temp: MutableMapping[str, Any] = {}
+            temp: dict[str, Any] = {}
             temp["temperature"] = try_to_float(temp_info.get("temperature", 0), 0)
             temp["name"] = (
                 f"{temp_info.get('type_translated', 'Num')} {temp_info.get('device_seq', i)}"

--- a/custom_components/opnsense/pyopnsense/unbound.py
+++ b/custom_components/opnsense/pyopnsense/unbound.py
@@ -59,7 +59,7 @@ class UnboundMixin(PyOPNsenseClientProtocol):
 
 
         """
-        payload: MutableMapping[str, Any] = {}
+        payload: dict[str, Any] = {}
         payload["unbound"] = {}
         payload["unbound"]["dnsbl"] = await self.get_unbound_blocklist_legacy()
         if not payload["unbound"]["dnsbl"]:
@@ -117,14 +117,14 @@ class UnboundMixin(PyOPNsenseClientProtocol):
                 e,
             )
         dnsbl_raw = await self._safe_dict_get("/api/unbound/settings/search_dnsbl")
-        if not isinstance(dnsbl_raw, dict):
+        if not isinstance(dnsbl_raw, MutableMapping):
             return {}
         dnsbl_rows = dnsbl_raw.get("rows", [])
         if not isinstance(dnsbl_rows, list) or not len(dnsbl_rows) > 0:
             return {}
         dnsbl_full: dict[str, Any] = {}
         for dnsbl in dnsbl_rows:
-            if not isinstance(dnsbl, dict):
+            if not isinstance(dnsbl, MutableMapping):
                 continue
             _LOGGER.debug("[get_unbound_blocklist] dnsbl: %s", dnsbl)
             if dnsbl.get("uuid"):

--- a/custom_components/opnsense/pyopnsense/vouchers.py
+++ b/custom_components/opnsense/pyopnsense/vouchers.py
@@ -42,7 +42,7 @@ class VouchersMixin(PyOPNsenseClientProtocol):
                 )
             server = servers[0]
         server_slug = quote(str(server), safe="")
-        payload: MutableMapping[str, Any] = dict(data).copy()
+        payload: dict[str, Any] = dict(data).copy()
         payload.pop("voucher_server", None)
         if self._use_snake_case:
             voucher_url: str = f"/api/captiveportal/voucher/generate_vouchers/{server_slug}/"
@@ -73,7 +73,7 @@ class VouchersMixin(PyOPNsenseClientProtocol):
                 voucher["expiry_timestamp"] = expiry_timestamp
                 voucher["expirytime"] = timestamp_to_datetime(expiry_timestamp)
 
-            rearranged_voucher: MutableMapping[str, Any] = {
+            rearranged_voucher: dict[str, Any] = {
                 key: voucher[key] for key in ordered_keys if key in voucher
             }
             voucher.clear()

--- a/custom_components/opnsense/pyopnsense/vpn.py
+++ b/custom_components/opnsense/pyopnsense/vpn.py
@@ -44,7 +44,7 @@ class VPNMixin(PyOPNsenseClientProtocol):
         # https://docs.opnsense.org/development/api/core/openvpn.html
         # https://github.com/opnsense/core/blob/master/src/opnsense/www/js/widgets/OpenVPNClients.js
         # https://github.com/opnsense/core/blob/master/src/opnsense/www/js/widgets/OpenVPNServers.js
-        openvpn: MutableMapping[str, Any] = {"servers": {}, "clients": {}}
+        openvpn: dict[str, Any] = {"servers": {}, "clients": {}}
 
         # Fetch data
         if self._use_snake_case:

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -451,7 +451,7 @@ async def async_setup_entry(
     """Set up the OPNsense sensors."""
 
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
-    state: MutableMapping[str, Any] = coordinator.data
+    state: dict[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in sensor async_setup_entry")
         return
@@ -585,8 +585,8 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        filesystem: MutableMapping[str, Any] = {}
-        state: MutableMapping[str, Any] = self.coordinator.data
+        filesystem: dict[str, Any] = {}
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
@@ -624,13 +624,13 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
         interface_name: str = self.entity_description.key.split(".")[1]
-        interface: MutableMapping[str, Any] = {}
+        interface: dict[str, Any] = {}
         interfaces = state.get("interfaces")
         if not isinstance(interfaces, Mapping):
             self._available = False
@@ -687,8 +687,8 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        carp_interface: MutableMapping[str, Any] = {}
-        state: MutableMapping[str, Any] = self.coordinator.data
+        carp_interface: dict[str, Any] = {}
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
@@ -740,12 +740,12 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
-        gateway: MutableMapping[str, Any] = {}
+        gateway: dict[str, Any] = {}
         gateway_name: str = self.entity_description.key.split(".")[1]
         for i_gateway_name, gway in state.get("gateways", {}).items():
             if i_gateway_name == gateway_name:
@@ -797,13 +797,13 @@ class OPNsenseVPNSensor(OPNsenseSensor):
     def _handle_coordinator_update(self) -> None:
         vpn_type: str = self.entity_description.key.split(".")[0]
         clients_servers: str = self.entity_description.key.split(".")[1]
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
         uuid: str = self.entity_description.key.split(".")[2]
-        instance: MutableMapping[str, Any] = {}
+        instance: dict[str, Any] = {}
         for instance_uuid, ins in (
             dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
         ).items():
@@ -890,7 +890,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         ):
             self._attr_extra_state_attributes["clients"] = []
             for clnt in instance.get("clients", {}):
-                client: MutableMapping[str, Any] = {}
+                client: dict[str, Any] = {}
                 for client_attr in (
                     "name",
                     "status",
@@ -919,13 +919,13 @@ class OPNsenseTempSensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
         sensor_temp_device: str = self.entity_description.key.split(".")[2]
-        temp: MutableMapping[str, Any] = {}
+        temp: dict[str, Any] = {}
         for temp_device, temp_temp in state.get("telemetry", {}).get("temps", {}).items():
             if temp_device == sensor_temp_device:
                 temp = temp_temp
@@ -956,7 +956,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
@@ -976,7 +976,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                 return
             self._available = True
             total_lease_count: int = 0
-            lease_counts: MutableMapping[str, Any] = {}
+            lease_counts: dict[str, Any] = {}
             try:
                 for ifn, if_descr in lease_interfaces.items():
                     if_count: int = sum(
@@ -993,7 +993,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                 self._available = False
                 self.async_write_ha_state()
                 return
-            sorted_lease_counts: MutableMapping[str, Any] = {
+            sorted_lease_counts: dict[str, Any] = {
                 key: lease_counts[key] for key in sorted(lease_counts)
             }
             self._attr_extra_state_attributes = dict(sorted_lease_counts)

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -474,7 +474,7 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
     success: bool | None = None
     response_list: list = []
     for client in clients:
-        response: MutableMapping[str, Any] = await client.kill_states(call.data.get("ip_addr"))
+        response: dict[str, Any] = await client.kill_states(call.data.get("ip_addr"))
         _LOGGER.debug(
             "[service_kill_states] client: %s, ip_addr: %s, response: %s",
             client.name,

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -57,7 +57,7 @@ async def _compile_filter_switches_legacy(
         return []
     entities: list = []
     for rule in rules:
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
 
         # do NOT add rules that are NAT rules
@@ -118,7 +118,7 @@ async def _compile_port_forward_switches_legacy(
         return []
     entities: list = []
     for rule in rules:
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
 
         tracker = dict_get(rule, "created.time")
@@ -171,7 +171,7 @@ async def _compile_nat_outbound_switches_legacy(
     entities: list = []
 
     for rule in rules:
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
 
         tracker = dict_get(rule, "created.time")
@@ -362,7 +362,7 @@ async def _compile_unbound_switches(
         return []
     entities: list = []
     for uuid, dnsbl in state.get(ATTR_UNBOUND_BLOCKLIST, {}).items():
-        if not isinstance(dnsbl, dict):
+        if not isinstance(dnsbl, MutableMapping):
             continue
 
         entity = OPNsenseUnboundBlocklistSwitch(
@@ -405,12 +405,12 @@ async def _compile_firewall_rules_switches(
 
     """
     rules = dict_get(state, "firewall.rules")
-    if not isinstance(rules, dict):
+    if not isinstance(rules, MutableMapping):
         return []
 
     entities: list = []
     for rule in rules.values():
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
         interface = rule.get("%interface", rule.get("interface", ""))
         if not isinstance(interface, str):
@@ -455,12 +455,12 @@ async def _compile_nat_source_rules_switches(
 
     """
     rules = dict_get(state, "firewall.nat.source_nat")
-    if not isinstance(rules, dict):
+    if not isinstance(rules, MutableMapping):
         return []
 
     entities: list = []
     for rule in rules.values():
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
         entity = OPNsenseNATRuleSwitch(
             config_entry=config_entry,
@@ -500,12 +500,12 @@ async def _compile_nat_destination_rules_switches(
 
     """
     rules = dict_get(state, "firewall.nat.d_nat")
-    if not isinstance(rules, dict):
+    if not isinstance(rules, MutableMapping):
         return []
 
     entities: list = []
     for rule in rules.values():
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
         entity = OPNsenseNATRuleSwitch(
             config_entry=config_entry,
@@ -545,12 +545,12 @@ async def _compile_nat_one_to_one_rules_switches(
 
     """
     rules = dict_get(state, "firewall.nat.one_to_one")
-    if not isinstance(rules, dict):
+    if not isinstance(rules, MutableMapping):
         return []
 
     entities: list = []
     for rule in rules.values():
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
         entity = OPNsenseNATRuleSwitch(
             config_entry=config_entry,
@@ -590,12 +590,12 @@ async def _compile_nat_npt_rules_switches(
 
     """
     rules = dict_get(state, "firewall.nat.npt")
-    if not isinstance(rules, dict):
+    if not isinstance(rules, MutableMapping):
         return []
 
     entities: list = []
     for rule in rules.values():
-        if not isinstance(rule, dict):
+        if not isinstance(rule, MutableMapping):
             continue
         entity = OPNsenseNATRuleSwitch(
             config_entry=config_entry,
@@ -630,7 +630,7 @@ async def async_setup_entry(
 
     """
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
-    state: MutableMapping[str, Any] = coordinator.data
+    state: dict[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in switch async_setup_entry")
         return
@@ -639,7 +639,7 @@ async def async_setup_entry(
     entities: list = []
 
     if config.get(CONF_SYNC_FIREWALL_AND_NAT, DEFAULT_SYNC_OPTION_VALUE):
-        firmware = state.get("host_firmware_version", None)
+        firmware = state.get("host_firmware_version")
         if firmware:
             try:
                 if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion(
@@ -701,7 +701,7 @@ async def async_setup_entry(
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
     if config.get(CONF_SYNC_UNBOUND, DEFAULT_SYNC_OPTION_VALUE):
-        firmware = state.get("host_firmware_version", None)
+        firmware = state.get("host_firmware_version")
         if firmware:
             try:
                 if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion(
@@ -869,7 +869,7 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             The rule data if available, None otherwise.
 
         """
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             return None
         return state.get("firewall", {}).get("rules", {}).get(self._rule_id, None)
@@ -1022,7 +1022,7 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             The rule data if available, None otherwise.
 
         """
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             return None
         return (
@@ -1199,7 +1199,7 @@ class OPNsenseFilterSwitchLegacy(OPNsenseSwitch):
             The rule data if available, None otherwise.
 
         """
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         tracker: str = self._opnsense_get_tracker()
         if not isinstance(state, MutableMapping):
             return None
@@ -1323,7 +1323,7 @@ class OPNsenseNatSwitchLegacy(OPNsenseSwitch):
             The rule data if available, None otherwise.
 
         """
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             return None
         rules: list = []
@@ -1465,7 +1465,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             The service data if available, None otherwise.
 
         """
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             return None
         service_id: str = self._opnsense_get_service_id()
@@ -1635,7 +1635,7 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
                 self.name,
             )
             return
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
@@ -1725,12 +1725,12 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         if self.delay_update:
             _LOGGER.debug("Skipping coordinator update for VPN switch %s due to delay", self.name)
             return
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
-        instance: MutableMapping[str, Any] = (
+        instance: dict[str, Any] = (
             state.get(self._vpn_type, {}).get(self._clients_servers, {}).get(self._uuid, {})
         )
         if not isinstance(instance, MutableMapping):
@@ -1776,7 +1776,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             properties = ["uuid", "name"]
 
         for attr in properties:
-            if instance.get(attr, None):
+            if instance.get(attr):
                 self._attr_extra_state_attributes[attr] = instance.get(attr)
         self.async_write_ha_state()
         # _LOGGER.debug(f"[OPNsenseVPNSwitch handle_coordinator_update] Name: {self.name}, available: {self.available}, is_on: {self.is_on}, extra_state_attributes: {self.extra_state_attributes}")

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -92,7 +92,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not self._is_update_available(state):
             self._available = False
             self.async_write_ha_state()
@@ -297,7 +297,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         self, version: str | None = None, backup: bool = False, **kwargs: Any
     ) -> None:
         """Install an update."""
-        state: MutableMapping[str, Any] = self.coordinator.data
+        state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             _LOGGER.error("Cannot update firmware, state data is missing")
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ background tasks, and simplify Home Assistant testing.
 """
 
 import asyncio
+from collections.abc import MutableMapping
 import contextlib
 import inspect
 import logging
@@ -276,7 +277,7 @@ def _patch_asyncio_create_task(monkeypatch):
         if frame:
             try:
                 g = getattr(frame, "f_globals", None) or {}
-                module_name = g.get("__name__", "") if isinstance(g, dict) else ""
+                module_name = g.get("__name__", "") if isinstance(g, MutableMapping) else ""
             except (AttributeError, TypeError):
                 module_name = ""
 
@@ -434,7 +435,7 @@ def _neutralize_pyopnsense_background_tasks(monkeypatch, request):
                 if frame:
                     try:
                         g = getattr(frame, "f_globals", None) or {}
-                        module_name = g.get("__name__", "") if isinstance(g, dict) else ""
+                        module_name = g.get("__name__", "") if isinstance(g, MutableMapping) else ""
                     except (AttributeError, TypeError):
                         module_name = ""
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,6 +5,7 @@ category building, state fetching, device ID mismatch handling, speed
 calculations, and update flow.
 """
 
+from collections.abc import MutableMapping
 from datetime import timedelta
 import time
 from unittest.mock import AsyncMock, MagicMock
@@ -134,7 +135,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     assert called["issue"] == 1
     assert called["shutdown"] == 1
     # validate the issue was created for the integration domain and expected id
-    assert isinstance(called["issue_kwargs"], dict)
+    assert isinstance(called["issue_kwargs"], MutableMapping)
     assert called["issue_kwargs"].get("domain") == coordinator_module.DOMAIN
     assert (
         called["issue_kwargs"].get("issue_id") == f"{coord._device_unique_id}_device_id_mismatched"
@@ -321,7 +322,7 @@ async def test_async_update_data_reentrancy_and_full_flow(
 
     # run update; should return a dict
     out = await coord._async_update_data()
-    assert isinstance(out, dict)
+    assert isinstance(out, MutableMapping)
     # Verify returned dict is the coordinator's state and bookkeeping completed
     assert out == coord._state
     assert coord._updating is False
@@ -487,7 +488,7 @@ async def test_async_update_data_strips_nested_previous_state(
     out = await coord._async_update_data()
 
     # previous_state assigned on the coordinator should not contain the nested key
-    assert isinstance(out, dict)
+    assert isinstance(out, MutableMapping)
     assert "previous_state" in out
     assert "previous_state" not in out["previous_state"]
     # other top-level keys from the original state should be preserved in the copy
@@ -645,7 +646,7 @@ async def test_async_update_dt_data_device_id_branches(
 
     if should_call_counts:
         # Should return the state and call get_query_counts
-        assert isinstance(res, dict)
+        assert isinstance(res, MutableMapping)
         assert res.get("device_unique_id") == "id"
         client.get_query_counts.assert_awaited_once()
     else:

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -4,6 +4,7 @@ These tests cover setup, coordinator update handling, restore state behavior,
 and device info formatting for the integration's device tracker entities.
 """
 
+from collections.abc import MutableMapping
 from datetime import datetime
 import importlib
 from unittest.mock import AsyncMock, MagicMock
@@ -256,7 +257,7 @@ async def test_restore_last_state_and_device_info(monkeypatch, coordinator, make
     # device_info should include the mac connection and via_device tuple
     devinfo = ent.device_info
     # support both DeviceInfo object and dict-shaped DeviceInfo used in tests
-    if isinstance(devinfo, dict):
+    if isinstance(devinfo, MutableMapping):
         connections = devinfo.get("connections", [])
         via = devinfo.get("via_device")
     else:

--- a/tests/test_pyopnsense.py
+++ b/tests/test_pyopnsense.py
@@ -569,7 +569,7 @@ async def test_telemetry_and_temps_and_notices_and_unbound_blocklist(make_client
             ]
         )
         temps = await client._get_telemetry_temps()
-        assert isinstance(temps, dict)
+        assert isinstance(temps, MutableMapping)
 
         # notices
         client._safe_dict_get = AsyncMock(
@@ -1143,7 +1143,7 @@ async def test_get_from_stream_parsing(make_client, fake_stream_response_factory
     try:
         res = await client._do_get_from_stream("/stream", caller="tst")
         # implementation returns the second 'data' message parsed as JSON
-        assert isinstance(res, dict)
+        assert isinstance(res, MutableMapping)
         assert res.get("b") == 2
     finally:
         await client.async_close()
@@ -1167,7 +1167,7 @@ async def test_get_from_stream_ignores_first_message(
     )
     try:
         res = await client._do_get_from_stream("/stream", caller="tst")
-        assert isinstance(res, dict)
+        assert isinstance(res, MutableMapping)
         # ensure the second message was selected
         assert res.get("id") == "second"
         assert res.get("body") == "keep me"
@@ -1412,7 +1412,7 @@ async def test_get_from_stream_partial_chunks_accumulates_buffer(
     )
     try:
         res = await client._do_get_from_stream("/stream2", caller="tst")
-        assert isinstance(res, dict)
+        assert isinstance(res, MutableMapping)
     finally:
         await client.async_close()
 
@@ -1982,7 +1982,7 @@ async def test_exec_php_returns_real_json_and_xmlrpc_timeout_decorator() -> None
         proxy.opnsense.exec_php.return_value = {"real": '{"ok": true, "val": 5}'}
         client._get_proxy = MagicMock(return_value=proxy)
         res = await client._exec_php("echo ok;")
-        assert isinstance(res, dict) and res.get("val") == 5
+        assert isinstance(res, MutableMapping) and res.get("val") == 5
 
         # Test the _xmlrpc_timeout decorator: wrap a simple async function
         class D:
@@ -2211,7 +2211,7 @@ async def test_do_get_and_do_post_success_paths() -> None:
     )
 
     got = await client._do_get("/api/x", caller="t")
-    assert isinstance(got, dict) and got.get("a") == 1
+    assert isinstance(got, MutableMapping) and got.get("a") == 1
 
     posted = await client._do_post("/api/x", payload={"x": 1}, caller="t")
     assert isinstance(posted, list) and posted[0] == 1
@@ -2393,7 +2393,7 @@ async def test_telemetry_system_parsing_and_filesystems() -> None:
         client._safe_dict_post = AsyncMock(side_effect=fake_safe_post)
 
         sys = await client._get_telemetry_system()
-        assert isinstance(sys, dict)
+        assert isinstance(sys, MutableMapping)
         # At least one of the expected fields is normalized/present
         assert any(k in sys for k in ("uptime", "boottime", "loadavg"))
 
@@ -2690,7 +2690,7 @@ async def test_telemetry_mbuf_pfstate_and_temps() -> None:
             return_value=[{"temperature": "45.5", "type_translated": "CPU", "device_seq": 0}]
         )
         temps = await client._get_telemetry_temps()
-        assert isinstance(temps, dict) and len(temps) == 1
+        assert isinstance(temps, MutableMapping) and len(temps) == 1
     finally:
         await client.async_close()
 
@@ -2778,7 +2778,7 @@ async def test_exercise_many_misc_branches() -> None:
         }
         client._safe_dict_post = AsyncMock(return_value=ti)
         sys = await client._get_telemetry_system()
-        assert isinstance(sys, dict)
+        assert isinstance(sys, MutableMapping)
 
         # reload_interface paths (snake_case vs camelCase)
         client._use_snake_case = True
@@ -2800,14 +2800,14 @@ async def test_exercise_many_misc_branches() -> None:
         client._get_telemetry_filesystems = AsyncMock(return_value={})
         client._get_telemetry_temps = AsyncMock(return_value={})
         telem = await client.get_telemetry()
-        assert isinstance(telem, dict)
+        assert isinstance(telem, MutableMapping)
 
         # call get_openvpn with empty dicts to exercise early return and processing functions
         client._safe_dict_get = AsyncMock(
             side_effect=[{"rows": []}, {"rows": []}, {}, {"rows": []}, {}]
         )
         res = await client.get_openvpn()
-        assert isinstance(res, dict)
+        assert isinstance(res, MutableMapping)
     finally:
         await client.async_close()
 
@@ -2886,7 +2886,7 @@ async def test_get_dhcp_leases_combined_structure() -> None:
     client._get_kea_interfaces = AsyncMock(return_value={"em0": "eth0"})
 
     combined = await client.get_dhcp_leases()
-    assert isinstance(combined, dict)
+    assert isinstance(combined, MutableMapping)
     assert "lease_interfaces" in combined and "leases" in combined
     await client.async_close()
 
@@ -2911,7 +2911,7 @@ async def test_get_arp_table_and_manage_service_upgrade_flow() -> None:
     # upgrade_firmware: update -> calls safe_list_post
     client._safe_dict_post = AsyncMock(return_value={"status": "ok"})
     res = await client.upgrade_firmware("update")
-    assert isinstance(res, dict)
+    assert isinstance(res, MutableMapping)
 
     # upgrade_firmware: unknown type returns None
     assert await client.upgrade_firmware("noop") is None
@@ -3188,7 +3188,7 @@ async def test_enable_filter_rule_by_created_time_legacy(
         assert called[0] == "filter"
         # second arg is the filter section; ensure the matching rule no longer has 'disabled'
         filter_section = called[1]
-        assert isinstance(filter_section, dict)
+        assert isinstance(filter_section, MutableMapping)
         # find the matching rule inside the passed filter section
         rules_passed = filter_section.get("rule", [])
         matched = [r for r in rules_passed if r.get("created", {}).get("time") == created_time]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,6 +5,7 @@ async setup flows for the integration's switch platform.
 """
 
 import asyncio
+from collections.abc import MutableMapping
 import contextlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -591,7 +592,7 @@ async def test_unbound_and_vpn_variations(coordinator, ph_hass, make_config_entr
         vpn._handle_coordinator_update()
         assert vpn.available is True
         inst = state.get(vpn._vpn_type, {}).get(vpn._clients_servers, {}).get(vpn._uuid)
-        assert isinstance(inst, dict)
+        assert isinstance(inst, MutableMapping)
         assert vpn.is_on is bool(inst.get("enabled"))
 
 


### PR DESCRIPTION
This pull request refactors the codebase to replace usage of `MutableMapping` with `dict` for type annotations and variable declarations throughout the OPNsense Home Assistant integration. This change improves clarity, aligns with modern Python typing practices, and simplifies the code. The refactor touches multiple files and functions, but does not alter any runtime logic.

Type annotation and variable declaration refactor:

**Core integration and migration logic**
* Replaced `MutableMapping` with `dict` in type annotations and variable declarations in migration functions (`_migrate_1_to_2`, `_migrate_2_to_3`, `_migrate_3_to_4`) and throughout `custom_components/opnsense/__init__.py`. [[1]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL8-R8) [[2]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL540-R540) [[3]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL578-R578) [[4]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL662-R662) [[5]](diffhunk://#diff-9c1e8aad6c866095840d391b3ce875711e534b4d73c2cd4425ed1302a357f97cL705-R705)

**Config flow and schema building**
* Updated type annotations and variable declarations from `MutableMapping` to `dict` in config flow logic, schema builders, and device tracker entry functions in `custom_components/opnsense/config_flow.py`. [[1]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L308-R308) [[2]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L385-R385) [[3]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L462-R462) [[4]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L479-R479) [[5]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L495-R493) [[6]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L520-R518) [[7]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L539-R537) [[8]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L659-R658) [[9]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L778-R776)

**Coordinator and device tracker**
* Changed type annotations and variable declarations from `MutableMapping` to `dict` in state handling, category building, VPN speed calculation, and device tracker setup in `custom_components/opnsense/coordinator.py` and `custom_components/opnsense/device_tracker.py`. [[1]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL82-R83) [[2]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL108-R114) [[3]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL270-R275) [[4]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL360-R360) [[5]](diffhunk://#diff-bb6e3513cdec02a77ea585da5c2c337bc44e6637b26d7ecaef307483883018aeL52-R52) [[6]](diffhunk://#diff-bb6e3513cdec02a77ea585da5c2c337bc44e6637b26d7ecaef307483883018aeL77-R77) [[7]](diffhunk://#diff-bb6e3513cdec02a77ea585da5c2c337bc44e6637b26d7ecaef307483883018aeR106-R113) [[8]](diffhunk://#diff-bb6e3513cdec02a77ea585da5c2c337bc44e6637b26d7ecaef307483883018aeL200-R210) [[9]](diffhunk://#diff-bb6e3513cdec02a77ea585da5c2c337bc44e6637b26d7ecaef307483883018aeL254-R265)

**Entity and binary sensor classes**
* Updated entity and binary sensor classes to use `dict` instead of `MutableMapping` for state and device info handling in `custom_components/opnsense/entity.py` and `custom_components/opnsense/binary_sensor.py`. [[1]](diffhunk://#diff-30fb31ecf05f06ffff8bf37e77a6bdc3cad00b4888d45ec48cfb85f1de5002aeL3) [[2]](diffhunk://#diff-30fb31ecf05f06ffff8bf37e77a6bdc3cad00b4888d45ec48cfb85f1de5002aeL76-R81) [[3]](diffhunk://#diff-3c10fa953ce6b6a66776f465c327384108175ab1ff1bc2ac250490a560ef22d8L99-R99) [[4]](diffhunk://#diff-3c10fa953ce6b6a66776f465c327384108175ab1ff1bc2ac250490a560ef22d8L120-R120)

**Typing and interface definitions**
* Modified abstract methods and interface definitions in `custom_components/opnsense/pyopnsense/_typing.py` to use `dict` in place of `MutableMapping` for payloads and return types. [[1]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66L55-R55) [[2]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66L65-R65) [[3]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66L89-R89) [[4]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66L99-R100) [[5]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66L125-R125)