### PR TITLE
Add vnStat Sensors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,12 @@ Project structure expectations
 
 Coding standards
 - Add typing annotations to all functions and classes (including return types).
-- Add or update docstrings for all files, classes and methods, including private methods. Method docstrings must be in NumPy format.
+- Add or update docstrings for all files, classes and methods, including private methods and nested methods. Method docstrings must be in NumPy format.
 - Preserve existing comments and keep imports at the top of files.
-- Follow existing repository style; run `pre-commit` and `ruff` where available.
+- Follow existing repository style; run `pre-commit`, and run `mypy` separately where available.
 
 Local tooling note
-- Use `pre-commit` and `pytest` configured in the repo. You must run these inside `./.venv`.
+- Use the repo's `pre-commit`, `mypy`, and `pytest` commands inside `./.venv`. Note that `mypy` is not currently wired into the pre-commit hooks. You must always run these inside `./.venv`.
 - By default, run the full pytest suite. If running targeted tests, explain why.
 - Avoid recommending `tox`, it is not in use by this repo.
 

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -48,6 +48,7 @@ CONF_DEVICE_UNIQUE_ID = "device_unique_id"
 CONF_FIRMWARE_VERSION = "firmware_version"
 
 CONF_SYNC_TELEMETRY = "sync_telemetry"
+CONF_SYNC_VNSTAT = "sync_vnstat"
 CONF_SYNC_VPN = "sync_vpn"
 CONF_SYNC_FIRMWARE_UPDATES = "sync_firmware_updates"
 CONF_SYNC_CARP = "sync_carp"
@@ -66,6 +67,7 @@ DEFAULT_SYNC_OPTION_VALUE = True
 SYNC_ITEMS_REQUIRING_PLUGIN = (CONF_SYNC_FIREWALL_AND_NAT,)
 GRANULAR_SYNC_ITEMS = (
     CONF_SYNC_TELEMETRY,
+    CONF_SYNC_VNSTAT,
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_DHCP_LEASES,
@@ -80,6 +82,7 @@ GRANULAR_SYNC_ITEMS = (
 )
 GRANULAR_SYNC_PREFIX = {
     CONF_SYNC_TELEMETRY: ["telemetry"],
+    CONF_SYNC_VNSTAT: ["vnstat"],
     CONF_SYNC_VPN: ["wireguard", "openvpn"],
     CONF_SYNC_FIRMWARE_UPDATES: ["firmware"],
     CONF_SYNC_CARP: ["carp"],

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_SYNC_SERVICES,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_UNBOUND,
+    CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     DEFAULT_SYNC_OPTION_VALUE,
     DOMAIN,
@@ -124,6 +125,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
 
         if config.get(CONF_SYNC_TELEMETRY, DEFAULT_SYNC_OPTION_VALUE):
             categories.append({"function": "get_telemetry", "state_key": "telemetry"})
+        if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
+            categories.append({"function": "get_vnstat", "state_key": "vnstat"})
         if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
             categories.extend(
                 [

--- a/custom_components/opnsense/pyopnsense/client.py
+++ b/custom_components/opnsense/pyopnsense/client.py
@@ -8,6 +8,7 @@ from .services import ServicesMixin
 from .system import SystemMixin
 from .telemetry import TelemetryMixin
 from .unbound import UnboundMixin
+from .vnstat import VnstatMixin
 from .vouchers import VouchersMixin
 from .vpn import VPNMixin
 
@@ -22,6 +23,7 @@ class OPNsenseClient(
     UnboundMixin,
     VouchersMixin,
     TelemetryMixin,
+    VnstatMixin,
     VPNMixin,
 ):
     """Async client for OPNsense REST and XMLRPC endpoints."""

--- a/custom_components/opnsense/pyopnsense/vnstat.py
+++ b/custom_components/opnsense/pyopnsense/vnstat.py
@@ -1,0 +1,554 @@
+"""vnStat collection and parsing methods for OPNsenseClient."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import date, datetime, timedelta, timezone, tzinfo
+import re
+from typing import Any
+
+from dateutil.parser import ParserError, UnknownTimezoneWarning, parse
+
+from ._typing import PyOPNsenseClientProtocol
+from .const import AMBIGUOUS_TZINFOS
+from .helpers import _LOGGER, _log_errors, try_to_float
+
+_VSTAT_HEADER_RE = re.compile(
+    r"^\s*(?P<interface>[^\s]+)\s*/\s*(?P<period>hourly|daily|monthly|yearly)\s*$",
+    re.IGNORECASE,
+)
+_VSTAT_ROW_RE = re.compile(
+    r"^\s*(?P<label>.+?)\s+"
+    r"(?P<rx_value>[\d.]+)\s+(?P<rx_unit>[KMGTP]?i?B)\s+\|\s+"
+    r"(?P<tx_value>[\d.]+)\s+(?P<tx_unit>[KMGTP]?i?B)\s+\|\s+"
+    r"(?P<total_value>[\d.]+)\s+(?P<total_unit>[KMGTP]?i?B)\s+\|\s+"
+    r"(?P<rate_value>[\d.]+)\s+(?P<rate_unit>[KMGTP]?bit/s)\s*$",
+    re.IGNORECASE,
+)
+_VSTAT_HOURLY_DAY_RE = re.compile(r"^\d{2}/\d{2}/\d{2}$")
+_VSTAT_HOURLY_TIME_RE = re.compile(r"^\d{2}:\d{2}$")
+_BYTE_FACTORS = {
+    "B": 1,
+    "KIB": 1024,
+    "MIB": 1024**2,
+    "GIB": 1024**3,
+    "TIB": 1024**4,
+    "PIB": 1024**5,
+    "KB": 1000,
+    "MB": 1000**2,
+    "GB": 1000**3,
+    "TB": 1000**4,
+    "PB": 1000**5,
+}
+_RATE_FACTORS = {
+    "BIT/S": 1,
+    "KBIT/S": 1000,
+    "MBIT/S": 1000**2,
+    "GBIT/S": 1000**3,
+    "TBIT/S": 1000**4,
+    "PBIT/S": 1000**5,
+}
+
+
+class VnstatMixin(PyOPNsenseClientProtocol):
+    """vnStat methods for OPNsenseClient."""
+
+    @_log_errors
+    async def get_vnstat(self) -> MutableMapping[str, Any]:
+        """Collect vnStat hourly, daily, and monthly usage data.
+
+        Returns
+        -------
+        MutableMapping[str, Any]
+            Parsed vnStat payload with per-interface rows and per-interface
+            summary metrics for Home Assistant sensors.
+
+        """
+        opnsense_tz = await self._get_opnsense_timezone()
+        hourly = self._parse_vnstat_payload(
+            await self._safe_dict_get("/api/vnstat/service/hourly"),
+            expected_period="hourly",
+        )
+        daily = self._parse_vnstat_payload(
+            await self._safe_dict_get("/api/vnstat/service/daily"),
+            expected_period="daily",
+        )
+        monthly = self._parse_vnstat_payload(
+            await self._safe_dict_get("/api/vnstat/service/monthly"),
+            expected_period="monthly",
+        )
+        interface_names = self._collect_vnstat_interfaces(hourly, daily, monthly)
+        interface_data: dict[str, Any] = {}
+
+        for interface in interface_names:
+            rows_hourly = self._interface_rows(hourly, interface)
+            rows_daily = self._interface_rows(daily, interface)
+            rows_monthly = self._interface_rows(monthly, interface)
+            selected_rows = {
+                "vnstat_today": self._pick_daily_row(
+                    rows_daily, days_ago=0, current_tz=opnsense_tz
+                ),
+                "vnstat_this_month": self._pick_monthly_row(
+                    rows_monthly, months_ago=0, current_tz=opnsense_tz
+                ),
+                "vnstat_yesterday_total": self._pick_daily_row(
+                    rows_daily, days_ago=1, current_tz=opnsense_tz
+                ),
+                "vnstat_last_month_total": self._pick_monthly_row(
+                    rows_monthly, months_ago=1, current_tz=opnsense_tz
+                ),
+                "vnstat_last_hour_total": self._pick_last_hour_row(
+                    rows_hourly, current_tz=opnsense_tz
+                ),
+            }
+            metrics: dict[str, dict[str, int | None]] = {}
+            for metric_name, metric_row in selected_rows.items():
+                metric_values = self._metric_values(metric_row)
+                metrics[metric_name] = {
+                    "total_bytes": metric_values["total_bytes"] if metric_values else None,
+                    "rx_bytes": metric_values["rx_bytes"] if metric_values else None,
+                    "tx_bytes": metric_values["tx_bytes"] if metric_values else None,
+                }
+
+            interface_data[interface] = {
+                "hourly": rows_hourly,
+                "daily": rows_daily,
+                "monthly": rows_monthly,
+                "metrics": metrics,
+            }
+        return {
+            "interfaces": interface_data,
+            "interface_count": len(interface_names),
+        }
+
+    async def _get_opnsense_timezone(self) -> tzinfo:
+        """Resolve timezone information from OPNsense system time endpoint.
+
+        Returns
+        -------
+        tzinfo
+            Parsed timezone from OPNsense ``system_time`` output, or a local
+            timezone-offset fallback when parsing fails.
+
+        """
+        path = (
+            "/api/diagnostics/system/system_time"
+            if self._use_snake_case
+            else "/api/diagnostics/system/systemTime"
+        )
+        time_info = await self._safe_dict_post(path)
+        datetime_str = time_info.get("datetime")
+        if isinstance(datetime_str, str):
+            try:
+                parsed_time = parse(datetime_str, tzinfos=AMBIGUOUS_TZINFOS)
+                if parsed_time.tzinfo is not None:
+                    return parsed_time.tzinfo
+            except (ValueError, TypeError, ParserError, UnknownTimezoneWarning) as err:
+                _LOGGER.debug(
+                    "Failed to parse OPNsense timezone from datetime '%s': %s: %s",
+                    datetime_str,
+                    type(err).__name__,
+                    err,
+                )
+        return timezone(datetime.now().astimezone().utcoffset() or timedelta())
+
+    def _parse_vnstat_payload(
+        self, payload: MutableMapping[str, Any], expected_period: str
+    ) -> dict[str, Any]:
+        """Parse a vnStat endpoint payload into normalized rows.
+
+        Parameters
+        ----------
+        payload : MutableMapping[str, Any]
+            Raw API response payload expected to contain a ``response`` string.
+        expected_period : str
+            Period requested from the endpoint (hourly, daily, monthly).
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary containing parsed period and per-interface row data.
+
+        """
+        response_text = payload.get("response", "")
+        if not isinstance(response_text, str):
+            return {"period": expected_period, "interfaces": {}}
+
+        parsed_period = expected_period
+        current_interface: str | None = None
+        current_hourly_day: str | None = None
+        interfaces: dict[str, list[dict[str, Any]]] = {}
+        for line in response_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            header_match = _VSTAT_HEADER_RE.match(stripped)
+            if header_match:
+                current_interface = header_match.group("interface")
+                parsed_period = header_match.group("period").lower()
+                interfaces.setdefault(current_interface, [])
+                current_hourly_day = None
+                continue
+            if (
+                expected_period == "hourly"
+                and current_interface
+                and _VSTAT_HOURLY_DAY_RE.match(stripped)
+            ):
+                current_hourly_day = stripped
+                continue
+            if current_interface is None:
+                continue
+            row = self._parse_vnstat_row(stripped)
+            if row is not None:
+                if expected_period == "hourly":
+                    row_label = row.get("label")
+                    if (
+                        isinstance(row_label, str)
+                        and _VSTAT_HOURLY_TIME_RE.match(row_label)
+                        and current_hourly_day
+                    ):
+                        row["hour"] = row_label
+                        row["day"] = current_hourly_day
+                        row["label"] = f"{current_hourly_day} {row_label}"
+                interfaces[current_interface].append(row)
+
+        if parsed_period != expected_period:
+            _LOGGER.debug(
+                "vnStat period mismatch. expected=%s parsed=%s",
+                expected_period,
+                parsed_period,
+            )
+
+        return {
+            "period": parsed_period,
+            "interfaces": interfaces,
+        }
+
+    def _parse_vnstat_row(self, line: str) -> dict[str, Any] | None:
+        """Parse a single vnStat data row from fixed-width text output.
+
+        Parameters
+        ----------
+        line : str
+            Raw line from vnStat table output.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Normalized row dictionary when parsing succeeds; otherwise ``None``.
+
+        """
+        lowered = line.lower()
+        if lowered.startswith(("-", "estimated")):
+            return None
+
+        match = _VSTAT_ROW_RE.match(line)
+        if not match:
+            return None
+
+        rx_bytes = self._to_bytes(match.group("rx_value"), match.group("rx_unit"))
+        tx_bytes = self._to_bytes(match.group("tx_value"), match.group("tx_unit"))
+        total_bytes = self._to_bytes(match.group("total_value"), match.group("total_unit"))
+        avg_rate = self._to_bits_per_second(match.group("rate_value"), match.group("rate_unit"))
+
+        if rx_bytes is None or tx_bytes is None or total_bytes is None or avg_rate is None:
+            return None
+
+        return {
+            "label": match.group("label").strip(),
+            "rx_bytes": rx_bytes,
+            "tx_bytes": tx_bytes,
+            "total_bytes": total_bytes,
+            "avg_rate_bits_per_second": avg_rate,
+        }
+
+    def _to_bytes(self, value: str, unit: str) -> int | None:
+        """Convert vnStat byte strings into integer bytes.
+
+        Parameters
+        ----------
+        value : str
+            Numeric string representing byte quantity.
+        unit : str
+            Unit string such as ``GiB`` or ``MiB``.
+
+        Returns
+        -------
+        int | None
+            Byte count as integer when conversion succeeds; otherwise ``None``.
+
+        """
+        parsed_value = try_to_float(value)
+        factor = _BYTE_FACTORS.get(unit.upper())
+        if parsed_value is None or factor is None:
+            return None
+        return int(round(parsed_value * factor))
+
+    def _to_bits_per_second(self, value: str, unit: str) -> int | None:
+        """Convert vnStat rate strings into integer bits-per-second.
+
+        Parameters
+        ----------
+        value : str
+            Numeric rate value string.
+        unit : str
+            Rate unit string such as ``Mbit/s``.
+
+        Returns
+        -------
+        int | None
+            Rate in bits-per-second as integer when conversion succeeds;
+            otherwise ``None``.
+
+        """
+        parsed_value = try_to_float(value)
+        factor = _RATE_FACTORS.get(unit.upper())
+        if parsed_value is None or factor is None:
+            return None
+        return int(round(parsed_value * factor))
+
+    def _pick_daily_row(
+        self, rows: Sequence[dict[str, Any]], days_ago: int, current_tz: tzinfo
+    ) -> dict[str, Any] | None:
+        """Select a daily row by matching day label or falling back by position.
+
+        Parameters
+        ----------
+        rows : Sequence[dict[str, Any]]
+            Parsed daily rows.
+        days_ago : int
+            Offset from today where ``0`` is today and ``1`` is yesterday.
+        current_tz : tzinfo
+            Timezone used for determining the current day.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Selected daily row, or ``None`` when unavailable.
+
+        """
+        target_day = datetime.now(tz=current_tz).date() - timedelta(days=days_ago)
+        for row in rows:
+            parsed_day = self._parse_daily_label(row.get("label"))
+            if parsed_day == target_day:
+                return row
+        if days_ago == 0 and rows:
+            return rows[-1]
+        if days_ago == 1 and len(rows) >= 2:
+            return rows[-2]
+        return None
+
+    def _pick_monthly_row(
+        self, rows: Sequence[dict[str, Any]], months_ago: int, current_tz: tzinfo
+    ) -> dict[str, Any] | None:
+        """Select a monthly row by matching month label or fallback position.
+
+        Parameters
+        ----------
+        rows : Sequence[dict[str, Any]]
+            Parsed monthly rows.
+        months_ago : int
+            Offset from current month where ``0`` is this month and ``1`` is
+            last month.
+        current_tz : tzinfo
+            Timezone used for determining the current month.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Selected monthly row, or ``None`` when unavailable.
+
+        """
+        now = datetime.now(tz=current_tz).date()
+        target_year = now.year
+        target_month = now.month - months_ago
+        while target_month <= 0:
+            target_month += 12
+            target_year -= 1
+
+        for row in rows:
+            parsed_month = self._parse_month_label(row.get("label"))
+            if parsed_month == (target_year, target_month):
+                return row
+        if months_ago == 0 and rows:
+            return rows[-1]
+        if months_ago == 1 and len(rows) >= 2:
+            return rows[-2]
+        return None
+
+    def _pick_last_hour_row(
+        self, rows: Sequence[dict[str, Any]], current_tz: tzinfo
+    ) -> dict[str, Any] | None:
+        """Select the last complete hour row from parsed hourly rows.
+
+        Parameters
+        ----------
+        rows : Sequence[dict[str, Any]]
+            Parsed hourly rows.
+        current_tz : tzinfo
+            Timezone used for determining the current and previous hour.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Row for the previous hour, or a fallback row when labels cannot be
+            matched.
+
+        """
+        now = datetime.now(tz=current_tz)
+        current_hour = now.replace(minute=0, second=0, microsecond=0)
+        target_hour = current_hour - timedelta(hours=1)
+        for row in rows:
+            parsed_hour = self._parse_hourly_label(row.get("label"), current_tz)
+            if parsed_hour == target_hour:
+                return row
+        if rows:
+            latest_row_hour = self._parse_hourly_label(rows[-1].get("label"), current_tz)
+            if latest_row_hour == current_hour and len(rows) >= 2:
+                return rows[-2]
+            return rows[-1]
+        return None
+
+    def _metric_values(self, row: Mapping[str, Any] | None) -> dict[str, int] | None:
+        """Extract metric values from a parsed row.
+
+        Parameters
+        ----------
+        row : Mapping[str, Any] | None
+            Parsed vnStat row payload.
+
+        Returns
+        -------
+        dict[str, int] | None
+            ``total_bytes``, ``rx_bytes``, and ``tx_bytes`` when available.
+
+        """
+        if not isinstance(row, Mapping):
+            return None
+        total = row.get("total_bytes")
+        rx = row.get("rx_bytes")
+        tx = row.get("tx_bytes")
+        if isinstance(total, int) and isinstance(rx, int) and isinstance(tx, int):
+            return {"total_bytes": total, "rx_bytes": rx, "tx_bytes": tx}
+        return None
+
+    def _collect_vnstat_interfaces(
+        self, *payloads: Mapping[str, Any] | MutableMapping[str, Any]
+    ) -> list[str]:
+        """Collect interface names present across parsed vnStat payloads.
+
+        Parameters
+        ----------
+        payloads : Mapping[str, Any] | MutableMapping[str, Any]
+            Parsed payloads from hourly, daily, and monthly endpoints.
+
+        Returns
+        -------
+        list[str]
+            Sorted list of interface names found in payloads.
+
+        """
+        interfaces: set[str] = set()
+        for payload in payloads:
+            by_interface = payload.get("interfaces", {})
+            if not isinstance(by_interface, Mapping):
+                continue
+            for interface in by_interface:
+                if isinstance(interface, str):
+                    interfaces.add(interface)
+        return sorted(interfaces)
+
+    def _interface_rows(self, payload: Mapping[str, Any], interface: str) -> list[dict[str, Any]]:
+        """Return parsed rows for a specific interface from a payload.
+
+        Parameters
+        ----------
+        payload : Mapping[str, Any]
+            Parsed endpoint payload.
+        interface : str
+            Interface name to retrieve.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            Parsed rows for the interface, or an empty list.
+
+        """
+        by_interface = payload.get("interfaces", {})
+        if not isinstance(by_interface, Mapping):
+            return []
+        rows = by_interface.get(interface)
+        return rows if isinstance(rows, list) else []
+
+    def _parse_daily_label(self, label: Any) -> date | None:
+        """Parse daily row labels into ``date`` values.
+
+        Parameters
+        ----------
+        label : Any
+            Raw daily label string.
+
+        Returns
+        -------
+        date | None
+            Parsed date value or ``None`` when parsing fails.
+
+        """
+        if not isinstance(label, str):
+            return None
+        for fmt in ("%m/%d/%y", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(label, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+    def _parse_month_label(self, label: Any) -> tuple[int, int] | None:
+        """Parse monthly row labels into year/month tuples.
+
+        Parameters
+        ----------
+        label : Any
+            Raw monthly label string.
+
+        Returns
+        -------
+        tuple[int, int] | None
+            ``(year, month)`` tuple or ``None`` when parsing fails.
+
+        """
+        if not isinstance(label, str):
+            return None
+        for fmt in ("%Y-%m", "%b '%y", "%B '%y"):
+            try:
+                parsed = datetime.strptime(label, fmt)
+            except ValueError:
+                continue
+            else:
+                return parsed.year, parsed.month
+        return None
+
+    def _parse_hourly_label(self, label: Any, current_tz: tzinfo) -> datetime | None:
+        """Parse hourly row labels into minute-precision datetimes.
+
+        Parameters
+        ----------
+        label : Any
+            Raw hourly label string.
+        current_tz : tzinfo
+            Timezone assigned to parsed hourly values.
+
+        Returns
+        -------
+        datetime | None
+            Parsed local datetime value or ``None`` when parsing fails.
+
+        """
+        if not isinstance(label, str):
+            return None
+        for fmt in ("%m/%d/%y %H:%M", "%Y-%m-%d %H:%M"):
+            try:
+                return datetime.strptime(label, fmt).replace(tzinfo=current_tz)
+            except ValueError:
+                continue
+        return None

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1,6 +1,7 @@
 """Provides sensors to track various status aspects of OPNsense."""
 
 from collections.abc import Mapping, MutableMapping
+import inspect
 import logging
 import re
 from typing import Any
@@ -31,12 +32,14 @@ from .const import (
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_TELEMETRY,
+    CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     COORDINATOR,
     COUNT,
     DATA_PACKETS,
     DATA_RATE_PACKETS_PER_SECOND,
     DEFAULT_SYNC_OPTION_VALUE,
+    OPNSENSE_CLIENT,
     STATIC_CERTIFICATE_SENSORS,
     STATIC_TELEMETRY_SENSORS,
 )
@@ -45,6 +48,112 @@ from .entity import OPNsenseEntity
 from .helpers import dict_get
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def _build_interface_device_description_map(
+    interfaces: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    """Build lookup map from interface device/identifier names to friendly descriptions.
+
+    Parameters
+    ----------
+    interfaces : Mapping[str, Any] | None
+        Interface payload in ``get_interfaces`` shape.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of possible interface identifiers (device, logical name, key) to
+        user-facing description names.
+
+    """
+    if not isinstance(interfaces, Mapping):
+        return {}
+
+    descriptions: dict[str, str] = {}
+    for interface_key, interface_data in interfaces.items():
+        if not isinstance(interface_data, Mapping):
+            continue
+
+        friendly_name = interface_data.get("name")
+        if not isinstance(friendly_name, str) or not friendly_name.strip():
+            continue
+        friendly_name = friendly_name.strip()
+
+        for candidate in (
+            interface_data.get("device"),
+            interface_data.get("interface"),
+            interface_key,
+        ):
+            if isinstance(candidate, str) and candidate.strip():
+                descriptions[candidate.strip()] = friendly_name
+
+    return descriptions
+
+
+async def _resolve_vnstat_interface_descriptions(
+    config_entry: ConfigEntry,
+    state: MutableMapping[str, Any],
+) -> dict[str, str]:
+    """Resolve vnStat interface display names from existing state with client fallback.
+
+    Parameters
+    ----------
+    config_entry : ConfigEntry
+        Config entry containing runtime client reference.
+    state : MutableMapping[str, Any]
+        Coordinator state payload.
+
+    Returns
+    -------
+    dict[str, str]
+        Interface identifier to description mapping used for sensor naming.
+
+    """
+    descriptions = _build_interface_device_description_map(dict_get(state, "interfaces", {}) or {})
+    if descriptions:
+        return descriptions
+
+    client = getattr(config_entry.runtime_data, OPNSENSE_CLIENT, None)
+    if client is None:
+        return descriptions
+
+    get_interfaces = getattr(client, "get_interfaces", None)
+    if not callable(get_interfaces):
+        return descriptions
+
+    maybe_interfaces = get_interfaces()
+    if not inspect.isawaitable(maybe_interfaces):
+        return descriptions
+
+    interfaces = await maybe_interfaces
+    if isinstance(interfaces, Mapping):
+        descriptions = _build_interface_device_description_map(interfaces)
+    return descriptions
+
+
+def _vnstat_metric_display_name(metric_name: str) -> str:
+    """Return display label for vnStat metric names.
+
+    Parameters
+    ----------
+    metric_name : str
+        Internal vnStat metric key.
+
+    Returns
+    -------
+    str
+        Human-readable metric label for the entity name.
+
+    """
+    metric_names: dict[str, str] = {
+        "vnstat_today": "Today",
+        "vnstat_this_month": "This Month",
+        "vnstat_yesterday_total": "Yesterday Total",
+        "vnstat_last_month_total": "Last Month Total",
+        "vnstat_last_hour_total": "Last Hour Total",
+    }
+    return metric_names.get(metric_name, metric_name)
 
 
 async def _compile_static_telemetry_sensors(
@@ -74,6 +183,67 @@ async def _compile_static_certificate_sensors(
             entity_description=static_sensor,
         )
         entities.append(entity)
+    return entities
+
+
+async def _compile_vnstat_sensors(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+) -> list:
+    """Compile per-interface vnStat sensors."""
+    if not isinstance(state, MutableMapping):
+        return []
+    vnstat_interfaces = dict_get(state, "vnstat.interfaces", {}) or {}
+    if not isinstance(vnstat_interfaces, MutableMapping):
+        return []
+    interface_descriptions = await _resolve_vnstat_interface_descriptions(config_entry, state)
+
+    metric_defs: dict[str, dict[str, Any]] = {
+        "vnstat_today": {
+            "state_class": SensorStateClass.TOTAL_INCREASING,
+            "icon": "mdi:calendar-today",
+        },
+        "vnstat_this_month": {
+            "state_class": SensorStateClass.TOTAL_INCREASING,
+            "icon": "mdi:calendar-month",
+        },
+        "vnstat_yesterday_total": {
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:calendar-arrow-left",
+        },
+        "vnstat_last_month_total": {
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:calendar-text",
+        },
+        "vnstat_last_hour_total": {
+            "state_class": SensorStateClass.MEASUREMENT,
+            "icon": "mdi:clock-time-four-outline",
+        },
+    }
+
+    entities: list = []
+    for interface_name in vnstat_interfaces:
+        if not isinstance(interface_name, str):
+            continue
+        interface_display_name = interface_descriptions.get(interface_name, interface_name)
+        for metric_name, metric_def in metric_defs.items():
+            entity = OPNsenseVnstatSensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=SensorEntityDescription(
+                    key=f"vnstat.{interface_name}.{metric_name}",
+                    name=f"vnStat: {interface_display_name}: {_vnstat_metric_display_name(metric_name)}",
+                    native_unit_of_measurement=UnitOfInformation.BYTES,
+                    device_class=SensorDeviceClass.DATA_SIZE,
+                    icon=metric_def["icon"],
+                    state_class=metric_def["state_class"],
+                    suggested_display_precision=1,
+                    suggested_unit_of_measurement=UnitOfInformation.GIBIBYTES,
+                    entity_registry_enabled_default=False,
+                ),
+            )
+            entities.append(entity)
     return entities
 
 
@@ -463,6 +633,8 @@ async def async_setup_entry(
         entities.extend(await _compile_static_telemetry_sensors(config_entry, coordinator))
         entities.extend(await _compile_filesystem_sensors(config_entry, coordinator, state))
         entities.extend(await _compile_temperature_sensors(config_entry, coordinator, state))
+    if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
+        entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_CERTIFICATES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_certificate_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
@@ -576,6 +748,50 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
             certs = self._get_opnsense_state_value(self.entity_description.key)
             if isinstance(certs, MutableMapping):
                 self._attr_extra_state_attributes = dict(certs)
+
+        self.async_write_ha_state()
+
+
+class OPNsenseVnstatSensor(OPNsenseSensor):
+    """Class for OPNsense vnStat sensors."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        key_parts = self.entity_description.key.split(".")
+        if len(key_parts) != 3:
+            self._available = False
+            self.async_write_ha_state()
+            return
+        _, interface_name, metric_name = key_parts
+
+        metric = dict_get(state, f"vnstat.interfaces.{interface_name}.metrics.{metric_name}", {})
+        if not isinstance(metric, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        total = metric.get("total_bytes")
+        if not isinstance(total, int):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._available = True
+        self._attr_native_value = total
+
+        self._attr_extra_state_attributes = {"interface": interface_name}
+        rx_bytes = metric.get("rx_bytes")
+        tx_bytes = metric.get("tx_bytes")
+        if isinstance(rx_bytes, int):
+            self._attr_extra_state_attributes["rx_bytes"] = rx_bytes
+        if isinstance(tx_bytes, int):
+            self._attr_extra_state_attributes["tx_bytes"] = tx_bytes
 
         self.async_write_ha_state()
 

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -34,6 +34,7 @@
       "granular_sync": {
         "data": {
           "sync_telemetry": "Basic telemetry data",
+          "sync_vnstat": "vnStat bandwidth usage",
           "sync_vpn": "VPN information and switches",
           "sync_firmware_updates": "Firmware updates",
           "sync_carp": "CARP information",
@@ -78,6 +79,7 @@
       "granular_sync": {
         "data": {
           "sync_telemetry": "Basic telemetry data",
+          "sync_vnstat": "vnStat bandwidth usage",
           "sync_vpn": "VPN information and switches",
           "sync_firmware_updates": "Firmware updates",
           "sync_carp": "CARP information",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,6 +587,9 @@ def fake_client():
             async def get_interfaces(self):
                 return {"eth0": {"inbytes": 200, "outbytes": 100}}
 
+            async def get_vnstat(self):
+                return {"interface_count": 0, "interfaces": {}}
+
             async def get_openvpn(self):
                 return {"servers": {}}
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -27,6 +27,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_SERVICES,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_UNBOUND,
+    CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
@@ -397,6 +398,7 @@ def test_build_categories_returns_empty_when_no_config(make_config_entry, fake_c
     "flag,expected_keys",
     [
         (CONF_SYNC_TELEMETRY, ["telemetry"]),
+        (CONF_SYNC_VNSTAT, ["vnstat"]),
         (CONF_SYNC_VPN, ["openvpn", "wireguard"]),
         (CONF_SYNC_FIRMWARE_UPDATES, ["firmware_update_info"]),
         (CONF_SYNC_CARP, ["carp_interfaces", "carp_status"]),

--- a/tests/test_pyopnsense.py
+++ b/tests/test_pyopnsense.py
@@ -9,7 +9,7 @@ import asyncio
 from collections.abc import MutableMapping
 import contextlib
 import copy
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import inspect as _inspect
 import socket
 from ssl import SSLError
@@ -586,6 +586,257 @@ async def test_telemetry_and_temps_and_notices_and_unbound_blocklist(make_client
         # unbound blocklist _set when empty
         client.get_unbound_blocklist_legacy = AsyncMock(return_value={})
         assert await client._set_unbound_blocklist_legacy(True) is False
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_parse_vnstat_payload_hourly_with_split_day_rows(make_client) -> None:
+    """Hourly vnStat payloads should combine date rows with time rows."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        payload = {
+            "response": """
+ igc0 / hourly
+
+         hour        rx      |     tx      |    total    |   avg. rate
+     03/07/26
+         18:00      1.00 GiB |  512.00 MiB |    1.50 GiB |    2.00 Mbit/s
+         19:00      2.00 GiB |  256.00 MiB |    2.25 GiB |    3.00 Mbit/s
+"""
+        }
+        parsed = client._parse_vnstat_payload(payload, expected_period="hourly")
+        rows = parsed["interfaces"]["igc0"]
+        assert len(rows) == 2
+        assert rows[0]["label"] == "03/07/26 18:00"
+        assert rows[0]["day"] == "03/07/26"
+        assert rows[0]["hour"] == "18:00"
+        assert rows[1]["label"] == "03/07/26 19:00"
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_parse_vnstat_month_label_apostrophe_format(make_client) -> None:
+    """Monthly vnStat labels like ``Apr '25`` should parse as year/month."""
+    client = make_client(session=MagicMock(spec=aiohttp.ClientSession))
+    try:
+        assert client._parse_month_label("Apr '25") == (2025, 4)
+        assert client._parse_month_label("March '26") == (2026, 3)
+        assert client._parse_month_label("2026-03") == (2026, 3)
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_vnstat_summary_from_hourly_daily_monthly(make_client) -> None:
+    """get_vnstat should produce per-interface summary fields used by sensors."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        # Keep payload dates aligned with mocked OPNsense system time to avoid
+        # day-boundary/timezone flakiness in CI.
+        now = datetime(2000, 1, 15, 12, 0, 0)
+        prev_hour = now - timedelta(hours=1)
+        this_month = now.date().replace(day=1)
+        prev_month = this_month - timedelta(days=1)
+        rollover_date_header = (
+            f"     {now.strftime('%m/%d/%y')}\n" if now.date() != prev_hour.date() else ""
+        )
+
+        hourly_payload = {
+            "response": f"""
+ igc0 / hourly
+
+         hour        rx      |     tx      |    total    |   avg. rate
+     {prev_hour.strftime("%m/%d/%y")}
+         {prev_hour.strftime("%H:%M")}      1.00 GiB |    1.00 GiB |    2.00 GiB |    4.00 Mbit/s
+{rollover_date_header}         {now.strftime("%H:%M")}      2.00 GiB |    1.00 GiB |    3.00 GiB |    6.00 Mbit/s
+ igc1 / hourly
+
+         hour        rx      |     tx      |    total    |   avg. rate
+     {prev_hour.strftime("%m/%d/%y")}
+         {prev_hour.strftime("%H:%M")}      512.00 MiB |  512.00 MiB |    1.00 GiB |    2.00 Mbit/s
+{rollover_date_header}         {now.strftime("%H:%M")}      1.00 GiB |  512.00 MiB |    1.50 GiB |    3.00 Mbit/s
+"""
+        }
+        daily_payload = {
+            "response": f"""
+ igc0 / daily
+
+          day        rx      |     tx      |    total    |   avg. rate
+      {(now.date() - timedelta(days=1)).strftime("%m/%d/%y")}      1.00 GiB |    1.00 GiB |    2.00 GiB |    1.00 Mbit/s
+      {now.strftime("%m/%d/%y")}      2.00 GiB |    2.00 GiB |    4.00 GiB |    2.00 Mbit/s
+ igc1 / daily
+
+          day        rx      |     tx      |    total    |   avg. rate
+      {(now.date() - timedelta(days=1)).strftime("%m/%d/%y")}    512.00 MiB |  512.00 MiB |    1.00 GiB |    0.50 Mbit/s
+      {now.strftime("%m/%d/%y")}      1.00 GiB |  512.00 MiB |    1.50 GiB |    0.75 Mbit/s
+"""
+        }
+        monthly_payload = {
+            "response": f"""
+ igc0 / monthly
+
+        month        rx      |     tx      |    total    |   avg. rate
+       {prev_month.strftime("%b '%y")}      3.00 GiB |    3.00 GiB |    6.00 GiB |    1.00 Mbit/s
+       {this_month.strftime("%b '%y")}      4.00 GiB |    4.00 GiB |    8.00 GiB |    2.00 Mbit/s
+ igc1 / monthly
+
+        month        rx      |     tx      |    total    |   avg. rate
+       {prev_month.strftime("%b '%y")}      1.00 GiB |    1.00 GiB |    2.00 GiB |    1.00 Mbit/s
+       {this_month.strftime("%b '%y")}      1.50 GiB |    1.50 GiB |    3.00 GiB |    2.00 Mbit/s
+"""
+        }
+
+        client._safe_dict_get = AsyncMock(
+            side_effect=[hourly_payload, daily_payload, monthly_payload]
+        )
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "2000-01-15 12:00:00 EST"})
+        vnstat = await client.get_vnstat()
+
+        gib = 1024**3
+        assert vnstat["interface_count"] == 2
+        igc0_metrics = vnstat["interfaces"]["igc0"]["metrics"]
+        assert igc0_metrics["vnstat_today"]["total_bytes"] == 4 * gib
+        assert igc0_metrics["vnstat_today"]["rx_bytes"] == 2 * gib
+        assert igc0_metrics["vnstat_today"]["tx_bytes"] == 2 * gib
+        assert igc0_metrics["vnstat_this_month"]["total_bytes"] == 8 * gib
+        assert igc0_metrics["vnstat_yesterday_total"]["total_bytes"] == 2 * gib
+        assert igc0_metrics["vnstat_last_month_total"]["total_bytes"] == 6 * gib
+        assert igc0_metrics["vnstat_last_hour_total"]["total_bytes"] == 3 * gib
+
+        igc1_metrics = vnstat["interfaces"]["igc1"]["metrics"]
+        assert igc1_metrics["vnstat_today"]["total_bytes"] == int(1.5 * gib)
+        assert igc1_metrics["vnstat_today"]["rx_bytes"] == 1 * gib
+        assert igc1_metrics["vnstat_today"]["tx_bytes"] == int(0.5 * gib)
+        assert igc1_metrics["vnstat_this_month"]["total_bytes"] == 3 * gib
+        assert igc1_metrics["vnstat_yesterday_total"]["total_bytes"] == 1 * gib
+        assert igc1_metrics["vnstat_last_month_total"]["total_bytes"] == 2 * gib
+        assert igc1_metrics["vnstat_last_hour_total"]["total_bytes"] == int(1.5 * gib)
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_vnstat_uses_systemtime_endpoint_path(make_client) -> None:
+    """get_vnstat should query snake_case and camelCase system-time endpoints correctly."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._safe_dict_get = AsyncMock(return_value={"response": ""})
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "invalid"})
+
+        client._use_snake_case = True
+        await client.get_vnstat()
+        client._safe_dict_post.assert_awaited_with("/api/diagnostics/system/system_time")
+
+        client._safe_dict_post.reset_mock()
+        client._use_snake_case = False
+        await client.get_vnstat()
+        client._safe_dict_post.assert_awaited_with("/api/diagnostics/system/systemTime")
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_opnsense_timezone_parse_and_fallback(make_client) -> None:
+    """_get_opnsense_timezone should parse valid timezone strings and fallback on errors."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._use_snake_case = True
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "2026-03-07 12:00:00 EST"})
+        parsed_tz = await client._get_opnsense_timezone()
+        assert parsed_tz is not None
+
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "not-a-datetime"})
+        fallback_tz = await client._get_opnsense_timezone()
+        assert fallback_tz is not None
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_parse_vnstat_payload_and_helpers_edge_cases(make_client) -> None:
+    """VnStat payload/helper methods should handle malformed and fallback scenarios."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        parsed_empty = client._parse_vnstat_payload({"response": 123}, expected_period="hourly")
+        assert parsed_empty["interfaces"] == {}
+
+        parsed_mismatch = client._parse_vnstat_payload(
+            {"response": "igc0 / daily\n03/07/26    1.00 GiB | 1.00 GiB | 2.00 GiB | 1.00 Mbit/s"},
+            expected_period="hourly",
+        )
+        assert parsed_mismatch["period"] == "daily"
+
+        assert client._parse_vnstat_row("estimated      2.41 TiB | 676.07 GiB | 3.07 TiB |") is None
+        assert client._parse_vnstat_row("nonsense row") is None
+        assert client._to_bytes("3.14", "BAD") is None
+        assert client._to_bits_per_second("3.14", "BAD") is None
+
+        assert client._collect_vnstat_interfaces(
+            {"interfaces": {"igc0": []}}, {"interfaces": {1: []}}
+        ) == ["igc0"]
+        assert client._interface_rows({"interfaces": {"igc0": [{"label": "x"}]}}, "igc0") == [
+            {"label": "x"}
+        ]
+        assert client._interface_rows({"interfaces": []}, "igc0") == []
+
+        tz = UTC
+        today = datetime.now(tz=tz).date()
+        yesterday = today - timedelta(days=1)
+        assert (
+            client._pick_daily_row(
+                [
+                    {"label": yesterday.strftime("%m/%d/%y")},
+                    {"label": today.strftime("%m/%d/%y")},
+                ],
+                0,
+                tz,
+            )
+            is not None
+        )
+        assert client._pick_daily_row([{"label": "bad"}], 0, tz) == {"label": "bad"}
+        assert client._pick_daily_row([{"label": "bad0"}, {"label": "bad1"}], 1, tz) == {
+            "label": "bad0"
+        }
+
+        this_month = datetime.now(tz=tz).strftime("%b '%y")
+        assert client._pick_monthly_row([{"label": this_month}], 0, tz) == {"label": this_month}
+        assert client._pick_monthly_row([{"label": "bad0"}, {"label": "bad1"}], 1, tz) == {
+            "label": "bad0"
+        }
+
+        now_hour = datetime.now(tz=tz).replace(minute=0, second=0, microsecond=0)
+        prev_hour = now_hour - timedelta(hours=1)
+        rows = [
+            {"label": prev_hour.strftime("%m/%d/%y %H:%M"), "total_bytes": 1},
+            {"label": now_hour.strftime("%m/%d/%y %H:%M"), "total_bytes": 2},
+        ]
+        selected = client._pick_last_hour_row(rows, tz)
+        assert selected == rows[0]
+        assert client._parse_hourly_label(now_hour.strftime("%m/%d/%y %H:%M"), tz) is not None
+        assert client._parse_hourly_label("bad", tz) is None
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_vnstat_metric_values_none_and_valid(make_client) -> None:
+    """_metric_values should return valid mapping only when all fields are ints."""
+    client = make_client(session=MagicMock(spec=aiohttp.ClientSession))
+    try:
+        assert client._metric_values(None) is None
+        assert client._metric_values({"total_bytes": 1, "rx_bytes": 2, "tx_bytes": 3}) == {
+            "total_bytes": 1,
+            "rx_bytes": 2,
+            "tx_bytes": 3,
+        }
+        assert client._metric_values({"total_bytes": 1, "rx_bytes": None, "tx_bytes": 3}) is None
     finally:
         await client.async_close()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,6 +14,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_TELEMETRY,
+    CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     COORDINATOR,
 )
@@ -25,11 +26,13 @@ from custom_components.opnsense.sensor import (
     OPNsenseInterfaceSensor,
     OPNsenseStaticKeySensor,
     OPNsenseTempSensor,
+    OPNsenseVnstatSensor,
     OPNsenseVPNSensor,
     async_setup_entry,
     normalize_filesystem_mountpoint,
     slugify_filesystem_mountpoint,
 )
+from homeassistant.components.sensor import SensorStateClass
 
 
 @pytest.mark.asyncio
@@ -1016,6 +1019,7 @@ def _setup_entry_with_all_syncs(state: dict, make_config_entry):
     base.update(
         {
             CONF_SYNC_TELEMETRY: True,
+            CONF_SYNC_VNSTAT: True,
             CONF_SYNC_CERTIFICATES: True,
             CONF_SYNC_VPN: True,
             CONF_SYNC_GATEWAYS: True,
@@ -1173,6 +1177,105 @@ async def test_async_setup_entry_creates_entities(make_config_entry):
     # Ensure setup produced at least one created entity
     assert created, "no entities created"
     assert any(isinstance(e, OPNsenseStaticKeySensor) for e in created)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_vnstat_sensors(make_config_entry):
+    """VnStat sensors should be created with expected state classes and values."""
+    state = {
+        "telemetry": {"filesystems": [], "temps": {}},
+        "interfaces": {
+            "wan": {
+                "name": "WAN",
+                "device": "igc0",
+                "interface": "wan",
+            }
+        },
+        "vnstat": {
+            "interfaces": {
+                "igc0": {
+                    "metrics": {
+                        "vnstat_today": {"total_bytes": 1000, "rx_bytes": 700, "tx_bytes": 300},
+                        "vnstat_this_month": {
+                            "total_bytes": 2000,
+                            "rx_bytes": 1200,
+                            "tx_bytes": 800,
+                        },
+                        "vnstat_yesterday_total": {
+                            "total_bytes": 900,
+                            "rx_bytes": 600,
+                            "tx_bytes": 300,
+                        },
+                        "vnstat_last_month_total": {
+                            "total_bytes": 1500,
+                            "rx_bytes": 800,
+                            "tx_bytes": 700,
+                        },
+                        "vnstat_last_hour_total": {
+                            "total_bytes": 50,
+                            "rx_bytes": 30,
+                            "tx_bytes": 20,
+                        },
+                    }
+                }
+            }
+        },
+    }
+    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
+
+    created: list = []
+
+    def add_entities(ents):
+        created.extend(ents)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+    key_to_entity = {
+        e.entity_description.key: e for e in created if isinstance(e, OPNsenseVnstatSensor)
+    }
+
+    assert key_to_entity["vnstat.igc0.vnstat_today"].entity_description.state_class is (
+        SensorStateClass.TOTAL_INCREASING
+    )
+    assert key_to_entity["vnstat.igc0.vnstat_this_month"].entity_description.state_class is (
+        SensorStateClass.TOTAL_INCREASING
+    )
+    assert key_to_entity["vnstat.igc0.vnstat_yesterday_total"].entity_description.state_class is (
+        SensorStateClass.MEASUREMENT
+    )
+    assert key_to_entity["vnstat.igc0.vnstat_last_month_total"].entity_description.state_class is (
+        SensorStateClass.MEASUREMENT
+    )
+    assert key_to_entity["vnstat.igc0.vnstat_last_hour_total"].entity_description.state_class is (
+        SensorStateClass.MEASUREMENT
+    )
+    assert key_to_entity["vnstat.igc0.vnstat_today"].entity_description.name == "vnStat: WAN: Today"
+    assert (
+        key_to_entity["vnstat.igc0.vnstat_last_month_total"].entity_description.name
+        == "vnStat: WAN: Last Month Total"
+    )
+
+    for key in (
+        "vnstat.igc0.vnstat_today",
+        "vnstat.igc0.vnstat_this_month",
+        "vnstat.igc0.vnstat_yesterday_total",
+        "vnstat.igc0.vnstat_last_month_total",
+        "vnstat.igc0.vnstat_last_hour_total",
+    ):
+        entity = key_to_entity[key]
+        entity.hass = MagicMock()
+        entity.entity_id = f"sensor.{entity.entity_description.key.replace('.', '_')}"
+        entity.async_write_ha_state = lambda: None
+        entity._handle_coordinator_update()
+        assert entity.available is True
+
+    today_entity = key_to_entity["vnstat.igc0.vnstat_today"]
+    assert today_entity.native_value == 1000
+    assert today_entity.extra_state_attributes.get("rx_bytes") == 700
+    assert today_entity.extra_state_attributes.get("tx_bytes") == 300
+    assert key_to_entity["vnstat.igc0.vnstat_this_month"].native_value == 2000
+    assert key_to_entity["vnstat.igc0.vnstat_yesterday_total"].native_value == 900
+    assert key_to_entity["vnstat.igc0.vnstat_last_month_total"].native_value == 1500
+    assert key_to_entity["vnstat.igc0.vnstat_last_hour_total"].native_value == 50
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request introduces support for vnStat bandwidth usage monitoring in the OPNsense integration. The main changes add configuration options, sensor entities, and translations for vnStat, as well as update the coordinator, client, and tests to handle the new functionality.

**vnStat integration support:**

* Added `CONF_SYNC_VNSTAT` constant, included it in granular sync items and prefixes, and updated translations to describe vnStat bandwidth usage. (`custom_components/opnsense/const.py`, `custom_components/opnsense/translations/en.json`) [[1]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R51) [[2]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R70) [[3]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R85) [[4]](diffhunk://#diff-7125894a1ae7fc56881bda2c6257bc20fb1448aedddf82f4121b86aef9521cf3R37) [[5]](diffhunk://#diff-7125894a1ae7fc56881bda2c6257bc20fb1448aedddf82f4121b86aef9521cf3R82)
* Updated coordinator to handle vnStat sync option, build vnStat categories, and added test coverage for category building. (`custom_components/opnsense/coordinator.py`, `tests/test_coordinator.py`) [[1]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cR28) [[2]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cR128-R129) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R30) [[4]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R401)

**Sensor and client enhancements:**

* Implemented `OPNsenseVnstatSensor` class and `_compile_vnstat_sensors` function to create per-interface vnStat sensors, and integrated them into sensor setup. (`custom_components/opnsense/sensor.py`) [[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R81-R139) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R526-R527) [[3]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R645-R688)
* Added `VnstatMixin` to the OPNsense client and updated imports. (`custom_components/opnsense/pyopnsense/client.py`) [[1]](diffhunk://#diff-0a1d503fb6f2802a4f35e5f29252bdb179a48ccd70b89865cf66edafaa325cdfR11) [[2]](diffhunk://#diff-0a1d503fb6f2802a4f35e5f29252bdb179a48ccd70b89865cf66edafaa325cdfR26)

**Test updates:**

* Mocked `get_vnstat` method in test fixtures for coverage and correctness. (`tests/conftest.py`)

**Miscellaneous:**

* Minor update to datetime import for UTC support. (`tests/test_pyopnsense.py`)

These changes collectively add granular vnStat bandwidth sync and sensor support, improve configuration and test coverage, and update documentation and translations for the new feature.

Resolves #368 