### PR TITLE
Standardize timezone function

### DIFF
--- a/custom_components/opnsense/pyopnsense/_typing.py
+++ b/custom_components/opnsense/pyopnsense/_typing.py
@@ -2,6 +2,7 @@
 
 from abc import abstractmethod
 from collections.abc import MutableMapping
+from datetime import tzinfo
 from typing import Any, Protocol
 
 
@@ -157,6 +158,23 @@ class PyOPNsenseClientProtocol(Protocol):
         -------
         list
             List payload.
+
+        """
+        ...
+
+    @abstractmethod
+    async def _get_opnsense_timezone(self, datetime_str: str | None = None) -> tzinfo:
+        """Resolve timezone information from OPNsense system time data.
+
+        Parameters
+        ----------
+        datetime_str : str | None
+            Optional datetime string from OPNsense ``system_time`` output.
+
+        Returns
+        -------
+        tzinfo
+            Parsed timezone when available, otherwise a local fixed-offset fallback.
 
         """
         ...

--- a/custom_components/opnsense/pyopnsense/dhcp.py
+++ b/custom_components/opnsense/pyopnsense/dhcp.py
@@ -1,7 +1,7 @@
 """DHCP and ARP methods for OPNsenseClient."""
 
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, tzinfo
 from typing import Any
 
 import awesomeversion
@@ -40,8 +40,13 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         return arp_table
 
     @_log_errors
-    async def get_dhcp_leases(self) -> dict[str, Any]:
+    async def get_dhcp_leases(self, opnsense_tz: tzinfo | None = None) -> dict[str, Any]:
         """Return list of DHCP leases.
+
+        Parameters
+        ----------
+        opnsense_tz : tzinfo | None
+            Optional pre-fetched timezone for this refresh cycle.
 
         Returns
         -------
@@ -50,11 +55,13 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
 
         """
+        if opnsense_tz is None:
+            opnsense_tz = await self._get_opnsense_timezone()
         leases_raw: list = (
-            await self._get_kea_dhcpv4_leases()
-            + await self._get_isc_dhcpv4_leases()
-            + await self._get_isc_dhcpv6_leases()
-            + await self._get_dnsmasq_leases()
+            await self._get_kea_dhcpv4_leases(opnsense_tz=opnsense_tz)
+            + await self._get_isc_dhcpv4_leases(opnsense_tz=opnsense_tz)
+            + await self._get_isc_dhcpv6_leases(opnsense_tz=opnsense_tz)
+            + await self._get_dnsmasq_leases(opnsense_tz=opnsense_tz)
         )
         # TODO: Add Kea dhcpv6 leases if API ever gets added
 
@@ -114,8 +121,14 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug(f"[get_kea_interfaces] lease_interfaces: {lease_interfaces}")
         return lease_interfaces
 
-    async def _get_kea_dhcpv4_leases(self) -> list:
+    async def _get_kea_dhcpv4_leases(self, opnsense_tz: tzinfo | None = None) -> list:
         """Return IPv4 DHCP Leases by Kea.
+
+        Parameters
+        ----------
+        opnsense_tz : tzinfo | None
+            Optional pre-fetched timezone for this refresh cycle. Kea lease timestamps
+            are parsed from epoch values and do not currently use this value.
 
         Returns
         -------
@@ -219,8 +232,14 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
         return list(seen.values())
 
-    async def _get_dnsmasq_leases(self) -> list:
+    async def _get_dnsmasq_leases(self, opnsense_tz: tzinfo | None = None) -> list:
         """Return Dnsmasq IPv4 and IPv6 DHCP Leases.
+
+        Parameters
+        ----------
+        opnsense_tz : tzinfo | None
+            Optional pre-fetched timezone for this refresh cycle. Dnsmasq lease timestamps
+            are parsed from epoch values and do not currently use this value.
 
         Returns
         -------
@@ -288,8 +307,13 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug("[get_dnsmasq_leases] leases: %s", leases)
         return leases
 
-    async def _get_isc_dhcpv4_leases(self) -> list:
+    async def _get_isc_dhcpv4_leases(self, opnsense_tz: tzinfo | None = None) -> list:
         """Return IPv4 DHCP Leases by ISC.
+
+        Parameters
+        ----------
+        opnsense_tz : tzinfo | None
+            Optional pre-fetched timezone for this refresh cycle.
 
         Returns
         -------
@@ -308,6 +332,8 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         leases_info: list = response.get("rows", [])
         if not isinstance(leases_info, list):
             return []
+        if opnsense_tz is None:
+            opnsense_tz = await self._get_opnsense_timezone()
         # _LOGGER.debug(f"[get_isc_dhcpv4_leases] leases_info: {leases_info}")
         leases: list = []
         for lease_info in leases_info:
@@ -337,9 +363,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                     )
                 except (TypeError, ValueError):
                     continue
-                lease["expires"] = dt.replace(
-                    tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
-                )
+                lease["expires"] = dt.replace(tzinfo=opnsense_tz)
                 if lease["expires"] < datetime.now().astimezone():
                     continue
             else:
@@ -348,8 +372,13 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         # _LOGGER.debug(f"[get_isc_dhcpv4_leases] leases: {leases}")
         return leases
 
-    async def _get_isc_dhcpv6_leases(self) -> list:
+    async def _get_isc_dhcpv6_leases(self, opnsense_tz: tzinfo | None = None) -> list:
         """Return IPv6 DHCP Leases by ISC.
+
+        Parameters
+        ----------
+        opnsense_tz : tzinfo | None
+            Optional pre-fetched timezone for this refresh cycle.
 
         Returns
         -------
@@ -368,6 +397,8 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         leases_info: list = response.get("rows", [])
         if not isinstance(leases_info, list):
             return []
+        if opnsense_tz is None:
+            opnsense_tz = await self._get_opnsense_timezone()
         # _LOGGER.debug(f"[get_isc_dhcpv6_leases] leases_info: {leases_info}")
         leases: list = []
         for lease_info in leases_info:
@@ -397,9 +428,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                     )
                 except (TypeError, ValueError):
                     continue
-                lease["expires"] = dt.replace(
-                    tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
-                )
+                lease["expires"] = dt.replace(tzinfo=opnsense_tz)
                 if lease["expires"] < datetime.now().astimezone():
                     continue
             else:

--- a/custom_components/opnsense/pyopnsense/firmware.py
+++ b/custom_components/opnsense/pyopnsense/firmware.py
@@ -1,7 +1,7 @@
 """Firmware and plugin-related methods for OPNsenseClient."""
 
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
 import awesomeversion
@@ -168,9 +168,8 @@ class FirmwareMixin(PyOPNsenseClientProtocol):
             try:
                 last_check_dt = parse(last_check_str, tzinfos=AMBIGUOUS_TZINFOS)
                 if last_check_dt.tzinfo is None:
-                    last_check_dt = last_check_dt.replace(
-                        tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
-                    )
+                    opnsense_tz = await self._get_opnsense_timezone()
+                    last_check_dt = last_check_dt.replace(tzinfo=opnsense_tz)
                 last_check_expired = (datetime.now().astimezone() - last_check_dt) > timedelta(
                     days=1
                 )

--- a/custom_components/opnsense/pyopnsense/system.py
+++ b/custom_components/opnsense/pyopnsense/system.py
@@ -1,14 +1,84 @@
 """System and configuration methods for OPNsenseClient."""
 
 from collections.abc import MutableMapping
+from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any
+import warnings
+
+import aiohttp
+from dateutil.parser import ParserError, UnknownTimezoneWarning, parse
 
 from ._typing import PyOPNsenseClientProtocol
+from .const import AMBIGUOUS_TZINFOS
 from .helpers import _LOGGER, _log_errors, timestamp_to_datetime, try_to_int
 
 
 class SystemMixin(PyOPNsenseClientProtocol):
     """System methods for OPNsenseClient."""
+
+    def _get_local_timezone(self) -> tzinfo:
+        """Return a local timezone fallback with fixed UTC offset.
+
+        Returns
+        -------
+        tzinfo
+            Local timezone fallback using the host UTC offset.
+
+        """
+        return timezone(datetime.now().astimezone().utcoffset() or timedelta())
+
+    async def _get_opnsense_timezone(self, datetime_str: str | None = None) -> tzinfo:
+        """Resolve timezone information from OPNsense system time data.
+
+        Parameters
+        ----------
+        datetime_str : str | None
+            Optional datetime string from the system-time endpoint. When omitted,
+            the method queries OPNsense for current system-time data.
+
+        Returns
+        -------
+        tzinfo
+            Parsed timezone from OPNsense datetime output, or a local fixed-offset
+            fallback when parsing fails.
+
+        """
+        if datetime_str is None:
+            path = (
+                "/api/diagnostics/system/system_time"
+                if self._use_snake_case
+                else "/api/diagnostics/system/systemTime"
+            )
+            try:
+                datetime_raw = (await self._safe_dict_post(path)).get("datetime")
+            except (aiohttp.ClientError, TimeoutError) as err:
+                _LOGGER.debug(
+                    "Failed to fetch OPNsense system time for timezone resolution: %s: %s",
+                    type(err).__name__,
+                    err,
+                )
+                return self._get_local_timezone()
+            datetime_str = datetime_raw if isinstance(datetime_raw, str) else None
+
+        if datetime_str:
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", UnknownTimezoneWarning)
+                    parsed_time = parse(datetime_str, tzinfos=AMBIGUOUS_TZINFOS)
+                if parsed_time.tzinfo is not None:
+                    return parsed_time.tzinfo
+                _LOGGER.debug(
+                    "No timezone data in OPNsense datetime '%s', using local fallback",
+                    datetime_str,
+                )
+            except (ValueError, TypeError, ParserError, UnknownTimezoneWarning) as err:
+                _LOGGER.debug(
+                    "Failed to parse OPNsense timezone from datetime '%s': %s: %s",
+                    datetime_str,
+                    type(err).__name__,
+                    err,
+                )
+        return self._get_local_timezone()
 
     @_log_errors
     async def _filter_configure(self) -> None:

--- a/custom_components/opnsense/pyopnsense/telemetry.py
+++ b/custom_components/opnsense/pyopnsense/telemetry.py
@@ -1,7 +1,7 @@
 """Telemetry and interface statistics methods for OPNsenseClient."""
 
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import re
 from typing import Any
 
@@ -218,13 +218,12 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
             time_info = await self._safe_dict_post("/api/diagnostics/system/systemTime")
         # _LOGGER.debug("[get_telemetry_system] time_info: %s", time_info)
         system: dict[str, Any] = {}
+        opnsense_tz = await self._get_opnsense_timezone(time_info.get("datetime"))
 
         try:
             systemtime: datetime = parse(time_info["datetime"], tzinfos=AMBIGUOUS_TZINFOS)
             if systemtime.tzinfo is None:
-                systemtime = systemtime.replace(
-                    tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
-                )
+                systemtime = systemtime.replace(tzinfo=opnsense_tz)
         except (KeyError, ValueError, TypeError, ParserError, UnknownTimezoneWarning) as e:
             _LOGGER.warning(
                 "Failed to parse opnsense system time (aka. datetime), using HA system time instead: %s. %s: %s",
@@ -250,9 +249,7 @@ class TelemetryMixin(PyOPNsenseClientProtocol):
             try:
                 boottime = parse(time_info["boottime"], tzinfos=AMBIGUOUS_TZINFOS)
                 if boottime and boottime.tzinfo is None:
-                    boottime = boottime.replace(
-                        tzinfo=timezone(datetime.now().astimezone().utcoffset() or timedelta())
-                    )
+                    boottime = boottime.replace(tzinfo=opnsense_tz)
             except (ValueError, TypeError, ParserError, UnknownTimezoneWarning) as e:
                 _LOGGER.info(
                     "Failed to parse opnsense boottime: %s. %s: %s",

--- a/custom_components/opnsense/pyopnsense/vnstat.py
+++ b/custom_components/opnsense/pyopnsense/vnstat.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
-from datetime import date, datetime, timedelta, timezone, tzinfo
+from datetime import date, datetime, timedelta, tzinfo
 import re
 from typing import Any
 
-from dateutil.parser import ParserError, UnknownTimezoneWarning, parse
-
 from ._typing import PyOPNsenseClientProtocol
-from .const import AMBIGUOUS_TZINFOS
 from .helpers import _LOGGER, _log_errors, try_to_float
 
 _VSTAT_HEADER_RE = re.compile(
@@ -120,37 +117,6 @@ class VnstatMixin(PyOPNsenseClientProtocol):
             "interfaces": interface_data,
             "interface_count": len(interface_names),
         }
-
-    async def _get_opnsense_timezone(self) -> tzinfo:
-        """Resolve timezone information from OPNsense system time endpoint.
-
-        Returns
-        -------
-        tzinfo
-            Parsed timezone from OPNsense ``system_time`` output, or a local
-            timezone-offset fallback when parsing fails.
-
-        """
-        path = (
-            "/api/diagnostics/system/system_time"
-            if self._use_snake_case
-            else "/api/diagnostics/system/systemTime"
-        )
-        time_info = await self._safe_dict_post(path)
-        datetime_str = time_info.get("datetime")
-        if isinstance(datetime_str, str):
-            try:
-                parsed_time = parse(datetime_str, tzinfos=AMBIGUOUS_TZINFOS)
-                if parsed_time.tzinfo is not None:
-                    return parsed_time.tzinfo
-            except (ValueError, TypeError, ParserError, UnknownTimezoneWarning) as err:
-                _LOGGER.debug(
-                    "Failed to parse OPNsense timezone from datetime '%s': %s: %s",
-                    datetime_str,
-                    type(err).__name__,
-                    err,
-                )
-        return timezone(datetime.now().astimezone().utcoffset() or timedelta())
 
     def _parse_vnstat_payload(
         self, payload: MutableMapping[str, Any], expected_period: str

--- a/tests/pyopnsense/test_dhcp.py
+++ b/tests/pyopnsense/test_dhcp.py
@@ -141,6 +141,10 @@ async def test_get_isc_dhcpv4_and_v6_parsing() -> None:
         url="http://localhost", username="u", password="p", session=session
     )
     try:
+        local_tz = datetime.now().astimezone().tzinfo
+        assert local_tz is not None
+        client._get_opnsense_timezone = AsyncMock(return_value=local_tz)
+
         # v4: ends present and in future
         future_dt = (datetime.now() + timedelta(hours=1)).strftime("%Y/%m/%d %H:%M:%S")
         client._use_snake_case = False
@@ -164,6 +168,9 @@ async def test_get_isc_dhcpv4_and_v6_parsing() -> None:
         )
         v4 = await client._get_isc_dhcpv4_leases()
         assert isinstance(v4, list) and len(v4) == 1
+        assert v4[0]["address"] == "10.0.0.1"
+        assert v4[0]["mac"] == "m1"
+        assert v4[0]["hostname"] == "h1"
         assert isinstance(v4[0].get("expires"), datetime)
 
         # v6: ends missing -> field passed through
@@ -203,6 +210,10 @@ async def test_get_dhcp_leases_combined_structure() -> None:
         url="http://localhost", username="u", password="p", session=session
     )
     try:
+        local_tz = datetime.now().astimezone().tzinfo
+        assert local_tz is not None
+        client._get_opnsense_timezone = AsyncMock(return_value=local_tz)
+
         # return one lease from each source and one interface mapping
         client._get_kea_dhcpv4_leases = AsyncMock(
             return_value=[{"if_name": "em0", "address": "1.1.1.1", "mac": "m1"}]
@@ -229,6 +240,11 @@ async def test_get_dhcp_leases_combined_structure() -> None:
             lease.get("address") == "1.1.1.2" and lease.get("mac") == "m2"
             for lease in combined["leases"]["em0"]
         )
+        client._get_opnsense_timezone.assert_awaited_once_with()
+        client._get_kea_dhcpv4_leases.assert_awaited_once_with(opnsense_tz=local_tz)
+        client._get_isc_dhcpv4_leases.assert_awaited_once_with(opnsense_tz=local_tz)
+        client._get_isc_dhcpv6_leases.assert_awaited_once_with(opnsense_tz=local_tz)
+        client._get_dnsmasq_leases.assert_awaited_once_with(opnsense_tz=local_tz)
     finally:
         await client.async_close()
 

--- a/tests/pyopnsense/test_firmware.py
+++ b/tests/pyopnsense/test_firmware.py
@@ -1,6 +1,6 @@
 """Tests for `pyopnsense.firmware` behaviors."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -87,8 +87,10 @@ async def test_get_firmware_update_info_triggers_check_when_missing() -> None:
             "last_check": old_time,
         }
         client._safe_dict_get = AsyncMock(return_value=status)
+        client._get_opnsense_timezone = AsyncMock(return_value=UTC)
         client._post = AsyncMock(return_value={})
         await client.get_firmware_update_info()
+        client._get_opnsense_timezone.assert_awaited_once_with()
         client._post.assert_awaited_once_with("/api/core/firmware/check")
     finally:
         await client.async_close()

--- a/tests/pyopnsense/test_system.py
+++ b/tests/pyopnsense/test_system.py
@@ -1,6 +1,6 @@
 """Tests for `pyopnsense.system`."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -30,6 +30,39 @@ async def test_get_device_unique_id_and_system_info(make_client) -> None:
         client._safe_dict_get = AsyncMock(return_value={"name": "foo"})
         info = await client.get_system_info()
         assert info["name"] == "foo"
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_opnsense_timezone_parse_and_fallback(make_client) -> None:
+    """_get_opnsense_timezone should parse valid timezone strings and fallback on errors."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._use_snake_case = True
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "2026-03-07 12:00:00 EST"})
+        parsed_tz = await client._get_opnsense_timezone()
+        assert parsed_tz is not None
+        parsed_dt = datetime(2026, 3, 7, 12, 0, 0, tzinfo=parsed_tz)
+        assert parsed_tz.utcoffset(parsed_dt) == timedelta(hours=-5)
+
+        client._safe_dict_post = AsyncMock(return_value={"datetime": "not-a-datetime"})
+        fallback_tz = await client._get_opnsense_timezone()
+        assert fallback_tz is not None
+        local_tz = datetime.now().astimezone().tzinfo
+        assert local_tz is not None
+        now_local = datetime.now().astimezone()
+        assert fallback_tz == local_tz or fallback_tz.utcoffset(now_local) == local_tz.utcoffset(
+            now_local
+        )
+
+        client._safe_dict_post = AsyncMock(side_effect=aiohttp.ClientError("transient fetch error"))
+        fetch_fallback_tz = await client._get_opnsense_timezone()
+        assert fetch_fallback_tz is not None
+        assert fetch_fallback_tz == local_tz or fetch_fallback_tz.utcoffset(
+            now_local
+        ) == local_tz.utcoffset(now_local)
     finally:
         await client.async_close()
 

--- a/tests/pyopnsense/test_telemetry.py
+++ b/tests/pyopnsense/test_telemetry.py
@@ -1,6 +1,7 @@
 """Tests for `pyopnsense.telemetry`."""
 
 from collections.abc import MutableMapping
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -33,11 +34,13 @@ async def test_telemetry_system_parsing_and_filesystems() -> None:
             return {}
 
         client._safe_dict_post = AsyncMock(side_effect=fake_safe_post)
+        client._get_opnsense_timezone = AsyncMock(return_value=UTC)
 
         sys = await client._get_telemetry_system()
         assert isinstance(sys, MutableMapping)
         # At least one of the expected fields is normalized/present
         assert any(k in sys for k in ("uptime", "boottime", "loadavg"))
+        client._get_opnsense_timezone.assert_awaited_once_with("not-a-date")
 
         files = await client._get_telemetry_filesystems()
         assert files is None or isinstance(files, list)

--- a/tests/pyopnsense/test_vnstat.py
+++ b/tests/pyopnsense/test_vnstat.py
@@ -158,32 +158,6 @@ async def test_get_vnstat_uses_systemtime_endpoint_path(make_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_opnsense_timezone_parse_and_fallback(make_client) -> None:
-    """_get_opnsense_timezone should parse valid timezone strings and fallback on errors."""
-    session = MagicMock(spec=aiohttp.ClientSession)
-    client = make_client(session=session)
-    try:
-        client._use_snake_case = True
-        client._safe_dict_post = AsyncMock(return_value={"datetime": "2026-03-07 12:00:00 EST"})
-        parsed_tz = await client._get_opnsense_timezone()
-        assert parsed_tz is not None
-        parsed_dt = datetime(2026, 3, 7, 12, 0, 0, tzinfo=parsed_tz)
-        assert parsed_tz.utcoffset(parsed_dt) == timedelta(hours=-5)
-
-        client._safe_dict_post = AsyncMock(return_value={"datetime": "not-a-datetime"})
-        fallback_tz = await client._get_opnsense_timezone()
-        assert fallback_tz is not None
-        local_tz = datetime.now().astimezone().tzinfo
-        assert local_tz is not None
-        now_local = datetime.now().astimezone()
-        assert fallback_tz == local_tz or fallback_tz.utcoffset(now_local) == local_tz.utcoffset(
-            now_local
-        )
-    finally:
-        await client.async_close()
-
-
-@pytest.mark.asyncio
 async def test_parse_vnstat_payload_and_helpers_edge_cases(make_client) -> None:
     """VnStat payload/helper methods should handle malformed and fallback scenarios."""
     session = MagicMock(spec=aiohttp.ClientSession)


### PR DESCRIPTION
This pull request introduces a unified approach for handling timezone information across the OPNsense client, improving consistency and reliability when parsing and assigning timezones to datetime values. The most important changes are the addition of a centralized `_get_opnsense_timezone` method, refactoring of lease and telemetry methods to use this timezone, and updates to tests to verify correct timezone handling.

Timezone handling improvements:

* Added a centralized `_get_opnsense_timezone` method to `system.py` for resolving timezone information from OPNsense system time data, with robust fallback to local timezone when parsing fails.
* Refactored all DHCP lease methods (`_get_kea_dhcpv4_leases`, `_get_isc_dhcpv4_leases`, `_get_isc_dhcpv6_leases`, `_get_dnsmasq_leases`) and their callers to accept and use `opnsense_tz`, ensuring consistent timezone assignment for lease expiration datetimes. [[1]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L43-R64) [[2]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L117-R132) [[3]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L222-R243) [[4]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L291-R317) [[5]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598R335-R336) [[6]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L340-R366) [[7]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L351-R382) [[8]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598R400-R401) [[9]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L400-R431)
* Updated telemetry and firmware methods to use `_get_opnsense_timezone` for assigning timezones to parsed datetimes, replacing previous local offset logic. [[1]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6L171-R172) [[2]](diffhunk://#diff-132c576235e748a480ed0b904636d16d3f5d869343b61ce1204bf7985a9ab55eR221-R226) [[3]](diffhunk://#diff-132c576235e748a480ed0b904636d16d3f5d869343b61ce1204bf7985a9ab55eL253-R252)

Code cleanup and consolidation:

* Removed redundant timezone parsing code from `vnstat.py`, consolidating timezone resolution to the new centralized method.
* Updated imports and type hints throughout the codebase to use `tzinfo` and reflect the new timezone handling approach. [[1]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66R5) [[2]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L4-R4) [[3]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6L4-R4) [[4]](diffhunk://#diff-132c576235e748a480ed0b904636d16d3f5d869343b61ce1204bf7985a9ab55eL4-R4) [[5]](diffhunk://#diff-fcc9e13cfcd2bc1711e587d37cef6fbd50cae1c17a9dc5c599dcfc7ce8d06317L6-L13)

Test updates:

* Enhanced test cases to mock and verify the use of `_get_opnsense_timezone`, ensuring that all lease and combined structure methods correctly receive and use the resolved timezone. [[1]](diffhunk://#diff-d5e9b26acd4739452454508c37d6b2c06f3bbe09f4a0ee98aeffc954a25e2323R144-R147) [[2]](diffhunk://#diff-d5e9b26acd4739452454508c37d6b2c06f3bbe09f4a0ee98aeffc954a25e2323R171-R173) [[3]](diffhunk://#diff-d5e9b26acd4739452454508c37d6b2c06f3bbe09f4a0ee98aeffc954a25e2323R213-R216) [[4]](diffhunk://#diff-d5e9b26acd4739452454508c37d6b2c06f3bbe09f4a0ee98aeffc954a25e2323R243-R247)