### PR TITLE
Implement speedtest via undocumented API

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 
 * Certificates
 
+* Speedtest last and average results (download, upload, latency)
+
 ### Switch
 
 All of the switches are disabled by default
@@ -250,6 +252,9 @@ action: opnsense.kill_states
 data:
   ip_address: 192.168.0.100
 # Will optionally return the number of states dropped for each client
+
+action: opnsense.run_speedtest
+# Returns speedtest results as action response data
 
 action: opnsense.generate_vouchers
 data:

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -49,6 +49,7 @@ CONF_FIRMWARE_VERSION = "firmware_version"
 
 CONF_SYNC_TELEMETRY = "sync_telemetry"
 CONF_SYNC_VNSTAT = "sync_vnstat"
+CONF_SYNC_SPEEDTEST = "sync_speedtest"
 CONF_SYNC_VPN = "sync_vpn"
 CONF_SYNC_FIRMWARE_UPDATES = "sync_firmware_updates"
 CONF_SYNC_CARP = "sync_carp"
@@ -68,6 +69,7 @@ SYNC_ITEMS_REQUIRING_PLUGIN = (CONF_SYNC_FIREWALL_AND_NAT,)
 GRANULAR_SYNC_ITEMS = (
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_VNSTAT,
+    CONF_SYNC_SPEEDTEST,
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_DHCP_LEASES,
@@ -83,6 +85,7 @@ GRANULAR_SYNC_ITEMS = (
 GRANULAR_SYNC_PREFIX = {
     CONF_SYNC_TELEMETRY: ["telemetry"],
     CONF_SYNC_VNSTAT: ["vnstat"],
+    CONF_SYNC_SPEEDTEST: ["speedtest"],
     CONF_SYNC_VPN: ["wireguard", "openvpn"],
     CONF_SYNC_FIRMWARE_UPDATES: ["firmware"],
     CONF_SYNC_CARP: ["carp"],
@@ -339,3 +342,4 @@ SERVICE_RELOAD_INTERFACE = "reload_interface"
 SERVICE_GENERATE_VOUCHERS = "generate_vouchers"
 SERVICE_KILL_STATES = "kill_states"
 SERVICE_TOGGLE_ALIAS = "toggle_alias"
+SERVICE_RUN_SPEEDTEST = "run_speedtest"

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_SYNC_INTERFACES,
     CONF_SYNC_NOTICES,
     CONF_SYNC_SERVICES,
+    CONF_SYNC_SPEEDTEST,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_UNBOUND,
     CONF_SYNC_VNSTAT,
@@ -127,6 +128,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             categories.append({"function": "get_telemetry", "state_key": "telemetry"})
         if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
             categories.append({"function": "get_vnstat", "state_key": "vnstat"})
+        if config.get(CONF_SYNC_SPEEDTEST, DEFAULT_SYNC_OPTION_VALUE):
+            categories.append({"function": "get_speedtest", "state_key": "speedtest"})
         if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
             categories.extend(
                 [

--- a/custom_components/opnsense/pyopnsense/_typing.py
+++ b/custom_components/opnsense/pyopnsense/_typing.py
@@ -94,6 +94,27 @@ class PyOPNsenseClientProtocol(Protocol):
         ...
 
     @abstractmethod
+    async def _safe_dict_get_with_timeout(
+        self, path: str, timeout_seconds: float
+    ) -> dict[str, Any]:
+        """Fetch a GET payload with a custom timeout and coerce non-mapping values.
+
+        Parameters
+        ----------
+        path : str
+            Relative API path.
+        timeout_seconds : int | float
+            Total timeout window in seconds for the request.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary payload.
+
+        """
+        ...
+
+    @abstractmethod
     async def _safe_list_get(self, path: str) -> list:
         """Fetch a GET payload and coerce non-list values to an empty list.
 

--- a/custom_components/opnsense/pyopnsense/client.py
+++ b/custom_components/opnsense/pyopnsense/client.py
@@ -5,6 +5,7 @@ from .dhcp import DHCPMixin
 from .firewall import FirewallMixin
 from .firmware import FirmwareMixin
 from .services import ServicesMixin
+from .speedtest import SpeedtestMixin
 from .system import SystemMixin
 from .telemetry import TelemetryMixin
 from .unbound import UnboundMixin
@@ -19,6 +20,7 @@ class OPNsenseClient(
     FirewallMixin,
     DHCPMixin,
     ServicesMixin,
+    SpeedtestMixin,
     SystemMixin,
     UnboundMixin,
     VouchersMixin,

--- a/custom_components/opnsense/pyopnsense/client_base.py
+++ b/custom_components/opnsense/pyopnsense/client_base.py
@@ -546,7 +546,10 @@ $toreturn["real"] = json_encode($toreturn_real);
         return {}
 
     async def _do_get(
-        self, path: str, caller: str = "Unknown"
+        self,
+        path: str,
+        caller: str = "Unknown",
+        timeout_seconds: float | None = None,
     ) -> MutableMapping[str, Any] | list | None:
         """Execute a GET request immediately without queueing.
 
@@ -556,6 +559,9 @@ $toreturn["real"] = json_encode($toreturn_real);
             API endpoint path to call on the OPNsense host.
         caller : str
             Name of the calling method used for log context. Defaults to 'Unknown'.
+        timeout_seconds : int | float | None
+            Optional timeout value in seconds for this request. Defaults to None,
+            which uses the shared default timeout.
 
         Returns
         -------
@@ -568,11 +574,12 @@ $toreturn["real"] = json_encode($toreturn_real);
         self._rest_api_query_count += 1
         url: str = f"{self._url}{path}"
         _LOGGER.debug("[get] url: %s", url)
+        timeout_total: float = self._normalize_timeout_seconds(timeout_seconds)
         try:
             async with self._session.get(
                 url,
                 auth=aiohttp.BasicAuth(self._username, self._password),
-                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+                timeout=aiohttp.ClientTimeout(total=timeout_total),
                 ssl=self._verify_ssl,
             ) as response:
                 _LOGGER.debug("[get] Response %s: %s", response.status, response.reason)
@@ -607,6 +614,30 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         return None
 
+    def _normalize_timeout_seconds(self, timeout_seconds: float | None) -> float:
+        """Normalize per-call timeout values to a positive float in seconds.
+
+        Parameters
+        ----------
+        timeout_seconds : int | float | None
+            Requested timeout value in seconds.
+
+        Returns
+        -------
+        float
+            Positive timeout in seconds. Falls back to DEFAULT_TIMEOUT when invalid.
+
+        """
+        if timeout_seconds is None:
+            return float(DEFAULT_TIMEOUT)
+        try:
+            timeout_total = float(timeout_seconds)
+        except (TypeError, ValueError):
+            return float(DEFAULT_TIMEOUT)
+        if timeout_total <= 0:
+            return float(DEFAULT_TIMEOUT)
+        return timeout_total
+
     async def _safe_dict_get(self, path: str) -> dict[str, Any]:
         """Fetch data from the given path, ensuring the result is a dict.
 
@@ -623,6 +654,32 @@ $toreturn["real"] = json_encode($toreturn_real);
 
         """
         result = await self._get(path=path)
+        return dict(result) if isinstance(result, MutableMapping) else {}
+
+    async def _safe_dict_get_with_timeout(
+        self, path: str, timeout_seconds: float
+    ) -> dict[str, Any]:
+        """Fetch a GET payload with a custom timeout and coerce to a dictionary.
+
+        Parameters
+        ----------
+        path : str
+            API endpoint path to call on the OPNsense host.
+        timeout_seconds : int | float
+            Total timeout window in seconds for this request.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary payload from the GET request, or an empty dictionary if
+            the response is not a mapping.
+
+        """
+        result = await self._do_get(
+            path=path,
+            caller="_safe_dict_get_with_timeout",
+            timeout_seconds=timeout_seconds,
+        )
         return dict(result) if isinstance(result, MutableMapping) else {}
 
     async def _safe_list_get(self, path: str) -> list:

--- a/custom_components/opnsense/pyopnsense/speedtest.py
+++ b/custom_components/opnsense/pyopnsense/speedtest.py
@@ -1,0 +1,133 @@
+"""Speedtest methods for OPNsenseClient."""
+
+# Endpoints (GET):
+# /api/speedtest/service/showstat
+# /api/speedtest/service/showlog
+# /api/speedtest/service/showrecent
+# /api/speedtest/service/version
+# /api/speedtest/service/serverlist
+# /api/speedtest/service/run/[$serverid]
+#
+# Sources:
+# https://github.com/mimugmail/opn-repo/blob/main/net-mgmt/speedtest-community/src/opnsense/mvc/app/controllers/OPNsense/Speedtest/Api/ServiceController.php
+# https://github.com/mihakralj/opnsense-speedtest/blob/main/src/opnsense/mvc/app/controllers/OPNsense/Speedtest/Api/ServiceController.php
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+from ._typing import PyOPNsenseClientProtocol
+from .helpers import _LOGGER, _log_errors, try_to_float, try_to_int
+
+
+class SpeedtestMixin(PyOPNsenseClientProtocol):
+    """Speedtest methods for OPNsenseClient."""
+
+    @_log_errors
+    async def get_speedtest(self) -> dict[str, Any]:
+        """Return normalized speedtest summary payload for sensors.
+
+        Returns
+        -------
+        dict[str, Any]
+            Normalized speedtest state including last and average metrics.
+
+        """
+        if not await self.is_endpoint_available("/api/speedtest/service/showrecent"):
+            _LOGGER.debug("Speedtest recent endpoint unavailable, skipping speedtest retrieval")
+            return {"available": False}
+        if not await self.is_endpoint_available("/api/speedtest/service/showstat"):
+            _LOGGER.debug("Speedtest stat endpoint unavailable, skipping speedtest retrieval")
+            return {"available": False}
+
+        show_recent = await self._safe_dict_get("/api/speedtest/service/showrecent")
+        show_stat = await self._safe_dict_get("/api/speedtest/service/showstat")
+
+        server_id, server_name = self._parse_recent_server(show_recent.get("server"))
+        date = show_recent.get("date") if isinstance(show_recent.get("date"), str) else None
+        url = show_recent.get("url") if isinstance(show_recent.get("url"), str) else None
+
+        samples = try_to_int(show_stat.get("samples"))
+        period = show_stat.get("period", {})
+        oldest = period.get("oldest") if isinstance(period, MutableMapping) else None
+        youngest = period.get("youngest") if isinstance(period, MutableMapping) else None
+
+        output: dict[str, Any] = {
+            "available": True,
+            "last": {},
+            "average": {},
+        }
+        for metric in ("download", "upload", "latency"):
+            recent_value = try_to_float(show_recent.get(metric))
+            stat_metric = show_stat.get(metric, {})
+
+            output["last"][metric] = {
+                "value": recent_value,
+                "date": date,
+                "server_id": server_id,
+                "server": server_name,
+                "url": url,
+            }
+            output["average"][metric] = {
+                "value": try_to_float(
+                    stat_metric.get("avg") if isinstance(stat_metric, MutableMapping) else None
+                ),
+                "min": try_to_float(
+                    stat_metric.get("min") if isinstance(stat_metric, MutableMapping) else None
+                ),
+                "max": try_to_float(
+                    stat_metric.get("max") if isinstance(stat_metric, MutableMapping) else None
+                ),
+                "oldest": oldest,
+                "youngest": youngest,
+                "samples": samples,
+            }
+        return output
+
+    def _parse_recent_server(self, server_text: Any) -> tuple[str | None, str | None]:
+        """Parse the ``showrecent.server`` field into server ID and name.
+
+        Parameters
+        ----------
+        server_text : Any
+            Raw ``server`` field from the speedtest ``showrecent`` endpoint.
+
+        Returns
+        -------
+        tuple[str | None, str | None]
+            Parsed ``(server_id, server_name)`` tuple.
+
+        """
+        if not isinstance(server_text, str):
+            return None, None
+        cleaned = server_text.strip()
+        if not cleaned:
+            return None, None
+
+        parts = cleaned.split(" ", 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return parts[0], parts[1].strip()
+        return None, cleaned
+
+    @_log_errors
+    async def run_speedtest(self) -> dict[str, Any]:
+        """Run speedtest and return the endpoint response payload.
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw speedtest run result payload. Empty dictionary when unavailable.
+
+        """
+        if not await self.is_endpoint_available("/api/speedtest/service/run"):
+            _LOGGER.debug("Speedtest run endpoint unavailable, skipping speedtest action")
+            return {}
+
+        response = await self._safe_dict_get_with_timeout(
+            "/api/speedtest/service/run",
+            timeout_seconds=180,
+        )
+        if not isinstance(response, MutableMapping):
+            return {}
+        return dict(response)

--- a/custom_components/opnsense/pyopnsense/vnstat.py
+++ b/custom_components/opnsense/pyopnsense/vnstat.py
@@ -62,7 +62,7 @@ class VnstatMixin(PyOPNsenseClientProtocol):
 
         """
         if not await self.is_endpoint_available("/api/vnstat/service/hourly"):
-            _LOGGER.debug("vnStat endpoint unavailable, skipping data retrieval")
+            _LOGGER.debug("vnStat not installed")
             return {"interfaces": {}, "interface_count": 0}
 
         opnsense_tz = await self._get_opnsense_timezone()

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_SYNC_DHCP_LEASES,
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
+    CONF_SYNC_SPEEDTEST,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
@@ -244,6 +245,80 @@ async def _compile_vnstat_sensors(
                 ),
             )
             entities.append(entity)
+    return entities
+
+
+async def _compile_speedtest_sensors(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+) -> list:
+    """Compile speedtest sensors from normalized coordinator state."""
+    if not isinstance(state, MutableMapping):
+        return []
+    speedtest = state.get("speedtest")
+    if not isinstance(speedtest, MutableMapping) or not speedtest.get("available", False):
+        return []
+
+    metric_definitions: tuple[tuple[str, str, Any, str], ...] = (
+        (
+            "speedtest.last.download",
+            "Speedtest Last Download",
+            UnitOfDataRate.MEGABITS_PER_SECOND,
+            "mdi:download-network",
+        ),
+        (
+            "speedtest.last.upload",
+            "Speedtest Last Upload",
+            UnitOfDataRate.MEGABITS_PER_SECOND,
+            "mdi:upload-network",
+        ),
+        (
+            "speedtest.last.latency",
+            "Speedtest Last Latency",
+            UnitOfTime.MILLISECONDS,
+            "mdi:timer-outline",
+        ),
+        (
+            "speedtest.average.download",
+            "Speedtest Average Download",
+            UnitOfDataRate.MEGABITS_PER_SECOND,
+            "mdi:download-network",
+        ),
+        (
+            "speedtest.average.upload",
+            "Speedtest Average Upload",
+            UnitOfDataRate.MEGABITS_PER_SECOND,
+            "mdi:upload-network",
+        ),
+        (
+            "speedtest.average.latency",
+            "Speedtest Average Latency",
+            UnitOfTime.MILLISECONDS,
+            "mdi:timer-outline",
+        ),
+    )
+    entities: list = []
+    for key, name, native_unit, icon in metric_definitions:
+        device_class: SensorDeviceClass | None = None
+        if not key.endswith(".latency"):
+            device_class = SensorDeviceClass.DATA_RATE
+
+        entities.append(
+            OPNsenseSpeedtestSensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=SensorEntityDescription(
+                    key=key,
+                    name=name,
+                    native_unit_of_measurement=native_unit,
+                    device_class=device_class,
+                    icon=icon,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    entity_registry_enabled_default=False,
+                ),
+            )
+        )
     return entities
 
 
@@ -635,6 +710,8 @@ async def async_setup_entry(
         entities.extend(await _compile_temperature_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
+    if config.get(CONF_SYNC_SPEEDTEST, DEFAULT_SYNC_OPTION_VALUE):
+        entities.extend(await _compile_speedtest_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_CERTIFICATES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_certificate_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
@@ -793,6 +870,52 @@ class OPNsenseVnstatSensor(OPNsenseSensor):
         if isinstance(tx_bytes, int):
             self._attr_extra_state_attributes["tx_bytes"] = tx_bytes
 
+        self.async_write_ha_state()
+
+
+class OPNsenseSpeedtestSensor(OPNsenseSensor):
+    """Class for OPNsense Speedtest sensors."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator updates for speedtest sensors."""
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        key_parts = self.entity_description.key.split(".")
+        if len(key_parts) != 3:
+            self._available = False
+            self.async_write_ha_state()
+            return
+        _, speedtest_section, metric_name = key_parts
+
+        metric = dict_get(state, f"speedtest.{speedtest_section}.{metric_name}", {})
+        if not isinstance(metric, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        value = metric.get("value")
+        if not isinstance(value, (int, float)):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._available = True
+        self._attr_native_value = float(value)
+        self._attr_extra_state_attributes = {}
+
+        if speedtest_section == "last":
+            for attr in ("date", "server_id", "server", "url"):
+                if metric.get(attr) is not None:
+                    self._attr_extra_state_attributes[attr] = metric.get(attr)
+        else:
+            for attr in ("min", "max", "oldest", "youngest", "samples"):
+                if metric.get(attr) is not None:
+                    self._attr_extra_state_attributes[attr] = metric.get(attr)
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -22,6 +22,7 @@ from .const import (
     SERVICE_KILL_STATES,
     SERVICE_RELOAD_INTERFACE,
     SERVICE_RESTART_SERVICE,
+    SERVICE_RUN_SPEEDTEST,
     SERVICE_SEND_WOL,
     SERVICE_START_SERVICE,
     SERVICE_STOP_SERVICE,
@@ -198,6 +199,19 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         ),
         service_func=functools.partial(_service_kill_states, hass),
         supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_RUN_SPEEDTEST,
+        schema=vol.Schema(
+            {
+                vol.Optional("device_id"): vol.Any(cv.string),
+                vol.Optional("entity_id"): vol.Any(cv.string),
+            }
+        ),
+        service_func=functools.partial(_service_run_speedtest, hass),
+        supports_response=SupportsResponse.ONLY,
     )
 
     hass.services.async_register(
@@ -497,6 +511,46 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
     if return_response:
         return return_response
     return None
+
+
+async def _service_run_speedtest(hass: HomeAssistant, call: ServiceCall) -> ServiceResponse:
+    """Run speedtest and return speedtest results in action response data.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        Home Assistant instance.
+    call : ServiceCall
+        Service call payload that may contain ``device_id`` or ``entity_id``.
+
+    Returns
+    -------
+    ServiceResponse
+        Response payload containing per-client speedtest results.
+
+    """
+    clients: list = await _get_clients(
+        hass=hass,
+        opndevice_id=call.data.get("device_id", []),
+        opnentity_id=call.data.get("entity_id", []),
+    )
+    response_list: list[dict[str, Any]] = []
+    for client in clients:
+        response = await client.run_speedtest()
+        _LOGGER.debug("[service_run_speedtest] client: %s, response: %s", client.name, response)
+        if not isinstance(response, MutableMapping) or len(response) == 0:
+            continue
+        run_result: dict[str, Any] = {"client_name": client.name}
+        run_result.update(dict(response))
+        response_list.append(run_result)
+
+    if len(response_list) == 0:
+        raise ServiceValidationError(
+            "Run Speedtest Failed. No selected OPNsense clients have a working speedtest endpoint."
+        )
+    return_response: dict[str, Any] = {"results": response_list}
+    _LOGGER.debug("[service_run_speedtest] return_response: %s", return_response)
+    return return_response
 
 
 async def _service_toggle_alias(hass: HomeAssistant, call: ServiceCall) -> None:

--- a/custom_components/opnsense/services.yaml
+++ b/custom_components/opnsense/services.yaml
@@ -335,6 +335,30 @@ kill_states:
                 - integration: opnsense
                   domain: sensor
 
+run_speedtest:
+  fields:
+    multiple_opnsense:
+      collapsed: true
+      fields:
+        device_id:
+          required: false
+          selector:
+            device:
+              multiple: false
+              filter:
+                - integration: opnsense
+              entity:
+                - domain: sensor
+        entity_id:
+          example: "sensor.opnsense_interface_lan_status"
+          required: false
+          selector:
+            entity:
+              multiple: false
+              filter:
+                - integration: opnsense
+                  domain: sensor
+
 toggle_alias:
   fields:
     alias:

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -35,6 +35,7 @@
         "data": {
           "sync_telemetry": "Basic telemetry data",
           "sync_vnstat": "vnStat bandwidth usage",
+          "sync_speedtest": "Speedtest results",
           "sync_vpn": "VPN information and switches",
           "sync_firmware_updates": "Firmware updates",
           "sync_carp": "CARP information",
@@ -80,6 +81,7 @@
         "data": {
           "sync_telemetry": "Basic telemetry data",
           "sync_vnstat": "vnStat bandwidth usage",
+          "sync_speedtest": "Speedtest results",
           "sync_vpn": "VPN information and switches",
           "sync_firmware_updates": "Firmware updates",
           "sync_carp": "CARP information",
@@ -401,6 +403,25 @@
           "name": "IP Address",
           "description": "The IP Address to kill all states for. ipv4 or ipv6 accepted"
         },
+        "device_id": {
+          "name": "OPNsense Device",
+          "description": "Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers."
+        },
+        "entity_id": {
+          "name": "OPNsense Entity",
+          "description": "Pick any sensor in the OPNsense Router you want to call the command on. If not specified, the command will be sent to all OPNsense Routers."
+        }
+      },
+      "sections": {
+        "multiple_opnsense": {
+          "name": "Only needed if there is more than one OPNsense Router"
+        }
+      }
+    },
+    "run_speedtest": {
+      "name": "Run Speedtest",
+      "description": "Run an OPNsense speedtest and return results as action response data",
+      "fields": {
         "device_id": {
           "name": "OPNsense Device",
           "description": "Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers."

--- a/granular_permissions.md
+++ b/granular_permissions.md
@@ -14,6 +14,12 @@
 | ----- | ----- |
 | Lobby: Dashboard | /api/diagnostics/system/system_mbuf<br>/api/diagnostics/firewall/pf_states<br>/api/diagnostics/system/system_resources (or systemResources)<br>/api/diagnostics/system/system_swap<br>/api/diagnostics/system/system_time (or systemTime)<br>/api/diagnostics/cpu_usage/get_c_p_u_type (or getCPUType)<br>/api/diagnostics/cpu_usage/stream<br>/api/diagnostics/system/system_disk (or systemDisk)<br>/api/diagnostics/system/system_temperature (or systemTemperature) |
 
+## Speedtest results
+
+| OPNsense Permission | API Endpoints |
+| ----- | ----- |
+| Services: Speedtest (plugin) | /api/speedtest/service/showrecent<br>/api/speedtest/service/showstat |
+
 ## Gateway information
 
 | OPNsense Permission | API Endpoints |
@@ -171,6 +177,12 @@
 |  OPNsense Permission | API Endpoints |
 | ----- | ----- |
 | Services: Captive Portal | /api/captiveportal/voucher/generate_vouchers (or generateVouchers)<br>/api/captiveportal/voucher/list_providers (or listProviders) |
+
+## Run Speedtest _(opnsense.run_speedtest)_
+
+|  OPNsense Permission | API Endpoints |
+| ----- | ----- |
+| Services: Speedtest (plugin) | /api/speedtest/service/run |
 
 ## Toggle Alias _(opnsense.toggle_alias)_
 

--- a/tests/pyopnsense/test_client_base.py
+++ b/tests/pyopnsense/test_client_base.py
@@ -69,6 +69,30 @@ async def test_safe_dict_post_and_list_post(monkeypatch, make_client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_safe_dict_get_with_timeout(monkeypatch, make_client) -> None:
+    """Ensure custom-timeout safe getter coerces None to empty dict as expected."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session, username="user", password="pass")
+    try:
+        monkeypatch.setattr(
+            client, "_do_get", AsyncMock(return_value={"foo": "bar"}), raising=False
+        )
+        result_dict = await client._safe_dict_get_with_timeout("/fake", timeout_seconds=180)
+        assert result_dict == {"foo": "bar"}
+        client._do_get.assert_awaited_once_with(
+            path="/fake",
+            caller="_safe_dict_get_with_timeout",
+            timeout_seconds=180,
+        )
+
+        monkeypatch.setattr(client, "_do_get", AsyncMock(return_value=None), raising=False)
+        result_empty_dict = await client._safe_dict_get_with_timeout("/fake", timeout_seconds=180)
+        assert result_empty_dict == {}
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
 async def test_is_endpoint_available_caches_success(make_client) -> None:
     """Endpoint probe should cache positive results and avoid repeated calls."""
     session = MagicMock(spec=aiohttp.ClientSession)

--- a/tests/pyopnsense/test_speedtest.py
+++ b/tests/pyopnsense/test_speedtest.py
@@ -1,0 +1,210 @@
+"""Tests for `pyopnsense.speedtest`."""
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import aiohttp
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_skips_calls_when_endpoint_missing(make_client) -> None:
+    """get_speedtest should skip speedtest API calls when endpoint is unavailable."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(return_value=False)
+        client._safe_dict_get = AsyncMock()
+
+        result = await client.get_speedtest()
+
+        assert result == {"available": False}
+        client._safe_dict_get.assert_not_awaited()
+        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/showrecent")
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_normalizes_recent_and_stat_payloads(make_client) -> None:
+    """get_speedtest should normalize showrecent and showstat payload fields."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(side_effect=[True, True])
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "date": "2026-03-14T03:09:45",
+                    "server": "72800 RippleFiber, Newark, NJ",
+                    "download": "836.05",
+                    "upload": "832.97",
+                    "latency": "4.0",
+                    "url": "https://www.speedtest.net/result/c/abc",
+                },
+                {
+                    "samples": 10717,
+                    "period": {"oldest": "2023-01-22 00:29:00", "youngest": "2026-03-14 03:09:45"},
+                    "latency": {"avg": 13.42, "min": 2.35, "max": 1266.74},
+                    "download": {"avg": 723.83, "min": 4.18, "max": 942.02},
+                    "upload": {"avg": 706.7, "min": 1.54, "max": 890.32},
+                },
+            ]
+        )
+
+        result = await client.get_speedtest()
+
+        assert result["available"] is True
+        assert result["last"]["download"]["value"] == 836.05
+        assert result["last"]["download"]["server_id"] == "72800"
+        assert result["last"]["download"]["server"] == "RippleFiber, Newark, NJ"
+        assert result["average"]["download"]["value"] == 723.83
+        assert result["average"]["download"]["min"] == 4.18
+        assert result["average"]["download"]["max"] == 942.02
+        assert result["average"]["download"]["samples"] == 10717
+        assert result["average"]["download"]["oldest"] == "2023-01-22 00:29:00"
+        assert result["average"]["download"]["youngest"] == "2026-03-14 03:09:45"
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_skips_calls_when_showstat_endpoint_missing(make_client) -> None:
+    """get_speedtest should stop when showstat endpoint is unavailable."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(side_effect=[True, False])
+        client._safe_dict_get = AsyncMock()
+
+        result = await client.get_speedtest()
+
+        assert result == {"available": False}
+        client._safe_dict_get.assert_not_awaited()
+        assert client.is_endpoint_available.await_args_list == [
+            call("/api/speedtest/service/showrecent"),
+            call("/api/speedtest/service/showstat"),
+        ]
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_normalizes_malformed_payloads(make_client) -> None:
+    """get_speedtest should coerce malformed or missing values to None safely."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(side_effect=[True, True])
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "date": 12345,
+                    "server": "Regional POP - NYC",
+                    "download": "bad-number",
+                    "upload": "12.5",
+                    "latency": None,
+                    "url": 999,
+                },
+                {
+                    "samples": "not-an-int",
+                    "period": "bad-period-shape",
+                    "download": "bad-download-shape",
+                    "upload": None,
+                    "latency": ["bad-latency-shape"],
+                },
+            ]
+        )
+
+        result = await client.get_speedtest()
+
+        assert result["available"] is True
+        assert result["last"]["download"]["server_id"] is None
+        assert result["last"]["download"]["server"] == "Regional POP - NYC"
+        assert result["last"]["download"]["date"] is None
+        assert result["last"]["download"]["url"] is None
+        assert result["last"]["download"]["value"] is None
+        assert result["last"]["upload"]["value"] == 12.5
+        assert result["last"]["latency"]["value"] is None
+
+        assert result["average"]["download"]["value"] is None
+        assert result["average"]["download"]["min"] is None
+        assert result["average"]["download"]["max"] is None
+        assert result["average"]["download"]["samples"] is None
+        assert result["average"]["download"]["oldest"] is None
+        assert result["average"]["download"]["youngest"] is None
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_parse_recent_server_variants(make_client) -> None:
+    """_parse_recent_server should parse known server formats safely."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        assert client._parse_recent_server(None) == (None, None)
+        assert client._parse_recent_server("   ") == (None, None)
+        assert client._parse_recent_server("10001 Test ISP, NY") == ("10001", "Test ISP, NY")
+        assert client._parse_recent_server("Unstructured Server Name") == (
+            None,
+            "Unstructured Server Name",
+        )
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_run_speedtest_uses_extended_timeout(make_client) -> None:
+    """run_speedtest should use custom timeout helper for long-running endpoint calls."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(return_value=True)
+        client._safe_dict_get_with_timeout = AsyncMock(return_value={"timestamp": "x"})
+
+        result = await client.run_speedtest()
+
+        assert result == {"timestamp": "x"}
+        client._safe_dict_get_with_timeout.assert_awaited_once_with(
+            "/api/speedtest/service/run", timeout_seconds=180
+        )
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_run_speedtest_returns_empty_when_endpoint_missing(make_client) -> None:
+    """run_speedtest should return an empty payload when endpoint is unavailable."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(return_value=False)
+        client._safe_dict_get_with_timeout = AsyncMock()
+
+        result = await client.run_speedtest()
+
+        assert result == {}
+        client._safe_dict_get_with_timeout.assert_not_awaited()
+        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/run")
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_run_speedtest_returns_empty_for_non_mapping_response(make_client) -> None:
+    """run_speedtest should return an empty payload for non-mapping responses."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client.is_endpoint_available = AsyncMock(return_value=True)
+        client._safe_dict_get_with_timeout = AsyncMock(return_value=["not", "a", "mapping"])
+
+        result = await client.run_speedtest()
+
+        assert result == {}
+        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/run")
+        client._safe_dict_get_with_timeout.assert_awaited_once_with(
+            "/api/speedtest/service/run", timeout_seconds=180
+        )
+    finally:
+        await client.async_close()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -25,6 +25,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_INTERFACES,
     CONF_SYNC_NOTICES,
     CONF_SYNC_SERVICES,
+    CONF_SYNC_SPEEDTEST,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_UNBOUND,
     CONF_SYNC_VNSTAT,
@@ -399,6 +400,7 @@ def test_build_categories_returns_empty_when_no_config(make_config_entry, fake_c
     [
         (CONF_SYNC_TELEMETRY, ["telemetry"]),
         (CONF_SYNC_VNSTAT, ["vnstat"]),
+        (CONF_SYNC_SPEEDTEST, ["speedtest"]),
         (CONF_SYNC_VPN, ["openvpn", "wireguard"]),
         (CONF_SYNC_FIRMWARE_UPDATES, ["firmware_update_info"]),
         (CONF_SYNC_CARP, ["carp_interfaces", "carp_status"]),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_DHCP_LEASES,
     CONF_SYNC_GATEWAYS,
     CONF_SYNC_INTERFACES,
+    CONF_SYNC_SPEEDTEST,
     CONF_SYNC_TELEMETRY,
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
@@ -24,6 +25,7 @@ from custom_components.opnsense.sensor import (
     OPNsenseDHCPLeasesSensor,
     OPNsenseGatewaySensor,
     OPNsenseInterfaceSensor,
+    OPNsenseSpeedtestSensor,
     OPNsenseStaticKeySensor,
     OPNsenseTempSensor,
     OPNsenseVnstatSensor,
@@ -1020,6 +1022,7 @@ def _setup_entry_with_all_syncs(state: dict, make_config_entry):
         {
             CONF_SYNC_TELEMETRY: True,
             CONF_SYNC_VNSTAT: True,
+            CONF_SYNC_SPEEDTEST: True,
             CONF_SYNC_CERTIFICATES: True,
             CONF_SYNC_VPN: True,
             CONF_SYNC_GATEWAYS: True,
@@ -1295,6 +1298,237 @@ async def test_async_setup_entry_skips_vnstat_sensors_when_no_interfaces(make_co
 
     await async_setup_entry(MagicMock(), entry, add_entities)
     assert not any(isinstance(e, OPNsenseVnstatSensor) for e in created)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_speedtest_sensors(make_config_entry):
+    """Speedtest sensors should be created when speedtest data is available."""
+    state = {
+        "speedtest": {
+            "available": True,
+            "last": {
+                "download": {
+                    "value": 836.05,
+                    "date": "2026-03-14T03:09:45",
+                    "server_id": "72800",
+                    "server": "RippleFiber, Newark, NJ",
+                    "url": "https://www.speedtest.net/result/c/abc",
+                },
+                "upload": {
+                    "value": 832.97,
+                    "date": "2026-03-14T03:09:45",
+                    "server_id": "72800",
+                    "server": "RippleFiber, Newark, NJ",
+                    "url": "https://www.speedtest.net/result/c/abc",
+                },
+                "latency": {
+                    "value": 4.0,
+                    "date": "2026-03-14T03:09:45",
+                    "server_id": "72800",
+                    "server": "RippleFiber, Newark, NJ",
+                    "url": "https://www.speedtest.net/result/c/abc",
+                },
+            },
+            "average": {
+                "download": {
+                    "value": 723.83,
+                    "min": 4.18,
+                    "max": 942.02,
+                    "oldest": "2023-01-22 00:29:00",
+                    "youngest": "2026-03-14 03:09:45",
+                    "samples": 10717,
+                },
+                "upload": {
+                    "value": 706.7,
+                    "min": 1.54,
+                    "max": 890.32,
+                    "oldest": "2023-01-22 00:29:00",
+                    "youngest": "2026-03-14 03:09:45",
+                    "samples": 10717,
+                },
+                "latency": {
+                    "value": 13.42,
+                    "min": 2.35,
+                    "max": 1266.74,
+                    "oldest": "2023-01-22 00:29:00",
+                    "youngest": "2026-03-14 03:09:45",
+                    "samples": 10717,
+                },
+            },
+        }
+    }
+
+    entry = make_config_entry(
+        {
+            "device_unique_id": "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_CERTIFICATES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_SPEEDTEST: True,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+
+    created: list = []
+
+    def add_entities(entities):
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+    speedtest_entities = [e for e in created if isinstance(e, OPNsenseSpeedtestSensor)]
+    assert len(speedtest_entities) == 6
+    assert all(not e.entity_description.entity_registry_enabled_default for e in speedtest_entities)
+
+    entities_by_key = {e.entity_description.key: e for e in speedtest_entities}
+    for entity in speedtest_entities:
+        entity.hass = MagicMock()
+        entity.entity_id = f"sensor.{entity.entity_description.key.replace('.', '_')}"
+        entity.async_write_ha_state = lambda: None
+        entity._handle_coordinator_update()
+        assert entity.available is True
+
+    assert entities_by_key["speedtest.last.download"].native_value == 836.05
+    assert entities_by_key["speedtest.last.download"].extra_state_attributes["server_id"] == "72800"
+    assert entities_by_key["speedtest.average.latency"].native_value == 13.42
+    assert entities_by_key["speedtest.average.latency"].extra_state_attributes["samples"] == 10717
+
+
+@pytest.mark.parametrize(
+    "state,key",
+    [
+        ([], "speedtest.last.download"),
+        ({"speedtest": {"last": {"download": {"value": 100}}}}, "speedtest.last"),
+        ({"speedtest": {"last": {"download": 100}}}, "speedtest.last.download"),
+        ({"speedtest": {"last": {"download": {"value": "bad"}}}}, "speedtest.last.download"),
+    ],
+)
+def test_speedtest_sensor_unavailable_variants(state, key, make_config_entry):
+    """Speedtest sensors should be unavailable for malformed key/state/value variants."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    description = MagicMock()
+    description.key = key
+    description.name = "Speedtest Sensor"
+
+    sensor = OPNsenseSpeedtestSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=description,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = f"sensor.{key.replace('.', '_')}"
+    sensor.async_write_ha_state = lambda: None
+
+    sensor._handle_coordinator_update()
+    assert sensor.available is False
+
+
+def test_speedtest_sensor_attribute_filtering(make_config_entry):
+    """Speedtest sensors should only include non-None attributes."""
+    state = {
+        "speedtest": {
+            "last": {
+                "download": {
+                    "value": 850.5,
+                    "date": None,
+                    "server_id": "10001",
+                    "server": None,
+                    "url": "https://example.test/result/1",
+                }
+            },
+            "average": {
+                "download": {
+                    "value": 750.2,
+                    "min": None,
+                    "max": 901.3,
+                    "oldest": None,
+                    "youngest": "2026-03-14 03:09:45",
+                    "samples": 0,
+                }
+            },
+        }
+    }
+
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    last_description = MagicMock()
+    last_description.key = "speedtest.last.download"
+    last_description.name = "Speedtest Last Download"
+    last_sensor = OPNsenseSpeedtestSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=last_description,
+    )
+    last_sensor.hass = MagicMock()
+    last_sensor.entity_id = "sensor.speedtest_last_download"
+    last_sensor.async_write_ha_state = lambda: None
+    last_sensor._handle_coordinator_update()
+    assert last_sensor.available is True
+    assert last_sensor.extra_state_attributes == {
+        "server_id": "10001",
+        "url": "https://example.test/result/1",
+    }
+
+    average_description = MagicMock()
+    average_description.key = "speedtest.average.download"
+    average_description.name = "Speedtest Average Download"
+    average_sensor = OPNsenseSpeedtestSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=average_description,
+    )
+    average_sensor.hass = MagicMock()
+    average_sensor.entity_id = "sensor.speedtest_average_download"
+    average_sensor.async_write_ha_state = lambda: None
+    average_sensor._handle_coordinator_update()
+    assert average_sensor.available is True
+    assert average_sensor.extra_state_attributes == {
+        "max": 901.3,
+        "youngest": "2026-03-14 03:09:45",
+        "samples": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_speedtest_sensors_when_unavailable(make_config_entry):
+    """Speedtest sensors should not be created when speedtest is unavailable."""
+    state = {"speedtest": {"available": False}}
+    entry = make_config_entry(
+        {
+            "device_unique_id": "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_CERTIFICATES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_SPEEDTEST: True,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+
+    created: list = []
+
+    def add_entities(entities):
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+    assert not any(isinstance(e, OPNsenseSpeedtestSensor) for e in created)
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -286,6 +286,39 @@ async def test_kill_states_success_and_failure(monkeypatch, ph_hass):
 
 
 @pytest.mark.asyncio
+async def test_run_speedtest_success_and_unavailable(monkeypatch, ph_hass):
+    """run_speedtest should return per-client results and raise when unavailable."""
+    hass = ph_hass
+    hass.data = {}
+    c1 = MagicMock()
+    c1.name = "c1"
+    c1.run_speedtest = AsyncMock(
+        return_value={"timestamp": "2026-03-14T03:09:45Z", "download": 836.05, "upload": 832.97}
+    )
+    c2 = MagicMock()
+    c2.name = "c2"
+    c2.run_speedtest = AsyncMock(return_value={})
+
+    async def fake_get(*args, **kwargs):
+        return [c1, c2]
+
+    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    call = MagicMock()
+    call.data = {}
+
+    response = await services_mod._service_run_speedtest(hass, call)
+    assert "results" in response
+    assert len(response["results"]) == 1
+    assert response["results"][0]["client_name"] == "c1"
+    assert response["results"][0]["download"] == 836.05
+
+    c1.run_speedtest = AsyncMock(return_value={})
+    c2.run_speedtest = AsyncMock(return_value={})
+    with pytest.raises(ServiceValidationError):
+        await services_mod._service_run_speedtest(hass, call)
+
+
+@pytest.mark.asyncio
 async def test_get_clients_no_data_returns_empty():
     """_get_clients returns an empty list when hass.data has no domain."""
     hass = MagicMock(spec=HomeAssistant)


### PR DESCRIPTION
This pull request introduces support for OPNsense Speedtest integration, enabling the collection, display, and on-demand execution of speedtest results within Home Assistant. The changes include backend support for fetching and running speedtests, new configuration and service options, and new sensor entities to surface speedtest metrics.

**Speedtest Integration:**

* Added `SpeedtestMixin` to the OPNsense client, providing methods to fetch recent and average speedtest results and to trigger a new speedtest run via the OPNsense API. (`custom_components/opnsense/pyopnsense/speedtest.py`)
* Implemented a new service (`opnsense.run_speedtest`) to allow users to trigger a speedtest from Home Assistant and receive results in response. (`custom_components/opnsense/const.py`, `README.md`) [[1]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R345) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R258)

**Configuration and Data Coordination:**

* Introduced the `sync_speedtest` configuration flag, allowing users to enable or disable speedtest data collection. Updated all relevant constants and configuration structures to support this new sync item. (`custom_components/opnsense/const.py`, `custom_components/opnsense/coordinator.py`, `custom_components/opnsense/sensor.py`) [[1]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R52) [[2]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R72) [[3]](diffhunk://#diff-0eb103f926c0467686d5f8535699f2381efb4f3233eaf9be1cc73bc076b17182R88) [[4]](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cR26) [[5]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R34)
* Updated the data coordinator to fetch speedtest data when enabled and to include it in the state passed to sensors. (`custom_components/opnsense/coordinator.py`)

**Sensor Entities:**

* Added new sensor entity class (`OPNsenseSpeedtestSensor`) and compilation logic to create sensors for last and average download, upload, and latency metrics. These sensors expose relevant attributes such as server, date, and min/max values. (`custom_components/opnsense/sensor.py`) [[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R251-R324) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R713-R714) [[3]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R876-R921)
* Updated the documentation to describe the new speedtest sensors and service. (`README.md`)

**Backend Improvements:**

* Extended the base client with a method to perform GET requests with a custom timeout, used for long-running speedtest actions. (`custom_components/opnsense/pyopnsense/_typing.py`, `custom_components/opnsense/pyopnsense/client_base.py`) [[1]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66R96-R116) [[2]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L549-R552) [[3]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R562-R564) [[4]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R577-R582) [[5]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R617-R640) [[6]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R659-R684)
* Registered the new mixin in the OPNsense client class. (`custom_components/opnsense/pyopnsense/client.py`) [[1]](diffhunk://#diff-0a1d503fb6f2802a4f35e5f29252bdb179a48ccd70b89865cf66edafaa325cdfR8) [[2]](diffhunk://#diff-0a1d503fb6f2802a4f35e5f29252bdb179a48ccd70b89865cf66edafaa325cdfR23)

These changes collectively enable robust speedtest monitoring and control for OPNsense users in Home Assistant, with granular configuration and rich sensor data.

Thanks @YaBoiDan
Resolves #75 