### PR TITLE
Refine vnStat Names

### DIFF
--- a/custom_components/opnsense/pyopnsense/vnstat.py
+++ b/custom_components/opnsense/pyopnsense/vnstat.py
@@ -92,15 +92,13 @@ class VnstatMixin(PyOPNsenseClientProtocol):
                 "vnstat_this_month": self._pick_monthly_row(
                     rows_monthly, months_ago=0, current_tz=opnsense_tz
                 ),
-                "vnstat_yesterday_total": self._pick_daily_row(
+                "vnstat_yesterday": self._pick_daily_row(
                     rows_daily, days_ago=1, current_tz=opnsense_tz
                 ),
-                "vnstat_last_month_total": self._pick_monthly_row(
+                "vnstat_last_month": self._pick_monthly_row(
                     rows_monthly, months_ago=1, current_tz=opnsense_tz
                 ),
-                "vnstat_last_hour_total": self._pick_last_hour_row(
-                    rows_hourly, current_tz=opnsense_tz
-                ),
+                "vnstat_last_hour": self._pick_last_hour_row(rows_hourly, current_tz=opnsense_tz),
             }
             metrics: dict[str, dict[str, int | None]] = {}
             for metric_name, metric_row in selected_rows.items():

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -150,9 +150,9 @@ def _vnstat_metric_display_name(metric_name: str) -> str:
     metric_names: dict[str, str] = {
         "vnstat_today": "Today",
         "vnstat_this_month": "This Month",
-        "vnstat_yesterday_total": "Yesterday Total",
-        "vnstat_last_month_total": "Last Month Total",
-        "vnstat_last_hour_total": "Last Hour Total",
+        "vnstat_yesterday": "Yesterday",
+        "vnstat_last_month": "Last Month",
+        "vnstat_last_hour": "Last Hour",
     }
     return metric_names.get(metric_name, metric_name)
 
@@ -209,15 +209,15 @@ async def _compile_vnstat_sensors(
             "state_class": SensorStateClass.TOTAL_INCREASING,
             "icon": "mdi:calendar-month",
         },
-        "vnstat_yesterday_total": {
+        "vnstat_yesterday": {
             "state_class": SensorStateClass.MEASUREMENT,
             "icon": "mdi:calendar-arrow-left",
         },
-        "vnstat_last_month_total": {
+        "vnstat_last_month": {
             "state_class": SensorStateClass.MEASUREMENT,
             "icon": "mdi:calendar-text",
         },
-        "vnstat_last_hour_total": {
+        "vnstat_last_hour": {
             "state_class": SensorStateClass.MEASUREMENT,
             "icon": "mdi:clock-time-four-outline",
         },

--- a/tests/pyopnsense/test_vnstat.py
+++ b/tests/pyopnsense/test_vnstat.py
@@ -121,18 +121,18 @@ async def test_get_vnstat_summary_from_hourly_daily_monthly(make_client) -> None
         assert igc0_metrics["vnstat_today"]["rx_bytes"] == 2 * gib
         assert igc0_metrics["vnstat_today"]["tx_bytes"] == 2 * gib
         assert igc0_metrics["vnstat_this_month"]["total_bytes"] == 8 * gib
-        assert igc0_metrics["vnstat_yesterday_total"]["total_bytes"] == 2 * gib
-        assert igc0_metrics["vnstat_last_month_total"]["total_bytes"] == 6 * gib
-        assert igc0_metrics["vnstat_last_hour_total"]["total_bytes"] == 3 * gib
+        assert igc0_metrics["vnstat_yesterday"]["total_bytes"] == 2 * gib
+        assert igc0_metrics["vnstat_last_month"]["total_bytes"] == 6 * gib
+        assert igc0_metrics["vnstat_last_hour"]["total_bytes"] == 3 * gib
 
         igc1_metrics = vnstat["interfaces"]["igc1"]["metrics"]
         assert igc1_metrics["vnstat_today"]["total_bytes"] == int(1.5 * gib)
         assert igc1_metrics["vnstat_today"]["rx_bytes"] == 1 * gib
         assert igc1_metrics["vnstat_today"]["tx_bytes"] == int(0.5 * gib)
         assert igc1_metrics["vnstat_this_month"]["total_bytes"] == 3 * gib
-        assert igc1_metrics["vnstat_yesterday_total"]["total_bytes"] == 1 * gib
-        assert igc1_metrics["vnstat_last_month_total"]["total_bytes"] == 2 * gib
-        assert igc1_metrics["vnstat_last_hour_total"]["total_bytes"] == int(1.5 * gib)
+        assert igc1_metrics["vnstat_yesterday"]["total_bytes"] == 1 * gib
+        assert igc1_metrics["vnstat_last_month"]["total_bytes"] == 2 * gib
+        assert igc1_metrics["vnstat_last_hour"]["total_bytes"] == int(1.5 * gib)
     finally:
         await client.async_close()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1204,17 +1204,17 @@ async def test_async_setup_entry_creates_vnstat_sensors(make_config_entry):
                             "rx_bytes": 1200,
                             "tx_bytes": 800,
                         },
-                        "vnstat_yesterday_total": {
+                        "vnstat_yesterday": {
                             "total_bytes": 900,
                             "rx_bytes": 600,
                             "tx_bytes": 300,
                         },
-                        "vnstat_last_month_total": {
+                        "vnstat_last_month": {
                             "total_bytes": 1500,
                             "rx_bytes": 800,
                             "tx_bytes": 700,
                         },
-                        "vnstat_last_hour_total": {
+                        "vnstat_last_hour": {
                             "total_bytes": 50,
                             "rx_bytes": 30,
                             "tx_bytes": 20,
@@ -1242,27 +1242,27 @@ async def test_async_setup_entry_creates_vnstat_sensors(make_config_entry):
     assert key_to_entity["vnstat.igc0.vnstat_this_month"].entity_description.state_class is (
         SensorStateClass.TOTAL_INCREASING
     )
-    assert key_to_entity["vnstat.igc0.vnstat_yesterday_total"].entity_description.state_class is (
+    assert key_to_entity["vnstat.igc0.vnstat_yesterday"].entity_description.state_class is (
         SensorStateClass.MEASUREMENT
     )
-    assert key_to_entity["vnstat.igc0.vnstat_last_month_total"].entity_description.state_class is (
+    assert key_to_entity["vnstat.igc0.vnstat_last_month"].entity_description.state_class is (
         SensorStateClass.MEASUREMENT
     )
-    assert key_to_entity["vnstat.igc0.vnstat_last_hour_total"].entity_description.state_class is (
+    assert key_to_entity["vnstat.igc0.vnstat_last_hour"].entity_description.state_class is (
         SensorStateClass.MEASUREMENT
     )
     assert key_to_entity["vnstat.igc0.vnstat_today"].entity_description.name == "vnStat: WAN: Today"
     assert (
-        key_to_entity["vnstat.igc0.vnstat_last_month_total"].entity_description.name
-        == "vnStat: WAN: Last Month Total"
+        key_to_entity["vnstat.igc0.vnstat_last_month"].entity_description.name
+        == "vnStat: WAN: Last Month"
     )
 
     for key in (
         "vnstat.igc0.vnstat_today",
         "vnstat.igc0.vnstat_this_month",
-        "vnstat.igc0.vnstat_yesterday_total",
-        "vnstat.igc0.vnstat_last_month_total",
-        "vnstat.igc0.vnstat_last_hour_total",
+        "vnstat.igc0.vnstat_yesterday",
+        "vnstat.igc0.vnstat_last_month",
+        "vnstat.igc0.vnstat_last_hour",
     ):
         entity = key_to_entity[key]
         entity.hass = MagicMock()
@@ -1276,9 +1276,9 @@ async def test_async_setup_entry_creates_vnstat_sensors(make_config_entry):
     assert today_entity.extra_state_attributes.get("rx_bytes") == 700
     assert today_entity.extra_state_attributes.get("tx_bytes") == 300
     assert key_to_entity["vnstat.igc0.vnstat_this_month"].native_value == 2000
-    assert key_to_entity["vnstat.igc0.vnstat_yesterday_total"].native_value == 900
-    assert key_to_entity["vnstat.igc0.vnstat_last_month_total"].native_value == 1500
-    assert key_to_entity["vnstat.igc0.vnstat_last_hour_total"].native_value == 50
+    assert key_to_entity["vnstat.igc0.vnstat_yesterday"].native_value == 900
+    assert key_to_entity["vnstat.igc0.vnstat_last_month"].native_value == 1500
+    assert key_to_entity["vnstat.igc0.vnstat_last_hour"].native_value == 50
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request standardizes the naming of several vnStat-related metrics and sensors throughout the codebase and updates all corresponding references in logic and tests. The main change is the removal of the `_total` suffix from the metric and sensor keys, making the names more concise and consistent.

**vnStat metric and sensor renaming:**

* Renamed all instances of `vnstat_yesterday_total`, `vnstat_last_month_total`, and `vnstat_last_hour_total` to `vnstat_yesterday`, `vnstat_last_month`, and `vnstat_last_hour` respectively in the main vnStat data retrieval logic (`vnstat.py`), sensor definitions (`sensor.py`), and all related tests. [[1]](diffhunk://#diff-fcc9e13cfcd2bc1711e587d37cef6fbd50cae1c17a9dc5c599dcfc7ce8d06317L95-R101) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L153-R155) [[3]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L212-R220) [[4]](diffhunk://#diff-1d7db45494fcdb7f0b29823a7ac13aa23661dc0806940235c912315453d114c0L124-R135) [[5]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1207-R1217) [[6]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1245-R1265) [[7]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1279-R1281)

**Test updates for new metric names:**

* Updated all test cases to use the new metric names, ensuring assertions and mock data match the renamed keys. [[1]](diffhunk://#diff-1d7db45494fcdb7f0b29823a7ac13aa23661dc0806940235c912315453d114c0L124-R135) [[2]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1207-R1217) [[3]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1245-R1265) [[4]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L1279-R1281)

**Display name and icon adjustments:**

* Adjusted display names and icons in sensor descriptions to match the new, shorter metric names, improving clarity in the UI. [[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L153-R155) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L212-R220)

These changes improve consistency and readability across the codebase, making it easier to maintain and reducing the likelihood of confusion between similar metrics.