### PR TITLE
Simplify plugin check logic

### DIFF
--- a/custom_components/opnsense/pyopnsense/_typing.py
+++ b/custom_components/opnsense/pyopnsense/_typing.py
@@ -14,11 +14,10 @@ class PyOPNsenseClientProtocol(Protocol):
     _firmware_version: str | None
     _installed_plugins: set[str] | None
     _installed_plugins_updated_at: datetime | None
+    _installed_plugins_refresh_succeeded: bool
     _plugin_cache_ttl_seconds: int
     _endpoint_availability: dict[str, bool]
     _endpoint_checked_at: dict[str, datetime]
-    _endpoint_retry_after: dict[str, datetime]
-    _endpoint_failure_count: dict[str, int]
     _endpoint_cache_ttl_seconds: int
 
     @abstractmethod
@@ -306,6 +305,15 @@ class PyOPNsenseClientProtocol(Protocol):
         -------
         bool
             ``True`` when endpoint probe succeeds.
+
+        Notes
+        -----
+        Implementations cache per-endpoint availability using a TTL window.
+        Successful probes and HTTP 404 "not found" probes are cached until TTL
+        expiry.
+        Other probe failures are treated as transient and retried on the next
+        check.
+        ``force_refresh=True`` bypasses cache freshness checks.
 
         """
         ...

--- a/custom_components/opnsense/pyopnsense/client_base.py
+++ b/custom_components/opnsense/pyopnsense/client_base.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import partial
 import inspect
 import json
@@ -15,15 +15,7 @@ import xmlrpc.client
 import aiohttp
 import awesomeversion
 
-from .const import (
-    DEFAULT_ENDPOINT_CACHE_TTL_SECONDS,
-    DEFAULT_ENDPOINT_NEGATIVE_CACHE_SECONDS,
-    DEFAULT_PLUGIN_CACHE_TTL_SECONDS,
-    DEFAULT_TIMEOUT,
-    MAX_ENDPOINT_NEGATIVE_CACHE_SECONDS,
-    MIN_ENDPOINT_CACHE_TTL_SECONDS,
-    MIN_PLUGIN_CACHE_TTL_SECONDS,
-)
+from .const import DEFAULT_CACHE_TTL_SECONDS, DEFAULT_REQUEST_TIMEOUT_SECONDS
 from .exceptions import UnknownFirmware
 from .helpers import _LOGGER, _xmlrpc_timeout
 
@@ -87,24 +79,11 @@ class ClientBaseMixin:
         self._plugin_deprecated: bool | None = None
         self._installed_plugins: set[str] | None = None
         self._installed_plugins_updated_at: datetime | None = None
+        self._installed_plugins_refresh_succeeded: bool = False
         self._endpoint_availability: dict[str, bool] = {}
         self._endpoint_checked_at: dict[str, datetime] = {}
-        self._endpoint_retry_after: dict[str, datetime] = {}
-        self._endpoint_failure_count: dict[str, int] = {}
-        requested_ttl = self._opts.get("plugin_cache_ttl_seconds", DEFAULT_PLUGIN_CACHE_TTL_SECONDS)
-        try:
-            ttl_seconds = int(requested_ttl)
-        except (TypeError, ValueError):
-            ttl_seconds = DEFAULT_PLUGIN_CACHE_TTL_SECONDS
-        self._plugin_cache_ttl_seconds = max(ttl_seconds, MIN_PLUGIN_CACHE_TTL_SECONDS)
-        requested_endpoint_ttl = self._opts.get(
-            "endpoint_cache_ttl_seconds", DEFAULT_ENDPOINT_CACHE_TTL_SECONDS
-        )
-        try:
-            endpoint_ttl_seconds = int(requested_endpoint_ttl)
-        except (TypeError, ValueError):
-            endpoint_ttl_seconds = DEFAULT_ENDPOINT_CACHE_TTL_SECONDS
-        self._endpoint_cache_ttl_seconds = max(endpoint_ttl_seconds, MIN_ENDPOINT_CACHE_TTL_SECONDS)
+        self._plugin_cache_ttl_seconds = DEFAULT_CACHE_TTL_SECONDS
+        self._endpoint_cache_ttl_seconds = DEFAULT_CACHE_TTL_SECONDS
         self._use_snake_case: bool = True
         self._xmlrpc_query_count = 0
         self._rest_api_query_count = 0
@@ -472,7 +451,7 @@ $toreturn["real"] = json_encode($toreturn_real);
             async with self._session.get(
                 url,
                 auth=aiohttp.BasicAuth(self._username, self._password),
-                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+                timeout=aiohttp.ClientTimeout(total=DEFAULT_REQUEST_TIMEOUT_SECONDS),
                 ssl=self._verify_ssl,
             ) as response:
                 _LOGGER.debug(
@@ -625,17 +604,18 @@ $toreturn["real"] = json_encode($toreturn_real);
         Returns
         -------
         float
-            Positive timeout in seconds. Falls back to DEFAULT_TIMEOUT when invalid.
+            Positive timeout in seconds. Falls back to
+            DEFAULT_REQUEST_TIMEOUT_SECONDS when invalid.
 
         """
         if timeout_seconds is None:
-            return float(DEFAULT_TIMEOUT)
+            return float(DEFAULT_REQUEST_TIMEOUT_SECONDS)
         try:
             timeout_total = float(timeout_seconds)
         except (TypeError, ValueError):
-            return float(DEFAULT_TIMEOUT)
+            return float(DEFAULT_REQUEST_TIMEOUT_SECONDS)
         if timeout_total <= 0:
-            return float(DEFAULT_TIMEOUT)
+            return float(DEFAULT_REQUEST_TIMEOUT_SECONDS)
         return timeout_total
 
     async def _safe_dict_get(self, path: str) -> dict[str, Any]:
@@ -730,7 +710,7 @@ $toreturn["real"] = json_encode($toreturn_real);
                 url,
                 json=payload,
                 auth=aiohttp.BasicAuth(self._username, self._password),
-                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+                timeout=aiohttp.ClientTimeout(total=DEFAULT_REQUEST_TIMEOUT_SECONDS),
                 ssl=self._verify_ssl,
             ) as response:
                 _LOGGER.debug("[post] Response %s: %s", response.status, response.reason)
@@ -825,6 +805,18 @@ $toreturn["real"] = json_encode($toreturn_real);
         bool
             ``True`` when endpoint probe succeeded, otherwise ``False``.
 
+        Notes
+        -----
+        Availability is cached per endpoint path in ``self._endpoint_availability`` and
+        timestamped in ``self._endpoint_checked_at``.
+        Cached entries are considered fresh for ``self._endpoint_cache_ttl_seconds``
+        seconds.
+        Successful checks (HTTP 2xx) and definitive "not found" checks (HTTP 404)
+        are cached and returned until TTL expiry.
+        Other HTTP failures (for example 4xx except 404, and 5xx) plus transport
+        exceptions are treated as transient failures and are not cached.
+        ``force_refresh=True`` bypasses cache freshness and probes immediately.
+
         """
         if not isinstance(path, str) or not path:
             return False
@@ -835,14 +827,6 @@ $toreturn["real"] = json_encode($toreturn_real);
             and (now - self._endpoint_checked_at[path]).total_seconds()
             < self._endpoint_cache_ttl_seconds
         )
-        retry_after = self._endpoint_retry_after.get(path)
-        availability = self._endpoint_availability.get(path)
-
-        if not force_refresh and availability is False and isinstance(retry_after, datetime):
-            if retry_after > now:
-                return False
-            # Retry window has elapsed, so probe again even if the TTL cache is still fresh.
-            cache_is_fresh = False
 
         if not force_refresh and cache_is_fresh and path in self._endpoint_availability:
             return self._endpoint_availability[path]
@@ -855,51 +839,38 @@ $toreturn["real"] = json_encode($toreturn_real);
             async with self._session.get(
                 url,
                 auth=aiohttp.BasicAuth(self._username, self._password),
-                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+                timeout=aiohttp.ClientTimeout(total=DEFAULT_REQUEST_TIMEOUT_SECONDS),
                 ssl=self._verify_ssl,
             ) as response:
-                available = bool(response.ok)
-                self._endpoint_availability[path] = available
-                self._endpoint_checked_at[path] = now
-
-                if available:
-                    self._endpoint_failure_count[path] = 0
-                    self._endpoint_retry_after.pop(path, None)
+                if response.ok:
+                    self._endpoint_availability[path] = True
+                    self._endpoint_checked_at[path] = now
                     return True
+                if response.status == 404:
+                    self._endpoint_availability[path] = False
+                    self._endpoint_checked_at[path] = now
+                    return False
 
-                failures = self._endpoint_failure_count.get(path, 0) + 1
-                self._endpoint_failure_count[path] = failures
-                retry_seconds = min(
-                    DEFAULT_ENDPOINT_NEGATIVE_CACHE_SECONDS * (2 ** (failures - 1)),
-                    MAX_ENDPOINT_NEGATIVE_CACHE_SECONDS,
-                )
-                self._endpoint_retry_after[path] = now + timedelta(seconds=retry_seconds)
-
+                self._endpoint_availability.pop(path, None)
+                self._endpoint_checked_at.pop(path, None)
                 if response.status == 403:
                     _LOGGER.error(
                         "Permission Error in is_endpoint_available. Path: %s. Ensure the OPNsense user connected to HA has appropriate access. Recommend full admin access",
                         url,
                     )
                 else:
-                    _LOGGER.debug(
-                        "Endpoint check failed for %s with status %s: %s",
+                    _LOGGER.warning(
+                        "Transient endpoint check failure for %s. Response %s: %s. Not caching result.",
                         path,
                         response.status,
                         response.reason,
                     )
                 return False
         except (aiohttp.ClientError, TimeoutError) as e:
-            failures = self._endpoint_failure_count.get(path, 0) + 1
-            self._endpoint_failure_count[path] = failures
-            retry_seconds = min(
-                DEFAULT_ENDPOINT_NEGATIVE_CACHE_SECONDS * (2 ** (failures - 1)),
-                MAX_ENDPOINT_NEGATIVE_CACHE_SECONDS,
-            )
-            self._endpoint_retry_after[path] = now + timedelta(seconds=retry_seconds)
-            self._endpoint_availability[path] = False
-            self._endpoint_checked_at[path] = now
+            self._endpoint_availability.pop(path, None)
+            self._endpoint_checked_at.pop(path, None)
             _LOGGER.warning(
-                "Endpoint availability check failed for %s. %s: %s",
+                "Endpoint availability check failed for %s. %s: %s. Not caching result.",
                 path,
                 type(e).__name__,
                 e,

--- a/custom_components/opnsense/pyopnsense/const.py
+++ b/custom_components/opnsense/pyopnsense/const.py
@@ -4,14 +4,12 @@ from typing import Any
 
 from dateutil.tz import gettz
 
-DEFAULT_TIMEOUT = 60
-DEFAULT_PLUGIN_CACHE_TTL_SECONDS = 6 * 60 * 60
-MIN_PLUGIN_CACHE_TTL_SECONDS = 60
-DEFAULT_ENDPOINT_CACHE_TTL_SECONDS = 60 * 60
-MIN_ENDPOINT_CACHE_TTL_SECONDS = 30
-DEFAULT_ENDPOINT_NEGATIVE_CACHE_SECONDS = 5 * 60
-MAX_ENDPOINT_NEGATIVE_CACHE_SECONDS = 60 * 60
+# Default timeout, in seconds, for HTTP/XMLRPC requests.
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
+# Shared cache time-to-live, in seconds, for plugin and endpoint availability state.
+DEFAULT_CACHE_TTL_SECONDS = 6 * 60 * 60
 
+# Mapping of ambiguous timezone abbreviations to explicit IANA timezones.
 AMBIGUOUS_TZINFOS: dict[str, Any] = {
     "ACST": gettz("Australia/Darwin"),  # Australian Central Standard Time
     "ACT": gettz("America/Rio_Branco"),  # Acre Time (Brazil)

--- a/custom_components/opnsense/pyopnsense/dhcp.py
+++ b/custom_components/opnsense/pyopnsense/dhcp.py
@@ -321,7 +321,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
         """
         if not await self.is_endpoint_available("/api/dhcpv4/service/status"):
-            _LOGGER.debug("ISC DHCPv4 endpoint unavailable, skipping lease retrieval")
+            _LOGGER.debug("ISC DHCP not installed")
             return []
         if self._use_snake_case:
             response = await self._safe_dict_get("/api/dhcpv4/leases/search_lease")
@@ -386,7 +386,7 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
         """
         if not await self.is_endpoint_available("/api/dhcpv6/service/status"):
-            _LOGGER.debug("ISC DHCPv6 endpoint unavailable, skipping lease retrieval")
+            _LOGGER.debug("ISC DHCP not installed")
             return []
         if self._use_snake_case:
             response = await self._safe_dict_get("/api/dhcpv6/leases/search_lease")

--- a/custom_components/opnsense/pyopnsense/firmware.py
+++ b/custom_components/opnsense/pyopnsense/firmware.py
@@ -19,6 +19,7 @@ class FirmwareMixin(PyOPNsenseClientProtocol):
     _plugin_deprecated: bool | None
     _installed_plugins: set[str] | None
     _installed_plugins_updated_at: datetime | None
+    _installed_plugins_refresh_succeeded: bool
     _plugin_cache_ttl_seconds: int
 
     async def _store_host_firmware_version(self) -> None:
@@ -53,16 +54,30 @@ class FirmwareMixin(PyOPNsenseClientProtocol):
         return self._firmware_version
 
     async def _refresh_installed_plugins(self, force: bool = False) -> None:
-        """Refresh the cached set of installed plugin package names.
+        """Refresh cached installed plugin package names from firmware metadata.
+
+        This method reads ``/api/core/firmware/info`` and rebuilds
+        ``self._installed_plugins`` with package names whose ``installed`` flag
+        equals ``"1"``. Cache refreshes are skipped while cached plugin data is
+        still fresh according to ``self._plugin_cache_ttl_seconds``, unless
+        ``force`` is ``True``.
+        TTL cache reuse only applies after a successful refresh. If the refresh
+        attempt fails (for example missing/invalid payload), the previous cache
+        is retained and the next call retries immediately.
 
         Parameters
         ----------
         force : bool
-            Whether to bypass TTL freshness checks and always refresh.
+            Whether to bypass TTL freshness checks and force a refresh attempt.
+
+        Returns
+        -------
+        None
 
         """
         if (
             not force
+            and self._installed_plugins_refresh_succeeded
             and self._installed_plugins is not None
             and self._installed_plugins_updated_at is not None
             and (datetime.now().astimezone() - self._installed_plugins_updated_at).total_seconds()
@@ -72,12 +87,14 @@ class FirmwareMixin(PyOPNsenseClientProtocol):
 
         firmware_info = await self._safe_dict_get("/api/core/firmware/info")
         if not firmware_info:
+            self._installed_plugins_refresh_succeeded = False
             return
 
         package_list = (
             firmware_info.get("package") if isinstance(firmware_info, MutableMapping) else None
         )
         if not isinstance(package_list, list):
+            self._installed_plugins_refresh_succeeded = False
             return
 
         now = datetime.now().astimezone()
@@ -92,6 +109,7 @@ class FirmwareMixin(PyOPNsenseClientProtocol):
                 installed_plugins.add(name)
         self._installed_plugins = installed_plugins
         self._installed_plugins_updated_at = now
+        self._installed_plugins_refresh_succeeded = True
 
     async def is_plugin_installed(self) -> bool:
         """Return whether the Home Assistant OPNsense plugin is installed.

--- a/custom_components/opnsense/pyopnsense/helpers.py
+++ b/custom_components/opnsense/pyopnsense/helpers.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
 
-from .const import DEFAULT_TIMEOUT
+from .const import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def _xmlrpc_timeout(func: Callable) -> Any:
 
     async def inner(self: Any, *args: Any, **kwargs: Any) -> Any:
         """Execute wrapped coroutine with a per-call asyncio timeout window."""
-        return await asyncio.wait_for(func(self, *args, **kwargs), DEFAULT_TIMEOUT)
+        return await asyncio.wait_for(func(self, *args, **kwargs), DEFAULT_REQUEST_TIMEOUT_SECONDS)
 
     return inner
 

--- a/custom_components/opnsense/pyopnsense/speedtest.py
+++ b/custom_components/opnsense/pyopnsense/speedtest.py
@@ -35,10 +35,7 @@ class SpeedtestMixin(PyOPNsenseClientProtocol):
 
         """
         if not await self.is_endpoint_available("/api/speedtest/service/showrecent"):
-            _LOGGER.debug("Speedtest recent endpoint unavailable, skipping speedtest retrieval")
-            return {"available": False}
-        if not await self.is_endpoint_available("/api/speedtest/service/showstat"):
-            _LOGGER.debug("Speedtest stat endpoint unavailable, skipping speedtest retrieval")
+            _LOGGER.debug("Speedtest not installed")
             return {"available": False}
 
         show_recent = await self._safe_dict_get("/api/speedtest/service/showrecent")
@@ -120,8 +117,8 @@ class SpeedtestMixin(PyOPNsenseClientProtocol):
             Raw speedtest run result payload. Empty dictionary when unavailable.
 
         """
-        if not await self.is_endpoint_available("/api/speedtest/service/run"):
-            _LOGGER.debug("Speedtest run endpoint unavailable, skipping speedtest action")
+        if not await self.is_endpoint_available("/api/speedtest/service/showrecent"):
+            _LOGGER.debug("Speedtest not installed")
             return {}
 
         response = await self._safe_dict_get_with_timeout(

--- a/tests/pyopnsense/test_client_base.py
+++ b/tests/pyopnsense/test_client_base.py
@@ -92,6 +92,29 @@ async def test_safe_dict_get_with_timeout(monkeypatch, make_client) -> None:
         await client.async_close()
 
 
+@pytest.mark.parametrize(
+    ("timeout_seconds", "expected"),
+    [
+        ("bad", float(pyopnsense_client_base.DEFAULT_REQUEST_TIMEOUT_SECONDS)),
+        (object(), float(pyopnsense_client_base.DEFAULT_REQUEST_TIMEOUT_SECONDS)),
+        (0, float(pyopnsense_client_base.DEFAULT_REQUEST_TIMEOUT_SECONDS)),
+        (-5, float(pyopnsense_client_base.DEFAULT_REQUEST_TIMEOUT_SECONDS)),
+        (1.75, 1.75),
+    ],
+)
+@pytest.mark.asyncio
+async def test_normalize_timeout_seconds(
+    timeout_seconds: Any, expected: float, make_client
+) -> None:
+    """_normalize_timeout_seconds should coerce invalid values to the default timeout."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        assert client._normalize_timeout_seconds(timeout_seconds) == expected
+    finally:
+        await client.async_close()
+
+
 @pytest.mark.asyncio
 async def test_is_endpoint_available_caches_success(make_client) -> None:
     """Endpoint probe should cache positive results and avoid repeated calls."""
@@ -126,8 +149,8 @@ async def test_is_endpoint_available_caches_success(make_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_is_endpoint_available_negative_cache_and_force_refresh(make_client) -> None:
-    """Endpoint probe should negative-cache failures unless force refreshed."""
+async def test_is_endpoint_available_cache_false_by_ttl_and_force_refresh(make_client) -> None:
+    """Endpoint probe should cache False results until TTL expiry or force refresh."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
     calls = 0
@@ -155,9 +178,12 @@ async def test_is_endpoint_available_negative_cache_and_force_refresh(make_clien
     try:
         path = "/api/test/endpoint"
         assert await client.is_endpoint_available(path) is False
-        # Keep _endpoint_checked_at recent but expire _endpoint_retry_after to force a re-probe.
+        assert await client.is_endpoint_available(path) is False
+        assert calls == 1
         assert path in client._endpoint_checked_at
-        client._endpoint_retry_after[path] = datetime.now().astimezone() - timedelta(seconds=1)
+        client._endpoint_checked_at[path] = datetime.now().astimezone() - timedelta(
+            seconds=client._endpoint_cache_ttl_seconds + 1
+        )
         assert await client.is_endpoint_available(path) is True
         assert calls == 2
         assert await client.is_endpoint_available(path) is True
@@ -170,7 +196,7 @@ async def test_is_endpoint_available_negative_cache_and_force_refresh(make_clien
 
 @pytest.mark.asyncio
 async def test_is_endpoint_available_handles_timeout(make_client) -> None:
-    """Endpoint probe should return False and cache timeout failures."""
+    """Endpoint probe should return False and retry after timeout failures."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
     calls = 0
@@ -184,7 +210,43 @@ async def test_is_endpoint_available_handles_timeout(make_client) -> None:
     try:
         assert await client.is_endpoint_available("/api/test/endpoint") is False
         assert await client.is_endpoint_available("/api/test/endpoint") is False
-        assert calls == 1
+        assert calls == 2
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_is_endpoint_available_does_not_cache_non_404_http_errors(make_client) -> None:
+    """Endpoint probe should retry when non-404 HTTP status codes are returned."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    calls = 0
+
+    class FakeResp:
+        def __init__(self, status: int, ok: bool) -> None:
+            self.status = status
+            self.reason = "ERR"
+            self.ok = ok
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def _get(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return FakeResp(status=500, ok=False)
+
+    session.get = _get
+    try:
+        path = "/api/test/endpoint"
+        assert await client.is_endpoint_available(path) is False
+        assert await client.is_endpoint_available(path) is False
+        assert calls == 2
+        assert path not in client._endpoint_checked_at
+        assert path not in client._endpoint_availability
     finally:
         await client.async_close()
 

--- a/tests/pyopnsense/test_firmware.py
+++ b/tests/pyopnsense/test_firmware.py
@@ -139,6 +139,35 @@ async def test_plugin_cache_not_poisoned_by_empty_firmware_info(make_client) -> 
 
 
 @pytest.mark.asyncio
+async def test_plugin_cache_retries_after_failed_forced_refresh(make_client) -> None:
+    """Failed refresh attempts should be retried on the next plugin check."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {"package": [{"name": "os-vnstat", "installed": "1"}]},
+                {},
+                {"package": [{"name": "os-vnstat", "installed": "1"}]},
+            ]
+        )
+        assert await client.is_named_plugin_installed("os-vnstat") is True
+        assert client._installed_plugins_refresh_succeeded is True
+
+        # Force a refresh attempt that fails to mark cache as retry-required.
+        await client._refresh_installed_plugins(force=True)
+        assert client._installed_plugins_refresh_succeeded is False
+
+        # Next call should retry immediately even though the last successful
+        # timestamp is still recent.
+        assert await client.is_named_plugin_installed("os-vnstat") is True
+        assert client._safe_dict_get.await_count == 3
+        assert client._installed_plugins_refresh_succeeded is True
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
 async def test_get_firmware_update_info_triggers_check_on_conditions(make_client) -> None:
     """Trigger firmware update check when status is missing data or outdated."""
     session = MagicMock(spec=aiohttp.ClientSession)

--- a/tests/pyopnsense/test_helpers.py
+++ b/tests/pyopnsense/test_helpers.py
@@ -174,8 +174,8 @@ async def test_log_errors_server_timeout_re_raise_and_suppress() -> None:
 
 @pytest.mark.asyncio
 async def test_xmlrpc_timeout_uses_per_call_asyncio_timeout(monkeypatch) -> None:
-    """_xmlrpc_timeout should use asyncio.wait_for with DEFAULT_TIMEOUT."""
-    monkeypatch.setattr(pyopnsense_helpers, "DEFAULT_TIMEOUT", 0.01)
+    """_xmlrpc_timeout should use asyncio.wait_for with DEFAULT_REQUEST_TIMEOUT_SECONDS."""
+    monkeypatch.setattr(pyopnsense_helpers, "DEFAULT_REQUEST_TIMEOUT_SECONDS", 0.01)
 
     @pyopnsense_helpers._xmlrpc_timeout
     async def fast_func(self):

--- a/tests/pyopnsense/test_speedtest.py
+++ b/tests/pyopnsense/test_speedtest.py
@@ -68,19 +68,26 @@ async def test_get_speedtest_normalizes_recent_and_stat_payloads(make_client) ->
 
 
 @pytest.mark.asyncio
-async def test_get_speedtest_skips_calls_when_showstat_endpoint_missing(make_client) -> None:
-    """get_speedtest should stop when showstat endpoint is unavailable."""
+async def test_get_speedtest_fetches_showstat_without_endpoint_probe(make_client) -> None:
+    """get_speedtest should only probe showrecent and then fetch both payloads."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
     try:
-        client.is_endpoint_available = AsyncMock(side_effect=[True, False])
-        client._safe_dict_get = AsyncMock()
+        client.is_endpoint_available = AsyncMock(return_value=True)
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {"download": "1", "upload": "2", "latency": "3"},
+                {},
+            ]
+        )
 
         result = await client.get_speedtest()
 
-        assert result == {"available": False}
-        client._safe_dict_get.assert_not_awaited()
+        assert result["available"] is True
         assert client.is_endpoint_available.await_args_list == [
+            call("/api/speedtest/service/showrecent")
+        ]
+        assert client._safe_dict_get.await_args_list == [
             call("/api/speedtest/service/showrecent"),
             call("/api/speedtest/service/showstat"),
         ]
@@ -185,7 +192,7 @@ async def test_run_speedtest_returns_empty_when_endpoint_missing(make_client) ->
 
         assert result == {}
         client._safe_dict_get_with_timeout.assert_not_awaited()
-        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/run")
+        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/showrecent")
     finally:
         await client.async_close()
 
@@ -202,7 +209,7 @@ async def test_run_speedtest_returns_empty_for_non_mapping_response(make_client)
         result = await client.run_speedtest()
 
         assert result == {}
-        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/run")
+        client.is_endpoint_available.assert_awaited_once_with("/api/speedtest/service/showrecent")
         client._safe_dict_get_with_timeout.assert_awaited_once_with(
             "/api/speedtest/service/run", timeout_seconds=180
         )


### PR DESCRIPTION
This pull request refactors and simplifies the caching and timeout logic for endpoint and plugin availability checks in the `pyopnsense` integration. It unifies cache TTL and timeout settings, removes complex negative caching and retry logic for endpoints, and improves documentation and reliability of cache refreshes. The changes also update log messages for clarity and add more robust tests for timeout normalization.

**Caching and Timeout Refactoring:**

- Unified cache TTL and request timeout settings by introducing `DEFAULT_CACHE_TTL_SECONDS` and `DEFAULT_REQUEST_TIMEOUT_SECONDS`, replacing multiple previous constants. All cache and timeout logic now uses these shared values. [[1]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L18-R18) [[2]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R82-R86) [[3]](diffhunk://#diff-faa70941bfe51e6b5bcedfdda05101b0a3a4fa832bb665ebc79dd540653b7381L7-R12) [[4]](diffhunk://#diff-deda83701777dd97975ebad6b69381106c3a0a876f4af946095613a93f2632dfL15-R15) [[5]](diffhunk://#diff-deda83701777dd97975ebad6b69381106c3a0a876f4af946095613a93f2632dfL83-R83)
- Removed negative caching and exponential backoff retry logic for endpoint availability checks. Now, only successful (2xx) and 404 responses are cached; all other failures are treated as transient and not cached. [[1]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66R17-L21) [[2]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R82-R86) [[3]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L838-L845) [[4]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L858-R873)
- Updated all HTTP request timeouts to use the new default request timeout constant. [[1]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L475-R454) [[2]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L733-R713) [[3]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L628-R618)

**Plugin and Endpoint Availability Improvements:**

- Improved plugin cache refresh logic: cache is only considered fresh after a successful refresh, and failures no longer update the cache timestamp. Added `_installed_plugins_refresh_succeeded` flag to track refresh status. [[1]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6R22) [[2]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6L56-R80) [[3]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6R90-R97) [[4]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6R112) [[5]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66R17-L21)
- Enhanced and clarified docstrings for endpoint and plugin availability methods, explaining new caching behavior. [[1]](diffhunk://#diff-b80999f077f26f5df7651e78972aed6a188b9ffa22d36c5d85d655cb995dcd66R309-R317) [[2]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28R808-R819) [[3]](diffhunk://#diff-86889f44916cf9adafa74a8d0b623e58fdaae7dea7bf79336dc1c9fa1f01c7b6L56-R80)

**Logging and Error Handling:**

- Updated log messages for endpoint and plugin checks to be more informative and consistent, especially when features are not installed or endpoints are unavailable. [[1]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L324-R324) [[2]](diffhunk://#diff-87cfa8f573c7ebd0b235dfe4eb9c4db9604cc81bd0004dfdcba3252c85242598L389-R389) [[3]](diffhunk://#diff-1c950592b69bbc30f13de85877365867b6e354c9aff0a986803ba818065f2899L38-R38) [[4]](diffhunk://#diff-1c950592b69bbc30f13de85877365867b6e354c9aff0a986803ba818065f2899L123-R121)

**Testing Improvements:**

- Added parameterized tests for `_normalize_timeout_seconds` to ensure invalid or edge-case values are handled correctly and default to the new timeout constant.

These changes make the codebase easier to maintain, more predictable in its caching behavior, and more robust in handling transient failures.