### PR TITLE
Bump recommended OPNsense firmware to 26.1+

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
-name: "Pull Request Labeler"
+name: 'Pull Request Labeler'
 on:
-    pull_request_target:
+  pull_request_target:
 
 jobs:
   labeler:
@@ -9,7 +9,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - name: Pull Request Labeler
-      uses: srvaroa/labeler@v1.14.0
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Pull Request Labeler
+        uses: srvaroa/labeler@v1.14.0
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
 
       - name: Debug GitHub Variables
         run: |
-            echo "github.event_name: ${{ github.event_name }}"
-            echo "github.ref_name: ${{ github.ref_name }}"
-            echo "github.event.release.tag_name: ${{ github.event.release.tag_name }}"
-            echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
-            echo "github.event.release.target_commitish: ${{ github.event.release.target_commitish }}"
-            echo "github.event.release.prerelease: ${{ github.event.release.prerelease }}"
-            echo "github.event.release.draft: ${{ github.event.release.draft }}"
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.event.release.tag_name: ${{ github.event.release.tag_name }}"
+          echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
+          echo "github.event.release.target_commitish: ${{ github.event.release.target_commitish }}"
+          echo "github.event.release.prerelease: ${{ github.event.release.prerelease }}"
+          echo "github.event.release.draft: ${{ github.event.release.draft }}"
 
       - name: Update Version in Manifest
         if: ${{ github.event_name == 'release' && github.event.release.draft == false }}
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo "Updating release with tag: ${{ github.event.release.tag_name }}"
           gh release edit ${{ github.event.release.tag_name }} \
-          --notes "<h3>OPNsense Minimum Firmware Required: ${{ env.OPNSENSE_MIN_FIRMWARE }}</h3><h4>OPNsense Recommended Firmware: ${{ env.OPNSENSE_LTD_FIRMWARE }}</h4><p>$(gh release view ${{ github.event.release.tag_name }} --json body -q .body)<p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i>"
+          --notes "<h3>OPNsense Minimum Firmware Required: ${{ env.OPNSENSE_MIN_FIRMWARE }}</h3><h4>OPNsense Recommended Firmware: ${{ env.OPNSENSE_LTD_FIRMWARE }}+</h4><p>$(gh release view ${{ github.event.release.tag_name }} --json body -q .body)<p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -11,7 +11,7 @@ from homeassistant.const import PERCENTAGE, Platform, UnitOfInformation, UnitOfT
 
 VERSION = "v0.6.2"
 DOMAIN = "opnsense"
-OPNSENSE_LTD_FIRMWARE = "25.1"  # If less than this, some functions may not work but the integration in general should work. Show repair warning.
+OPNSENSE_LTD_FIRMWARE = "26.1"  # If less than this, some functions may not work but the integration in general should work. Show repair warning.
 OPNSENSE_MIN_FIRMWARE = "24.7"  # If less than this, don't allow install. It will not work.
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"


### PR DESCRIPTION
This pull request includes minor updates to configuration and documentation for the OPNsense integration, as well as some formatting consistency improvements. The most significant change is the update of the recommended minimum firmware version for OPNsense, which is now reflected in both the code and release notes.

**OPNsense firmware requirements:**

* Updated the recommended minimum OPNsense firmware version from `25.1` to `26.1` in `const.py`, which affects user warnings and guidance.
* Updated the release notes template in the GitHub Actions workflow to display the new recommended firmware version with a `+` sign, indicating "26.1 or newer" is recommended.

**Workflow and formatting improvements:**

* Changed double quotes to single quotes in the `name` field of `.github/workflows/labeler.yml` for consistency.
* Updated the indentation and quoting style for the `GITHUB_TOKEN` environment variable in the labeler workflow for improved YAML formatting.