### PR TITLE
Handle if DHCP endpoints are unavailable

### DIFF
--- a/custom_components/opnsense/pyopnsense/dhcp.py
+++ b/custom_components/opnsense/pyopnsense/dhcp.py
@@ -135,6 +135,9 @@ class DHCPMixin(PyOPNsenseClientProtocol):
 
 
         """
+        if not await self.is_endpoint_available("/api/kea/leases4/search"):
+            _LOGGER.debug("Kea DHCP not installed")
+            return []
         response = await self._safe_dict_get("/api/kea/leases4/search")
         if not isinstance(response.get("rows", None), list):
             return []
@@ -257,6 +260,10 @@ class DHCPMixin(PyOPNsenseClientProtocol):
                 return []
         except (awesomeversion.exceptions.AwesomeVersionCompareException, TypeError, ValueError):
             pass
+
+        if not await self.is_endpoint_available("/api/dnsmasq/leases/search"):
+            _LOGGER.debug("Dnsmasq DHCP not installed")
+            return []
 
         response = await self._safe_dict_get("/api/dnsmasq/leases/search")
         leases_info: list = response.get("rows", [])


### PR DESCRIPTION
This pull request adds checks to ensure that the relevant DHCP API endpoints are available before attempting to fetch DHCP lease data. If the endpoints are not available (indicating that the corresponding DHCP service is not installed), the code now logs a debug message and returns an empty list, improving error handling and robustness.

Improvements to DHCP lease retrieval:

* Added a check in `_get_kea_dhcpv4_leases` to verify the availability of the `/api/kea/leases4/search` endpoint before making a request, logging a debug message and returning an empty list if the endpoint is unavailable.
* Added a similar check in `_get_dnsmasq_leases` for the `/api/dnsmasq/leases/search` endpoint, with corresponding debug logging and early return if the endpoint is missing.

Fixes #532 