### PR TITLE
Bump minimum Firmware to 25.1

### DIFF
--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -12,7 +12,7 @@ from homeassistant.const import PERCENTAGE, Platform, UnitOfInformation, UnitOfT
 VERSION = "v0.6.3"
 DOMAIN = "opnsense"
 OPNSENSE_LTD_FIRMWARE = "26.1"  # If less than this, some functions may not work but the integration in general should work. Show repair warning.
-OPNSENSE_MIN_FIRMWARE = "24.7"  # If less than this, don't allow install. It will not work.
+OPNSENSE_MIN_FIRMWARE = "25.1"  # If less than this, don't allow install. It will not work.
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"
 

--- a/custom_components/opnsense/pyopnsense/dhcp.py
+++ b/custom_components/opnsense/pyopnsense/dhcp.py
@@ -216,9 +216,6 @@ class DHCPMixin(PyOPNsenseClientProtocol):
         firmware = await self.get_host_firmware_version()
 
         try:
-            if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.1"):
-                _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1")
-                return []
             if awesomeversion.AwesomeVersion(firmware) < awesomeversion.AwesomeVersion("25.1.7"):
                 _LOGGER.debug("Skipping get_dnsmasq_leases for OPNsense < 25.1.7")
                 return []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -514,7 +514,7 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
     monkeypatch, ph_hass, coordinator_capture, fake_client, fake_coordinator, make_config_entry
 ):
     """async_setup_entry logs a warning issue for firmware between min and LTD but continues."""
-    patch_client_factory(monkeypatch, init_mod, fake_client(firmware_version="25.0"))
+    patch_client_factory(monkeypatch, init_mod, fake_client(firmware_version="25.1"))
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
     )
@@ -1501,7 +1501,7 @@ async def test_async_setup_entry_delete_not_called_for_between_min_and_ltd(
     monkeypatch, ph_hass, coordinator_capture, fake_client, fake_coordinator, make_config_entry
 ):
     """async_setup_entry should not call delete_issue for firmware between min and LTD."""
-    patch_client_factory(monkeypatch, init_mod, fake_client(firmware_version="25.0"))
+    patch_client_factory(monkeypatch, init_mod, fake_client(firmware_version="25.1"))
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
     )


### PR DESCRIPTION
This pull request updates the minimum supported OPNsense firmware version from 24.7 to 25.1 across the integration and test suite. It also adjusts logic and tests to align with this new minimum version, ensuring consistent behavior and compatibility checks.

**Minimum firmware version update:**

* Increased `OPNSENSE_MIN_FIRMWARE` from `"24.7"` to `"25.1"` in `const.py`, so the integration will not install on firmware versions below 25.1.

**Logic adjustments for firmware checks:**

* Removed the check for firmware `< 25.1` in `_get_dnsmasq_leases` (now only checks for `< 25.1.7`), since versions below 25.1 are no longer supported.

**Test updates:**

* Updated test cases in `test_async_setup_entry_firmware_between_min_and_ltd` and `test_async_setup_entry_delete_not_called_for_between_min_and_ltd` to use firmware version `"25.1"` instead of `"25.0"`, reflecting the new minimum version. [[1]](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eL517-R517) [[2]](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eL1504-R1504)