### PR TITLE
Show aiopnsense version at startup

### DIFF
--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Mapping, MutableMapping
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version as package_version
 import logging
 from typing import Any
 
@@ -15,11 +16,32 @@ from .client_protocol import OPNsenseClientProtocol
 from .pyopnsense import OPNsenseClient as LegacyOPNsenseClient
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-AI_OPNSENSE_MIN_FIRMWARE = "26.1.1"
+AIOPNSENSE_MIN_FIRMWARE = "26.1.1"
 
 
 class MissingExternalAiopnsenseDependency(ImportError):
     """Raised when external ``aiopnsense`` is required but unavailable."""
+
+
+async def _get_external_aiopnsense_version() -> str | None:
+    """Resolve installed external aiopnsense version in a non-blocking way.
+
+    Returns:
+        str | None: aiopnsense package version string when available, else `None`.
+    """
+    try:
+        external_module = await asyncio.to_thread(import_module, "aiopnsense")
+    except ImportError:
+        return None
+
+    module_version: Any = getattr(external_module, "__version__", None)
+    if isinstance(module_version, str) and module_version.strip():
+        return module_version.strip()
+
+    try:
+        return await asyncio.to_thread(package_version, "aiopnsense")
+    except PackageNotFoundError:
+        return None
 
 
 def _build_client_kwargs(
@@ -352,18 +374,27 @@ async def create_opnsense_client(
             await probe_client.async_close()
         finally:
             raise
-    _LOGGER.debug("Client factory detected firmware: %s", firmware)
+    # _LOGGER.debug("Client factory detected firmware: %s", firmware)
 
     try:
         if awesomeversion.AwesomeVersion(firmware) >= awesomeversion.AwesomeVersion(
-            AI_OPNSENSE_MIN_FIRMWARE
+            AIOPNSENSE_MIN_FIRMWARE
         ):
             await probe_client.async_close()
-            _LOGGER.debug(
-                "Using external aiopnsense backend for firmware >= %s",
-                AI_OPNSENSE_MIN_FIRMWARE,
-            )
-            return await _create_external_client(**kwargs)
+            client = await _create_external_client(**kwargs)
+            aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+            if aiopnsense_version:
+                _LOGGER.info(
+                    "Using aiopnsense %s for firmware >= %s",
+                    aiopnsense_version,
+                    AIOPNSENSE_MIN_FIRMWARE,
+                )
+            else:
+                _LOGGER.info(
+                    "Using aiopnsense for firmware >= %s",
+                    AIOPNSENSE_MIN_FIRMWARE,
+                )
+            return client
     except awesomeversion.exceptions.AwesomeVersionCompareException, TypeError, ValueError:
         _LOGGER.debug(
             "Unable to compare firmware '%s' in client factory. Falling back to legacy backend.",

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -308,6 +309,45 @@ async def test_create_client_uses_external_for_new_firmware(
     assert "name" not in client.kwargs
     assert "initial" not in client.kwargs
     assert await client.get_query_counts() == (5, 0)
+
+
+@pytest.mark.asyncio
+async def test_create_client_logs_external_version_for_new_firmware(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Factory should log external aiopnsense version when routing to external backend."""
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return new firmware so factory selects external backend."""
+            return "26.3"
+
+        async def async_close(self) -> None:
+            """Provide cleanup hook expected by factory code paths."""
+            return
+
+    class _ExternalClient:
+        pass
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+    monkeypatch.setattr(
+        factory_mod, "_get_external_aiopnsense_version", AsyncMock(return_value="1.0.2")
+    )
+
+    caplog.set_level("INFO")
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password="p",
+        session=SimpleNamespace(),
+        opts={"verify_ssl": True},
+    )
+
+    assert isinstance(client, _ExternalClient)
+    assert "Using aiopnsense 1.0.2 for firmware >= 26.1.1" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request enhances the OPNsense client factory by improving how the external `aiopnsense` backend is detected and logged, especially for newer firmware versions. It introduces a non-blocking method to retrieve the installed `aiopnsense` package version and updates logging to provide clearer information about which backend is being used. Additionally, a new test ensures that the version logging works as intended.

**Enhancements to external backend detection and logging:**

* Added an asynchronous function `_get_external_aiopnsense_version` that non-blockingly resolves the installed version of the `aiopnsense` package, improving efficiency and reliability when checking for external backend availability. [[1]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64R8) [[2]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64L18-R46)
* Updated the client factory logic to log the detected `aiopnsense` version (if available) when routing to the external backend for firmware versions >= `26.1.1`, providing clearer operational transparency.

**Testing improvements:**

* Added a test `test_create_client_logs_external_version_for_new_firmware` to verify that the correct version information is logged when the external backend is selected, ensuring this feature works as intended.

**Minor fixes:**

* Fixed a typo in the minimum firmware constant name (`AI_OPNSENSE_MIN_FIRMWARE` → `AIOPNSENSE_MIN_FIRMWARE`) for consistency. [[1]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64L18-R46) [[2]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64L355-R397)
* Added missing import for `AsyncMock` in the test suite to support asynchronous mocking.