### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Join `OPNsense` with `Home Assistant`!
 
 **With OPNsense Firmware 26.1.1+, a plugin is no longer needed on the OPNsense Router.**
 
+For OPNsense Firmware 26.1.1+, `hass-opnsense` uses [`aiopnsense`](https://pypi.org/project/aiopnsense/) as its backend client library.
+Source and releases for `aiopnsense`:
+
+* PyPI: <https://pypi.org/project/aiopnsense/>
+* GitHub: <https://github.com/Snuffy2/aiopnsense>
+
+For OPNsense Firmware < 26.1.1, the legacy, built-in `pyopnsense` path remains in place for compatibility.
 
 A Discord server to discuss the integration is available, please click the Discord badge at the beginning of the page for the invite link.
 


### PR DESCRIPTION
This pull request updates the documentation to clarify backend library usage for different OPNsense firmware versions. It specifies that `hass-opnsense` now uses `aiopnsense` for firmware 26.1.1 and above, while maintaining compatibility with older versions via the legacy `pyopnsense` path.

Backend library update documentation:

* Updated the `README.md` to state that `hass-opnsense` uses the `aiopnsense` library as its backend for OPNsense firmware 26.1.1 and newer, and provided links to its PyPI and GitHub pages.
* Clarified that the legacy `pyopnsense` path is retained for firmware versions below 26.1.1 to ensure backward compatibility.