### PR TITLE
Update release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update_version_and_create_zip:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -41,11 +43,10 @@ jobs:
 
       - name: Commit & Push Version Changes
         if: ${{ github.event_name == 'release' && github.event.release.draft == false && github.event.release.prerelease == false  }}
-        uses: actions-js/push@master
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.release.target_commitish }}
-          message: 'Updating to version ${{ github.event.release.tag_name }} [skip ci]'
+          commit_message: 'Updating to version ${{ github.event.release.tag_name }} [skip ci]'
 
       - name: Update Release with Version Changes Commit
         if: ${{ github.event_name == 'release' && github.event.release.draft == false && github.event.release.prerelease == false  }}


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to improve permissions management and the process for committing version changes. The most important changes are:

**Workflow Permissions and Security:**

* Added explicit `contents: write` permissions to the `update_version_and_create_zip` job to ensure the workflow has the necessary access to push changes to the repository.

**Commit and Push Process:**

* Switched from using `actions-js/push@master` to `stefanzweifel/git-auto-commit-action@v7` for committing and pushing version changes, which is a more robust and widely used action for automating git commits in workflows.
* Updated the input for the commit step to use `commit_message` instead of `message`, aligning with the new action's input requirements.