### PR TITLE
Fix CARP Sensors

### DIFF
--- a/.github/workflows/update_aiopnsense_manifest.yml
+++ b/.github/workflows/update_aiopnsense_manifest.yml
@@ -76,7 +76,7 @@ jobs:
           jq --arg latest "$latest_version" '
             .requirements |= map(
               if startswith("aiopnsense")
-              then "aiopnsense>=" + $latest
+              then "aiopnsense==" + $latest
               else .
               end
             )
@@ -177,14 +177,14 @@ jobs:
         with:
           branch: chore/update-aiopnsense-manifest
           delete-branch: true
-          commit-message: 'chore(deps): bump aiopnsense to >=${{ steps.versions.outputs.latest }}'
-          title: 'chore(deps): bump aiopnsense to >=${{ steps.versions.outputs.latest }}'
+          commit-message: 'chore(deps): bump aiopnsense to ==${{ steps.versions.outputs.latest }}'
+          title: 'chore(deps): bump aiopnsense to ==${{ steps.versions.outputs.latest }}'
           labels: dependencies,aiopnsense-auto-update
           body: |
             Automated update of `custom_components/opnsense/manifest.json`.
 
-            - Previous minimum version: `aiopnsense>=${{ steps.versions.outputs.current }}`
-            - Updated minimum version: `aiopnsense>=${{ steps.versions.outputs.latest }}`
+            - Previous pinned version: `aiopnsense==${{ steps.versions.outputs.current }}`
+            - Updated pinned version: `aiopnsense==${{ steps.versions.outputs.latest }}`
 
             ## aiopnsense release notes in range
             ${{ steps.release_notes.outputs.notes }}

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 
 ### Binary Sensor
 
-* CARP Status (enabled/disabled)
 * System Notices present *(the circle icon in the upper right of the UI)*
 * Firmware updates available
 
@@ -179,6 +178,7 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 * Filesystem usage
 * Interface details (status, stats, pps, kbs, etc.) *[speeds are based on the `Scan Interval (seconds)` config option]*
 * Gateways details (status, delay, stddev, loss)
+* CARP Status (aggregate)
 * CARP Interface status
 * DHCP Leases
 * OpenVPN and Wireguard server and client stats

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -1,4 +1,4 @@
-"""OPNsense integration."""
+"""OPNsense integration binary sensors."""
 
 from collections.abc import Mapping, MutableMapping
 import logging
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SYNC_CARP, CONF_SYNC_NOTICES, COORDINATOR, DEFAULT_SYNC_OPTION_VALUE
+from .const import CONF_SYNC_NOTICES, COORDINATOR, DEFAULT_SYNC_OPTION_VALUE
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
@@ -32,21 +32,6 @@ async def async_setup_entry(
     config: Mapping[str, Any] = config_entry.data
 
     entities: list = []
-    if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
-        entities.append(
-            OPNsenseCarpStatusBinarySensor(
-                config_entry=config_entry,
-                coordinator=coordinator,
-                entity_description=BinarySensorEntityDescription(
-                    key="carp.status",
-                    name="CARP Status",
-                    icon="mdi:gauge",
-                    device_class=None,
-                    # entity_category=entity_category,
-                    entity_registry_enabled_default=False,
-                ),
-            )
-        )
     if config.get(CONF_SYNC_NOTICES, DEFAULT_SYNC_OPTION_VALUE):
         entities.append(
             OPNsensePendingNoticesPresentBinarySensor(
@@ -89,28 +74,6 @@ class OPNsenseBinarySensor(OPNsenseEntity, BinarySensorEntity):
         )
         self.entity_description: BinarySensorEntityDescription = entity_description
         self._attr_is_on: bool = False
-
-
-class OPNsenseCarpStatusBinarySensor(OPNsenseBinarySensor):
-    """OPNsense Binary Sensor Carp Class."""
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
-            return
-        try:
-            self._attr_is_on = state["carp_status"]
-        except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
-            return
-        self._available = True
-        self._attr_extra_state_attributes = {}
-        self.async_write_ha_state()
 
 
 class OPNsensePendingNoticesPresentBinarySensor(OPNsenseBinarySensor):

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -172,12 +172,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
         if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
-            categories.extend(
-                [
-                    {"function": "get_carp_interfaces", "state_key": "carp_interfaces"},
-                    {"function": "get_carp_status", "state_key": "carp_status"},
-                ]
-            )
+            categories.append({"function": "get_carp", "state_key": "carp"})
         if config.get(CONF_SYNC_DHCP_LEASES, DEFAULT_SYNC_OPTION_VALUE):
             categories.append({"function": "get_dhcp_leases", "state_key": "dhcp_leases"})
         if config.get(CONF_SYNC_GATEWAYS, DEFAULT_SYNC_OPTION_VALUE):

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -37,3 +37,21 @@ def is_private_ip(url: str) -> bool:
         return False
     else:
         return ip_obj.is_private
+
+
+def coerce_bool(value: Any) -> bool:
+    """Normalize values that may represent booleans.
+
+    Args:
+        value: Arbitrary state value returned by backend APIs.
+
+    Returns:
+        bool: Parsed boolean interpretation for common numeric/string variants.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False

--- a/custom_components/opnsense/pyopnsense/helpers.py
+++ b/custom_components/opnsense/pyopnsense/helpers.py
@@ -221,3 +221,35 @@ def try_to_float(input: Any | None, retval: float | None = None) -> float | None
         return float(input)
     except ValueError, TypeError:
         return retval
+
+
+def coerce_bool(value: Any) -> bool:
+    """Normalize values that may represent booleans.
+
+    Args:
+        value: Arbitrary state value returned by backend APIs.
+
+    Returns:
+        bool: Parsed boolean interpretation for common numeric/string variants.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def normalize_lookup_token(value: Any) -> str:
+    """Normalize values for case-insensitive token matching.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        str: Lower-cased, stripped string token used for comparisons.
+    """
+    if value is None:
+        return ""
+    return str(value).strip().lower()

--- a/custom_components/opnsense/pyopnsense/system.py
+++ b/custom_components/opnsense/pyopnsense/system.py
@@ -1,6 +1,6 @@
 """System and configuration methods for OPNsenseClient."""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Any
 import warnings
@@ -10,11 +10,286 @@ from dateutil.parser import ParserError, UnknownTimezoneWarning, parse
 
 from ._typing import PyOPNsenseClientProtocol
 from .const import AMBIGUOUS_TZINFOS
-from .helpers import _LOGGER, _log_errors, timestamp_to_datetime, try_to_int
+from .helpers import (
+    _LOGGER,
+    _log_errors,
+    coerce_bool,
+    normalize_lookup_token,
+    timestamp_to_datetime,
+    try_to_int,
+)
 
 
 class SystemMixin(PyOPNsenseClientProtocol):
     """System methods for OPNsenseClient."""
+
+    def _parse_carp_vip_rows(self, rows: list[Any]) -> list[dict[str, Any]]:
+        """Normalize CARP VIP rows from OPNsense responses.
+
+        Args:
+            rows: Raw VIP rows returned by OPNsense endpoints.
+
+        Returns:
+            list[dict[str, Any]]: Filtered CARP VIP rows with normalized status values.
+        """
+        parsed_rows: list[dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, MutableMapping):
+                continue
+            mode = normalize_lookup_token(row.get("mode", ""))
+            if mode and mode != "carp":
+                continue
+            row_copy = dict(row)
+            raw_status = row_copy.get("status")
+            status_str = str(raw_status).strip() if raw_status is not None else ""
+            if not status_str:
+                row_copy["status"] = "DISABLED"
+            else:
+                row_copy["status"] = status_str.upper()
+            parsed_rows.append(row_copy)
+        return parsed_rows
+
+    @staticmethod
+    def _classify_carp_state(
+        has_carp_block: bool,
+        has_rows: bool,
+        enabled: bool,
+        maintenance_mode: bool,
+        vip_count: int,
+        demotion: int,
+        status_message: str,
+        other_count: int,
+    ) -> str:
+        """Classify aggregate CARP state from normalized summary values.
+
+        Args:
+            has_carp_block: Whether the response contains a CARP metadata block.
+            has_rows: Whether the response contains VIP rows.
+            enabled: Whether CARP is enabled.
+            maintenance_mode: Whether CARP maintenance mode is active.
+            vip_count: Number of CARP VIP entries.
+            demotion: Current CARP demotion counter.
+            status_message: CARP status message from OPNsense.
+            other_count: Count of VIPs in neither MASTER nor BACKUP state.
+
+        Returns:
+            str: Derived CARP state classification.
+        """
+        if not has_carp_block and not has_rows:
+            return "unknown"
+        if not enabled:
+            return "disabled"
+        if maintenance_mode:
+            return "maintenance"
+        if vip_count == 0:
+            return "not_configured"
+        if demotion != 0 or bool(status_message.strip()) or other_count > 0:
+            return "degraded"
+        return "healthy"
+
+    @staticmethod
+    def _select_carp_setting_candidate(
+        candidates: list[dict[str, Any]],
+        interface_key: str,
+        vhid_key: str,
+        subnet_key: str,
+    ) -> dict[str, Any] | None:
+        """Select the best fallback VIP setting candidate for a status row.
+
+        Args:
+            candidates: Candidate VIP settings with partial key collisions.
+            interface_key: Normalized interface key from the status row.
+            vhid_key: Normalized VHID key from the status row.
+            subnet_key: Normalized subnet key from the status row.
+
+        Returns:
+            dict[str, Any] | None: Best-matching candidate, or None when unavailable.
+        """
+        best_candidate: dict[str, Any] | None = None
+        best_score = -1
+        has_ambiguous_tie = False
+        for candidate in candidates:
+            score = 0
+            candidate_interface = normalize_lookup_token(candidate.get("interface", ""))
+            candidate_vhid = normalize_lookup_token(candidate.get("vhid", ""))
+            candidate_subnet = normalize_lookup_token(candidate.get("subnet", ""))
+            if interface_key and candidate_interface == interface_key:
+                score += 1
+            if vhid_key and candidate_vhid == vhid_key:
+                score += 1
+            if subnet_key and candidate_subnet == subnet_key:
+                score += 1
+            if score > best_score:
+                best_candidate = candidate
+                best_score = score
+                has_ambiguous_tie = False
+            elif score == best_score:
+                best_candidate = None
+                has_ambiguous_tie = True
+        if has_ambiguous_tie:
+            return None
+        return best_candidate
+
+    def _merge_carp_vip_rows(
+        self,
+        vip_status_rows: list[Any],
+        vip_settings_rows: list[Any],
+    ) -> list[dict[str, Any]]:
+        """Merge CARP VIP status rows with VIP settings rows.
+
+        Args:
+            vip_status_rows: Raw rows from the VIP status endpoint.
+            vip_settings_rows: Raw rows from the VIP settings endpoint.
+
+        Returns:
+            list[dict[str, Any]]: Merged CARP VIP rows with normalized subnet values.
+        """
+        vip_status = self._parse_carp_vip_rows(vip_status_rows)
+
+        vip_settings: list[dict[str, Any]] = []
+        for row in vip_settings_rows:
+            if not isinstance(row, MutableMapping):
+                continue
+            mode = normalize_lookup_token(row.get("mode", ""))
+            if mode and mode != "carp":
+                continue
+            vip_settings.append(dict(row))
+
+        settings_indexes = self._build_carp_settings_indexes(vip_settings)
+
+        merged_vips: list[dict[str, Any]] = []
+        for status_vip in vip_status:
+            settings_match = self._find_carp_settings_match(status_vip, settings_indexes)
+
+            if settings_match is None:
+                merged_vip = dict(status_vip)
+            else:
+                merged_vip = dict(settings_match)
+                merged_vip.update(status_vip)
+
+            subnet_value = merged_vip.get("subnet")
+            if isinstance(subnet_value, str):
+                subnet_value = subnet_value.strip()
+                if subnet_value:
+                    merged_vip["subnet"] = subnet_value
+            if not subnet_value:
+                continue
+            interface_value = merged_vip.get("interface")
+            if isinstance(interface_value, str):
+                interface_value = interface_value.strip()
+                if interface_value:
+                    merged_vip["interface"] = interface_value
+            if not interface_value:
+                continue
+            merged_vips.append(merged_vip)
+
+        return merged_vips
+
+    def _build_carp_settings_indexes(
+        self,
+        vip_settings: list[dict[str, Any]],
+    ) -> tuple[
+        dict[tuple[str, str, str], dict[str, Any]],
+        dict[tuple[str, str], list[dict[str, Any]]],
+        dict[tuple[str, str], list[dict[str, Any]]],
+        dict[str, list[dict[str, Any]]],
+        dict[str, list[dict[str, Any]]],
+    ]:
+        """Build CARP setting indexes used by fallback matching.
+
+        Args:
+            vip_settings: Normalized CARP VIP settings rows.
+
+        Returns:
+            tuple: Lookup dictionaries keyed by full identity and partial keys.
+        """
+        settings_by_full: dict[tuple[str, str, str], dict[str, Any]] = {}
+        settings_by_if_subnet: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        settings_by_if_vhid: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        settings_by_subnet: dict[str, list[dict[str, Any]]] = {}
+        settings_by_vhid: dict[str, list[dict[str, Any]]] = {}
+        for setting in vip_settings:
+            interface_key = normalize_lookup_token(setting.get("interface"))
+            vhid_key = normalize_lookup_token(setting.get("vhid"))
+            subnet_key = normalize_lookup_token(setting.get("subnet"))
+            settings_by_full[(interface_key, vhid_key, subnet_key)] = setting
+            if interface_key and subnet_key:
+                settings_by_if_subnet.setdefault((interface_key, subnet_key), []).append(setting)
+            if interface_key and vhid_key:
+                settings_by_if_vhid.setdefault((interface_key, vhid_key), []).append(setting)
+            if subnet_key:
+                settings_by_subnet.setdefault(subnet_key, []).append(setting)
+            if vhid_key:
+                settings_by_vhid.setdefault(vhid_key, []).append(setting)
+        return (
+            settings_by_full,
+            settings_by_if_subnet,
+            settings_by_if_vhid,
+            settings_by_subnet,
+            settings_by_vhid,
+        )
+
+    def _find_carp_settings_match(
+        self,
+        status_vip: dict[str, Any],
+        settings_indexes: tuple[
+            dict[tuple[str, str, str], dict[str, Any]],
+            dict[tuple[str, str], list[dict[str, Any]]],
+            dict[tuple[str, str], list[dict[str, Any]]],
+            dict[str, list[dict[str, Any]]],
+            dict[str, list[dict[str, Any]]],
+        ],
+    ) -> dict[str, Any] | None:
+        """Find the best settings row for one CARP status row.
+
+        Args:
+            status_vip: Parsed CARP status row.
+            settings_indexes: Lookup dictionaries generated from CARP settings rows.
+
+        Returns:
+            dict[str, Any] | None: Best matching settings row, or ``None`` when no unambiguous fallback exists.
+        """
+        (
+            settings_by_full,
+            settings_by_if_subnet,
+            settings_by_if_vhid,
+            settings_by_subnet,
+            settings_by_vhid,
+        ) = settings_indexes
+        interface_key = normalize_lookup_token(status_vip.get("interface"))
+        vhid_key = normalize_lookup_token(status_vip.get("vhid"))
+        subnet_key = normalize_lookup_token(status_vip.get("subnet"))
+
+        settings_match = settings_by_full.get((interface_key, vhid_key, subnet_key))
+        if settings_match is None and interface_key and subnet_key:
+            settings_match = self._select_carp_setting_candidate(
+                settings_by_if_subnet.get((interface_key, subnet_key), []),
+                interface_key,
+                vhid_key,
+                subnet_key,
+            )
+        if settings_match is None and interface_key and vhid_key:
+            settings_match = self._select_carp_setting_candidate(
+                settings_by_if_vhid.get((interface_key, vhid_key), []),
+                interface_key,
+                vhid_key,
+                subnet_key,
+            )
+        if settings_match is None and subnet_key:
+            settings_match = self._select_carp_setting_candidate(
+                settings_by_subnet.get(subnet_key, []),
+                interface_key,
+                vhid_key,
+                subnet_key,
+            )
+        if settings_match is None and vhid_key:
+            settings_match = self._select_carp_setting_candidate(
+                settings_by_vhid.get(vhid_key, []),
+                interface_key,
+                vhid_key,
+                subnet_key,
+            )
+        return settings_match
 
     def _get_local_timezone(self) -> tzinfo:
         """Return a local timezone fallback with fixed UTC offset.
@@ -149,51 +424,135 @@ $toreturn = [
         return dict(ret_data)
 
     @_log_errors
-    async def get_carp_status(self) -> bool:
-        """Return the Carp status.
+    async def get_carp(self) -> dict[str, Any]:
+        """Fetch one CARP snapshot and return both interfaces and aggregate summary.
 
         Returns:
-            bool: Parsed carp status payload returned by OPNsense APIs.
+            dict[str, Any]: Snapshot payload containing ``interfaces`` and
+            ``status_summary`` derived from one backend fetch.
         """
-        response = await self._safe_dict_get("/api/diagnostics/interface/get_vip_status")
-        # _LOGGER.debug(f"[get_carp_status] response: {response}")
-        return response.get("carp", {}).get("allow", "0") == "1"
+        response, vips = await self._fetch_and_merge_carp_vips()
+        return {
+            "interfaces": vips,
+            "status_summary": self._build_carp_status_summary(response=response, vips=vips),
+        }
 
-    @_log_errors
-    async def get_carp_interfaces(self) -> list:
-        """Return the interfaces used by Carp.
+    async def _fetch_and_merge_carp_vips(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Fetch CARP status/settings and return merged normalized VIP rows.
 
         Returns:
-            list: Parsed carp interfaces payload returned by OPNsense APIs.
+            tuple[dict[str, Any], list[dict[str, Any]]]: The raw VIP status response and
+            merged/normalized CARP VIP rows derived from status + settings endpoints.
         """
-        vip_settings_raw = await self._safe_dict_get("/api/interfaces/vip_settings/get")
-        if not isinstance(vip_settings_raw.get("rows", None), list):
-            vip_settings: list = []
-        else:
-            vip_settings = vip_settings_raw.get("rows", [])
-        # _LOGGER.debug(f"[get_carp_interfaces] vip_settings: {vip_settings}")
-
         vip_status_raw = await self._safe_dict_get("/api/diagnostics/interface/get_vip_status")
-        if not isinstance(vip_status_raw.get("rows", None), list):
-            vip_status: list = []
+        vip_settings_raw = await self._safe_dict_get("/api/interfaces/vip_settings/get")
+
+        vip_status = dict(vip_status_raw) if isinstance(vip_status_raw, MutableMapping) else {}
+        vip_status_rows = vip_status.get("rows")
+        vip_settings_rows = (
+            vip_settings_raw.get("rows") if isinstance(vip_settings_raw, MutableMapping) else None
+        )
+        merged_vips = self._merge_carp_vip_rows(
+            vip_status_rows if isinstance(vip_status_rows, list) else [],
+            vip_settings_rows if isinstance(vip_settings_rows, list) else [],
+        )
+        return vip_status, merged_vips
+
+    def _build_carp_status_summary(
+        self,
+        response: dict[str, Any],
+        vips: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Build aggregate CARP status summary using one merged VIP snapshot.
+
+        Args:
+            response: Raw response from ``get_vip_status`` endpoint.
+            vips: Merged/normalized CARP VIP rows from status + settings endpoints.
+
+        Returns:
+            dict[str, Any]: Aggregate CARP health/status payload for Home Assistant sensors.
+        """
+        summary: dict[str, Any] = {
+            "state": "unknown",
+            "enabled": False,
+            "maintenance_mode": False,
+            "demotion": 0,
+            "status_message": "",
+            "vip_count": 0,
+            "master_count": 0,
+            "backup_count": 0,
+            "other_count": 0,
+            "interfaces": [],
+            "vips": [],
+        }
+        if not response:
+            return summary
+
+        carp_raw = response.get("carp")
+        if isinstance(carp_raw, Mapping):
+            has_carp_block = True
+            carp_block: dict[str, Any] = dict(carp_raw)
         else:
-            vip_status = vip_status_raw.get("rows", [])
-        # _LOGGER.debug(f"[get_carp_interfaces] vip_status: {vip_status}")
-        carp = []
-        for vip in vip_settings:
-            if vip.get("mode", "").lower() != "carp":
-                continue
+            has_carp_block = False
+            carp_block = {}
+        has_rows = bool(vips)
 
-            for status in vip_status:
-                if vip.get("interface", "").lower() == status.get("interface", "_").lower():
-                    vip["status"] = status.get("status", None)
-                    break
-            if "status" not in vip or not vip.get("status"):
-                vip["status"] = "DISABLED"
+        enabled = coerce_bool(carp_block.get("allow")) if has_carp_block else bool(vips)
+        maintenance_mode = (
+            coerce_bool(carp_block.get("maintenancemode")) if has_carp_block else False
+        )
+        demotion_raw = try_to_int(carp_block.get("demotion"), 0) if has_carp_block else 0
+        demotion = demotion_raw if isinstance(demotion_raw, int) else 0
+        status_message_raw = carp_block.get("status_msg", "") if has_carp_block else ""
+        status_message = (
+            status_message_raw.strip()
+            if isinstance(status_message_raw, str) and status_message_raw.strip()
+            else ""
+        )
+        master_count = 0
+        backup_count = 0
+        other_count = 0
+        interfaces: set[str] = set()
+        for vip in vips:
+            status = str(vip.get("status", "")).strip().upper()
+            if status == "MASTER":
+                master_count += 1
+            elif status == "BACKUP":
+                backup_count += 1
+            else:
+                other_count += 1
+            interface_name = vip.get("interface")
+            if isinstance(interface_name, str) and interface_name.strip():
+                interfaces.add(interface_name.strip())
 
-            carp.append(vip)
-        _LOGGER.debug("[get_carp_interfaces] carp: %s", carp)
-        return carp
+        vip_count = len(vips)
+        state = self._classify_carp_state(
+            has_carp_block=has_carp_block,
+            has_rows=has_rows,
+            enabled=enabled,
+            maintenance_mode=maintenance_mode,
+            vip_count=vip_count,
+            demotion=demotion,
+            status_message=status_message,
+            other_count=other_count,
+        )
+
+        summary.update(
+            {
+                "state": state,
+                "enabled": enabled,
+                "maintenance_mode": maintenance_mode,
+                "demotion": demotion,
+                "status_message": status_message,
+                "vip_count": vip_count,
+                "master_count": master_count,
+                "backup_count": backup_count,
+                "other_count": other_count,
+                "interfaces": sorted(interfaces),
+                "vips": vips,
+            }
+        )
+        return summary
 
     @_log_errors
     async def system_reboot(self) -> bool:

--- a/custom_components/opnsense/pyopnsense/vnstat.py
+++ b/custom_components/opnsense/pyopnsense/vnstat.py
@@ -8,7 +8,7 @@ import re
 from typing import Any
 
 from ._typing import PyOPNsenseClientProtocol
-from .helpers import _LOGGER, _log_errors, try_to_float
+from .helpers import _LOGGER, _log_errors, normalize_lookup_token, try_to_float
 
 _VSTAT_HEADER_RE = re.compile(
     r"^\s*(?P<interface>[^\s]+)\s*/\s*(?P<period>hourly|daily|monthly|yearly)\s*$",
@@ -61,7 +61,7 @@ class VnstatMixin(PyOPNsenseClientProtocol):
         Returns:
             dict[str, Any]: Parsed vnStat payload with ``period`` and per-interface rows. Empty dictionary when the endpoint is unavailable or period is unsupported.
         """
-        requested_period = period.strip().lower() if isinstance(period, str) else ""
+        requested_period = normalize_lookup_token(period)
         if requested_period not in _VSTAT_PERIODS:
             return {}
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -46,7 +46,7 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
-from .helpers import dict_get
+from .helpers import coerce_bool, dict_get
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -374,23 +374,87 @@ async def _compile_carp_interface_sensors(
         return []
     entities: list = []
 
-    for interface in state.get("carp_interfaces", []):
-        entity = OPNsenseCarpInterfaceSensor(
+    interface_descriptions = _build_interface_device_description_map(
+        dict_get(state, "interfaces", {}) or {}
+    )
+    carp_interfaces = dict_get(state, "carp.interfaces", []) or []
+    for interface in carp_interfaces:
+        if not isinstance(interface, MutableMapping):
+            _LOGGER.debug(
+                "Skipping malformed CARP interface entry that is not a mapping: %r",
+                interface,
+            )
+            continue
+        try:
+            subnet = interface.get("subnet")
+            if not isinstance(subnet, str) or not subnet.strip():
+                _LOGGER.debug("Skipping CARP interface entry with invalid subnet: %r", interface)
+                continue
+            subnet = subnet.strip()
+
+            interface_name = interface.get("interface")
+            interface_label = str(interface_name).strip() if interface_name is not None else ""
+            if not interface_label:
+                interface_label = "unknown"
+            friendly_interface_name = interface_descriptions.get(interface_label, interface_label)
+
+            description = interface.get("descr")
+            description_text = str(description).strip() if description is not None else ""
+            if description_text:
+                display_name = (
+                    f"CARP Interface Status {friendly_interface_name} {subnet} ({description_text})"
+                )
+            else:
+                display_name = f"CARP Interface Status {friendly_interface_name} {subnet}"
+            entity = OPNsenseCarpInterfaceSensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=SensorEntityDescription(
+                    key=f"carp.interface.{slugify(subnet)}",  # subnet is actually the ip
+                    name=display_name,
+                    native_unit_of_measurement=None,
+                    device_class=None,
+                    icon="mdi:check-network",
+                    state_class=None,
+                    entity_registry_enabled_default=True,
+                    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+            )
+            entities.append(entity)
+        except (AttributeError, TypeError, ValueError) as err:
+            _LOGGER.debug("Skipping malformed CARP interface entry: %r (%s)", interface, err)
+    return entities
+
+
+async def _compile_carp_status_sensor(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+) -> list:
+    """Compile aggregate CARP status sensor.
+
+    Args:
+        config_entry: Config entry being exercised by the helper or test.
+        coordinator: Data update coordinator that caches OPNsense state for entities.
+        state: Coordinator state snapshot that contains CARP summary status data.
+    """
+    if not isinstance(state, MutableMapping):
+        return []
+    return [
+        OPNsenseCarpStatusSensor(
             config_entry=config_entry,
             coordinator=coordinator,
             entity_description=SensorEntityDescription(
-                key=f"carp.interface.{slugify(interface['subnet'])}",  # subnet is actually the ip
-                name=f"CARP Interface Status {slugify(interface['subnet'])} ({interface.get('descr', '')})",
+                key="carp.status_summary",
+                name="CARP Status",
                 native_unit_of_measurement=None,
                 device_class=None,
-                icon="mdi:check-network",
+                icon="mdi:gauge",
                 state_class=None,
                 entity_registry_enabled_default=True,
-                # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         )
-        entities.append(entity)
-    return entities
+    ]
 
 
 async def _compile_interface_sensors(
@@ -765,6 +829,7 @@ async def async_setup_entry(
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_interface_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
+        entities.extend(await _compile_carp_status_sensor(config_entry, coordinator, state))
         entities.extend(await _compile_carp_interface_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_DHCP_LEASES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_dhcp_leases_sensors(config_entry, coordinator, state))
@@ -1083,9 +1148,20 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
         carp_interface_name: str = self.entity_description.key.split(".")[2]
-        for i_interface in state.get("carp_interfaces", []):
-            if slugify(i_interface["subnet"]) == carp_interface_name:
-                carp_interface = i_interface
+        carp_interfaces = dict_get(state, "carp.interfaces", []) or []
+        for i_interface in carp_interfaces:
+            if not isinstance(i_interface, MutableMapping):
+                _LOGGER.debug(
+                    "Skipping malformed CARP interface entry that is not a mapping: %r",
+                    i_interface,
+                )
+                continue
+            subnet = i_interface.get("subnet")
+            if not isinstance(subnet, str) or not subnet.strip():
+                _LOGGER.debug("Skipping CARP interface entry with invalid subnet: %r", i_interface)
+                continue
+            if slugify(subnet.strip()) == carp_interface_name:
+                carp_interface = dict(i_interface)
                 break
         if not carp_interface:
             self._available = False
@@ -1108,6 +1184,7 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             "subnet_bits",
             "subnet",
             "descr",
+            "mode",
         ):
             if attr in carp_interface:
                 self._attr_extra_state_attributes[attr] = carp_interface[attr]
@@ -1116,7 +1193,65 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
     @property
     def icon(self) -> str | None:
         """Return the icon for the sensor."""
-        if self.native_value != "MASTER":
+        if not self.native_value or not isinstance(self.native_value, str):
+            return "mdi:close-network-outline"
+        status = self.native_value.upper()
+        if status == "MASTER":
+            return "mdi:check-network"
+        if status == "BACKUP":
+            return "mdi:backup-restore"
+        return "mdi:close-network-outline"
+
+
+class OPNsenseCarpStatusSensor(OPNsenseSensor):
+    """Class for OPNsense aggregate CARP status sensor."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator update."""
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+        summary_raw = dict_get(state, "carp.status_summary")
+        if not isinstance(summary_raw, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        summary = dict(summary_raw)
+        summary_state = summary.get("state")
+        if not isinstance(summary_state, str) or not summary_state:
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._available = True
+        self._attr_native_value = summary_state
+        self._attr_extra_state_attributes = {
+            "enabled": coerce_bool(summary.get("enabled")),
+            "maintenance_mode": coerce_bool(summary.get("maintenance_mode")),
+            "demotion": summary.get("demotion", 0),
+            "status_message": summary.get("status_message", ""),
+            "vip_count": summary.get("vip_count", 0),
+            "master_count": summary.get("master_count", 0),
+            "backup_count": summary.get("backup_count", 0),
+            "other_count": summary.get("other_count", 0),
+            "interfaces": summary.get("interfaces", []),
+            "vips": summary.get("vips", []),
+        }
+        self.async_write_ha_state()
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon for the sensor."""
+        state_value = str(self.native_value).lower()
+        if state_value == "healthy":
+            return "mdi:check-network"
+        if state_value in {"maintenance", "not_configured"}:
+            return "mdi:backup-restore"
+        if state_value in {"degraded", "disabled"}:
             return "mdi:close-network-outline"
         return super().icon
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ lint = [
 ]
 pytest = [
     "aiohttp",
+    "aiopnsense",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -702,6 +702,25 @@ def fake_client():
                 """Return an empty WireGuard payload for coordinator tests."""
                 return {"servers": {}}
 
+            async def get_carp(self) -> dict[str, Any]:
+                """Return one fake CARP payload with interfaces and aggregate summary."""
+                return {
+                    "interfaces": [],
+                    "status_summary": {
+                        "state": "not_configured",
+                        "enabled": True,
+                        "maintenance_mode": False,
+                        "demotion": 0,
+                        "status_message": "",
+                        "vip_count": 0,
+                        "master_count": 0,
+                        "backup_count": 0,
+                        "other_count": 0,
+                        "interfaces": [],
+                        "vips": [],
+                    },
+                }
+
         return FakeClient
 
     return _make

--- a/tests/pyopnsense/test_helpers.py
+++ b/tests/pyopnsense/test_helpers.py
@@ -81,6 +81,29 @@ def test_try_to_int_and_float() -> None:
     assert pyopnsense_helpers.try_to_float(None, 3.3) == 3.3
 
 
+def test_coerce_bool() -> None:
+    """Verify ``coerce_bool`` handles common bool-like edge cases."""
+    assert pyopnsense_helpers.coerce_bool(True) is True
+    assert pyopnsense_helpers.coerce_bool(False) is False
+    assert pyopnsense_helpers.coerce_bool(1) is True
+    assert pyopnsense_helpers.coerce_bool(0) is False
+    assert pyopnsense_helpers.coerce_bool(0.0) is False
+    assert pyopnsense_helpers.coerce_bool("1") is True
+    assert pyopnsense_helpers.coerce_bool("true") is True
+    assert pyopnsense_helpers.coerce_bool("yes") is True
+    assert pyopnsense_helpers.coerce_bool("on") is True
+    assert pyopnsense_helpers.coerce_bool("") is False
+    assert pyopnsense_helpers.coerce_bool(None) is False
+
+
+def test_normalize_lookup_token() -> None:
+    """Verify ``normalize_lookup_token`` lower-cases and trims lookup values."""
+    assert pyopnsense_helpers.normalize_lookup_token("Hello") == "hello"
+    assert pyopnsense_helpers.normalize_lookup_token("  WORLD  ") == "world"
+    assert pyopnsense_helpers.normalize_lookup_token(42) == "42"
+    assert pyopnsense_helpers.normalize_lookup_token(None) == ""
+
+
 def test_get_ip_key_sorting() -> None:
     """Sort IP-like items using get_ip_key ordering."""
     items = [

--- a/tests/pyopnsense/test_system.py
+++ b/tests/pyopnsense/test_system.py
@@ -1,6 +1,7 @@
 """Tests for `pyopnsense.system`."""
 
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -68,22 +69,58 @@ async def test_get_opnsense_timezone_parse_and_fallback(make_client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_carp_and_reboot_and_wol(make_client) -> None:
-    """Verify CARP interface discovery and system control endpoints (reboot/halt/WOL)."""
+async def test_carp_summary_and_reboot_and_wol(make_client) -> None:
+    """Verify CARP summary/discovery and system control endpoints (reboot/halt/WOL)."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
     try:
-        client._safe_dict_get = AsyncMock(return_value={"carp": {"allow": "1"}})
-        assert await client.get_carp_status() is True
+        client._safe_dict_get = AsyncMock(
+            return_value={
+                "rows": [
+                    {
+                        "interface": "em0",
+                        "subnet": "10.0.0.1",
+                        "status": "MASTER",
+                        "mode": "carp",
+                        "vhid": "1",
+                        "advbase": "1",
+                        "advskew": "0",
+                    }
+                ],
+                "carp": {
+                    "allow": "1",
+                    "demotion": "0",
+                    "maintenancemode": False,
+                    "status_msg": "",
+                },
+            }
+        )
+        summary = dict((await client.get_carp()).get("status_summary", {}))
+        assert summary["state"] == "healthy"
+        assert summary["enabled"] is True
+        assert summary["vip_count"] == 1
+        assert summary["master_count"] == 1
 
         client._safe_dict_get = AsyncMock(
             side_effect=[
-                {"rows": [{"mode": "carp", "interface": "em0"}]},
-                {"rows": [{"interface": "em0", "status": "OK"}]},
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "em0",
+                            "subnet": "10.0.0.1",
+                            "vhid": "1",
+                            "status": "MASTER",
+                        }
+                    ]
+                },
+                {"rows": [{"mode": "carp", "interface": "em0", "subnet": "10.0.0.1", "vhid": "1"}]},
             ]
         )
-        carp = await client.get_carp_interfaces()
+        carp = (await client.get_carp()).get("interfaces", [])
         assert isinstance(carp, list)
+        assert carp[0]["status"] == "MASTER"
+        assert carp[0]["interface"] == "em0"
 
         client._safe_dict_post = AsyncMock(return_value={"status": "ok"})
         assert await client.system_reboot() is True
@@ -175,33 +212,448 @@ async def test_gateways_notices_and_close_notice_all() -> None:
 
 
 @pytest.mark.asyncio
-async def test_carp_and_system_actions_and_wol() -> None:
-    """Test get_carp_status, get_carp_interfaces, reboot/halt and send_wol."""
+async def test_get_carp_handles_invalid_payloads_and_default_status() -> None:
+    """Verify CARP parsing tolerates malformed payloads and missing status values."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = pyopnsense.OPNsenseClient(
         url="http://localhost", username="u", password="p", session=session
     )
     try:
-        # carp status
-        client._safe_dict_get = AsyncMock(return_value={"carp": {"allow": "1"}})
-        assert await client.get_carp_status() is True
+        client._safe_dict_get = AsyncMock(side_effect=[{"rows": "bad"}, {"rows": "bad"}])
+        assert (await client.get_carp()).get("interfaces", []) == []
 
-        # carp interfaces: one vip with mode carp and matching status
-        vip_rows = [{"mode": "carp", "interface": "em0"}]
-        vip_status = [{"interface": "em0", "status": "UP"}]
-        # first call returns vip_settings, second returns vip_status
-        client._safe_dict_get = AsyncMock(side_effect=[{"rows": vip_rows}, {"rows": vip_status}])
-        carp = await client.get_carp_interfaces()
-        assert isinstance(carp, list) and carp[0].get("status")
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {"mode": "other", "interface": "em9"},
+                        {"mode": "carp", "interface": "em0", "subnet": "10.0.0.1", "vhid": "11"},
+                    ]
+                },
+                {
+                    "rows": [
+                        {"mode": "carp", "interface": "em1", "subnet": "10.0.0.9", "vhid": "12"}
+                    ]
+                },
+            ]
+        )
+        carp = (await client.get_carp()).get("interfaces", [])
+        assert len(carp) == 1
+        assert carp[0]["interface"] == "em0"
+        assert carp[0]["status"] == "DISABLED"
 
-        # system reboot/halt
-        client._safe_dict_post = AsyncMock(return_value={"status": "ok"})
-        assert await client.system_reboot() is True
-        assert await client.system_halt() is None
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "wan",
+                            "subnet": "192.0.2.10",
+                            "vhid": "20",
+                            "status": "BACKUP",
+                        }
+                    ]
+                },
+                {"rows": "not-a-list"},
+            ]
+        )
+        carp = (await client.get_carp()).get("interfaces", [])
+        assert len(carp) == 1
+        assert carp[0]["interface"] == "wan"
+        assert carp[0]["status"] == "BACKUP"
 
-        # send wol success
-        client._safe_dict_post = AsyncMock(return_value={"status": "ok"})
-        assert await client.send_wol("em0", "aa:bb:cc") is True
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "opt1",
+                            "vhid": "30",
+                            "status": "MASTER",
+                        }
+                    ]
+                },
+                {"rows": []},
+            ]
+        )
+        assert (await client.get_carp()).get("interfaces", []) == []
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_carp_matches_multiple_vips_on_same_interface() -> None:
+    """Verify CARP enrichment matches by VIP identity, not interface alone."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = pyopnsense.OPNsenseClient(
+        url="http://localhost", username="u", password="p", session=session
+    )
+    try:
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.1",
+                            "vhid": "1",
+                            "status": "MASTER",
+                        },
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.2",
+                            "vhid": "2",
+                            "status": "BACKUP",
+                        },
+                    ]
+                },
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.1",
+                            "vhid": "1",
+                            "descr": "first",
+                        },
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.2",
+                            "vhid": "2",
+                            "descr": "second",
+                        },
+                    ]
+                },
+            ]
+        )
+        carp = (await client.get_carp()).get("interfaces", [])
+        assert len(carp) == 2
+        by_subnet = {entry["subnet"]: entry for entry in carp}
+        assert by_subnet["10.0.0.1"]["status"] == "MASTER"
+        assert by_subnet["10.0.0.1"]["descr"] == "first"
+        assert by_subnet["10.0.0.2"]["status"] == "BACKUP"
+        assert by_subnet["10.0.0.2"]["descr"] == "second"
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_carp_returns_no_match_for_ambiguous_partial_key_collisions() -> None:
+    """Verify fallback selection rejects ambiguous VIP setting candidates.
+
+    Returns:
+        None: This test validates ambiguous fallback matching behavior.
+    """
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = pyopnsense.OPNsenseClient(
+        url="http://localhost", username="u", password="p", session=session
+    )
+    try:
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "vhid": "10",
+                            "status": "MASTER",
+                        }
+                    ]
+                },
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.1",
+                            "vhid": "10",
+                            "descr": "first-candidate",
+                        },
+                        {
+                            "mode": "carp",
+                            "interface": "lan",
+                            "subnet": "10.0.0.2",
+                            "vhid": "10",
+                            "descr": "second-candidate",
+                        },
+                    ]
+                },
+            ]
+        )
+        carp = (await client.get_carp()).get("interfaces", [])
+        assert carp == []
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected_state"),
+    [
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "MASTER", "interface": "wan", "subnet": "1.2.3.4"}
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            },
+            "healthy",
+        ),
+        (
+            {
+                "rows": [],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            },
+            "not_configured",
+        ),
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "MASTER", "interface": "wan", "subnet": "1.2.3.4"}
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": True,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            },
+            "maintenance",
+        ),
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "INIT", "interface": "wan", "subnet": "1.2.3.4"}
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "2",
+                    "status_msg": "demoted",
+                },
+            },
+            "degraded",
+        ),
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "MASTER", "interface": "wan", "subnet": "1.2.3.4"}
+                ],
+                "carp": {
+                    "allow": "0",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            },
+            "disabled",
+        ),
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "MASTER", "interface": "wan", "subnet": "1.2.3.4"}
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": 0,
+                },
+            },
+            "healthy",
+        ),
+        (
+            {
+                "rows": "bad",
+                "carp": "bad",
+            },
+            "unknown",
+        ),
+        (
+            {
+                "rows": [{"mode": "carp", "status": "MASTER", "interface": "wan"}],
+            },
+            "unknown",
+        ),
+        (
+            {
+                "rows": [
+                    {"mode": "carp", "status": "MASTER", "interface": "wan", "subnet": ""},
+                    {"mode": "carp", "status": "BACKUP", "subnet": "1.2.3.4"},
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            },
+            "not_configured",
+        ),
+    ],
+)
+async def test_get_carp_status_states(
+    payload: dict[str, Any],
+    expected_state: str,
+) -> None:
+    """Verify CARP summary state mapping across common health scenarios."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = pyopnsense.OPNsenseClient(
+        url="http://localhost", username="u", password="p", session=session
+    )
+    try:
+        client._safe_dict_get = AsyncMock(return_value=payload)
+        summary = dict((await client.get_carp()).get("status_summary", {}))
+        assert summary["state"] == expected_state
+        assert "vips" in summary
+        assert "vip_count" in summary
+        if isinstance(payload.get("carp"), dict) and not isinstance(
+            payload["carp"].get("status_msg", ""),
+            str,
+        ):
+            assert summary["status_message"] == ""
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_carp_skips_whitespace_interface_values() -> None:
+    """Verify CARP merge drops entries whose interface is blank after normalization.
+
+    Returns:
+        None: This test validates normalized interface filtering behavior.
+    """
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = pyopnsense.OPNsenseClient(
+        url="http://localhost", username="u", password="p", session=session
+    )
+    try:
+        client._safe_dict_get = AsyncMock(
+            return_value={
+                "rows": [
+                    {
+                        "mode": "carp",
+                        "status": "MASTER",
+                        "interface": "   ",
+                        "subnet": "1.2.3.4",
+                    },
+                    {
+                        "mode": "carp",
+                        "status": "BACKUP",
+                        "interface": "  wan  ",
+                        "subnet": "5.6.7.8",
+                    },
+                ],
+                "carp": {
+                    "allow": "1",
+                    "maintenancemode": False,
+                    "demotion": "0",
+                    "status_msg": "",
+                },
+            }
+        )
+        snapshot = await client.get_carp()
+        assert snapshot["interfaces"] == [
+            {
+                "interface": "wan",
+                "mode": "carp",
+                "status": "BACKUP",
+                "subnet": "5.6.7.8",
+            }
+        ]
+        assert snapshot["status_summary"]["vip_count"] == 1
+        assert snapshot["status_summary"]["interfaces"] == ["wan"]
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_carp_status_uses_settings_merge_for_partial_rows(make_client) -> None:
+    """Ensure summary reconstructs partial status rows using VIP settings merge."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "status": "MASTER",
+                            "interface": "wan",
+                            "vhid": "1",
+                        }
+                    ],
+                    "carp": {
+                        "allow": "1",
+                        "maintenancemode": False,
+                        "demotion": "0",
+                        "status_msg": "",
+                    },
+                },
+                {
+                    "rows": [
+                        {
+                            "mode": "carp",
+                            "interface": "wan",
+                            "subnet": "1.2.3.4",
+                            "vhid": "1",
+                        }
+                    ]
+                },
+            ]
+        )
+        summary = dict((await client.get_carp()).get("status_summary", {}))
+        assert summary["state"] == "healthy"
+        assert summary["vip_count"] == 1
+        assert summary["interfaces"] == ["wan"]
+        assert summary["vips"][0]["subnet"] == "1.2.3.4"
+    finally:
+        await client.async_close()
+
+
+@pytest.mark.asyncio
+async def test_get_carp_returns_interfaces_and_summary_from_one_fetch(
+    make_client,
+) -> None:
+    """Ensure one CARP call returns both interface and summary payloads."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = make_client(session=session)
+    try:
+        client._safe_dict_get = AsyncMock(
+            side_effect=[
+                {
+                    "rows": [{"mode": "carp", "status": "MASTER", "interface": "wan", "vhid": "1"}],
+                    "carp": {
+                        "allow": "1",
+                        "maintenancemode": False,
+                        "demotion": "0",
+                        "status_msg": "",
+                    },
+                },
+                {"rows": [{"mode": "carp", "interface": "wan", "subnet": "1.2.3.4", "vhid": "1"}]},
+            ]
+        )
+        snapshot = await client.get_carp()
+        assert snapshot["interfaces"][0]["subnet"] == "1.2.3.4"
+        assert snapshot["status_summary"]["state"] == "healthy"
+        assert client._safe_dict_get.await_count == 2
     finally:
         await client.async_close()
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -9,27 +9,18 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.opnsense.binary_sensor import (
-    OPNsenseCarpStatusBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
     async_setup_entry,
 )
-from custom_components.opnsense.const import (
-    CONF_DEVICE_UNIQUE_ID,
-    CONF_SYNC_CARP,
-    CONF_SYNC_NOTICES,
-    COORDINATOR,
-)
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, CONF_SYNC_NOTICES, COORDINATOR
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_creates_entities_when_enabled(make_config_entry):
-    """Create entities when sync options are enabled."""
-    # enable both sync options
-    entry = make_config_entry(
-        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_CARP: True, CONF_SYNC_NOTICES: True}
-    )
+    """Create notices binary sensor when notices sync is enabled."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_NOTICES: True})
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {}
     setattr(entry.runtime_data, COORDINATOR, coord)
@@ -45,19 +36,14 @@ async def test_async_setup_entry_creates_entities_when_enabled(make_config_entry
         created.extend(ents)
 
     await async_setup_entry(MagicMock(), entry, add_entities)
-    # expect two entities created
-    assert len(created) == 2
-    assert any(isinstance(e, OPNsenseCarpStatusBinarySensor) for e in created)
-    assert any(isinstance(e, OPNsensePendingNoticesPresentBinarySensor) for e in created)
+    assert len(created) == 1
+    assert isinstance(created[0], OPNsensePendingNoticesPresentBinarySensor)
 
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_skips_when_disabled(make_config_entry):
     """Skip creating entities when sync options are disabled."""
-    # explicitly disable both
-    entry = make_config_entry(
-        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_CARP: False, CONF_SYNC_NOTICES: False}
-    )
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_NOTICES: False})
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {}
     setattr(entry.runtime_data, COORDINATOR, coord)
@@ -77,39 +63,9 @@ async def test_async_setup_entry_skips_when_disabled(make_config_entry):
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_creates_only_carp_when_carp_enabled(make_config_entry):
-    """Create only CARP entity when CARP sync is enabled."""
-    # enable only CARP
-    entry = make_config_entry(
-        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_CARP: True, CONF_SYNC_NOTICES: False}
-    )
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {}
-    setattr(entry.runtime_data, COORDINATOR, coord)
-
-    created: list = []
-
-    def add_entities(ents):
-        """Add entities.
-
-        Args:
-            ents: Ents provided by pytest or the test case.
-        """
-        created.extend(ents)
-
-    await async_setup_entry(MagicMock(), entry, add_entities)
-    # expect one CARP entity created
-    assert len(created) == 1
-    assert isinstance(created[0], OPNsenseCarpStatusBinarySensor)
-
-
-@pytest.mark.asyncio
 async def test_async_setup_entry_creates_only_notices_when_notices_enabled(make_config_entry):
     """Create only Notices entity when notices sync is enabled."""
-    # enable only Notices
-    entry = make_config_entry(
-        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_CARP: False, CONF_SYNC_NOTICES: True}
-    )
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_NOTICES: True})
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {}
     setattr(entry.runtime_data, COORDINATOR, coord)
@@ -128,52 +84,6 @@ async def test_async_setup_entry_creates_only_notices_when_notices_enabled(make_
     # expect one Notices entity created
     assert len(created) == 1
     assert isinstance(created[0], OPNsensePendingNoticesPresentBinarySensor)
-
-
-@pytest.mark.parametrize(
-    "coord_data,expect_write_called,expect_available,expect_is_on,expect_extra",
-    [
-        (None, True, False, None, None),
-        ({"carp_status": True}, True, True, True, dict),
-        ({"carp_status": False}, True, True, False, dict),
-        ({"other": 1}, True, False, None, None),
-        # non-boolean carp value should trigger a write and mark sensor available; extras are dict
-        ({"carp_status": "up"}, True, True, None, dict),
-    ],
-)
-def test_carp_sensor_update_paths_param(
-    coord_data, expect_write_called, expect_available, expect_is_on, expect_extra, make_config_entry
-):
-    """Parameterized tests for CARP status sensor update paths. Covers: non-mapping (None), present True, and missing-key cases."""
-    entry = make_config_entry()
-    desc = BinarySensorEntityDescription(key="carp_status", name="CARP Status")
-
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = coord_data
-    s = OPNsenseCarpStatusBinarySensor(
-        config_entry=entry, coordinator=coord, entity_description=desc
-    )
-
-    write_called = {"val": False}
-
-    def write():
-        """Write."""
-        write_called["val"] = True
-
-    s.hass = MagicMock()
-    s.entity_id = "binary_sensor.carp"
-    # only replace writer when we expect to observe a call, else set a no-op
-    s.async_write_ha_state = write if expect_write_called else lambda: None
-
-    s._handle_coordinator_update()
-    assert write_called["val"] is expect_write_called
-    assert s.available is expect_available
-    if expect_is_on is not None:
-        assert s.is_on is expect_is_on
-    if expect_extra is not None:
-        assert isinstance(s.extra_state_attributes, expect_extra)
-        if coord_data and "carp_status" in (coord_data or {}):
-            assert s.extra_state_attributes == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -93,6 +93,36 @@ async def test_get_states_handles_missing_method_and_calls(make_config_entry, fa
 
 
 @pytest.mark.asyncio
+async def test_get_states_uses_single_carp_call(make_config_entry, fake_client):
+    """Coordinator should fetch CARP once and populate unified CARP state key."""
+    client = fake_client()()
+    client.get_carp = AsyncMock(
+        return_value={
+            "interfaces": [{"interface": "wan", "subnet": "1.2.3.4", "status": "MASTER"}],
+            "status_summary": {"state": "healthy", "vip_count": 1},
+        }
+    )
+
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=make_config_entry(),
+    )
+    categories = [
+        {"function": "get_carp", "state_key": "carp"},
+    ]
+
+    state = await coord._get_states(categories)
+
+    client.get_carp.assert_awaited_once()
+    assert state["carp"]["interfaces"][0]["status"] == "MASTER"
+    assert state["carp"]["status_summary"]["state"] == "healthy"
+
+
+@pytest.mark.asyncio
 async def test_check_device_unique_id_mismatch_triggers_issue(
     monkeypatch, make_config_entry, fake_client
 ):
@@ -414,7 +444,7 @@ def test_build_categories_returns_empty_when_no_config(make_config_entry, fake_c
         (CONF_SYNC_SPEEDTEST, ["speedtest"]),
         (CONF_SYNC_VPN, ["openvpn", "wireguard"]),
         (CONF_SYNC_FIRMWARE_UPDATES, ["firmware_update_info"]),
-        (CONF_SYNC_CARP, ["carp_interfaces", "carp_status"]),
+        (CONF_SYNC_CARP, ["carp"]),
         (CONF_SYNC_DHCP_LEASES, ["dhcp_leases"]),
         (CONF_SYNC_GATEWAYS, ["gateways"]),
         (CONF_SYNC_SERVICES, ["services"]),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -22,6 +22,7 @@ from custom_components.opnsense.const import (
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.sensor import (
     OPNsenseCarpInterfaceSensor,
+    OPNsenseCarpStatusSensor,
     OPNsenseDHCPLeasesSensor,
     OPNsenseGatewaySensor,
     OPNsenseInterfaceSensor,
@@ -97,8 +98,8 @@ async def test_static_key_sensor_cpu_and_boot_and_certificates(make_config_entry
     "coord_data,desc_subnet",
     [
         (None, "some"),
-        ({"carp_interfaces": [{"subnet": "10.0.0.5", "status": "MASTER"}]}, "192.168.1.10"),
-        ({"carp_interfaces": [{"subnet": "1.2.3.4", "interface": "lan0"}]}, "1.2.3.4"),
+        ({"carp": {"interfaces": [{"subnet": "10.0.0.5", "status": "MASTER"}]}}, "192.168.1.10"),
+        ({"carp": {"interfaces": [{"subnet": "1.2.3.4", "interface": "lan0"}]}}, "1.2.3.4"),
     ],
 )
 def test_carp_sensor_unavailable_variants(coord_data, desc_subnet, make_config_entry):
@@ -142,6 +143,7 @@ def test_carp_sensor_state_wrong_type(make_config_entry):
     "desc_key,cls",
     [
         ("carp.interface.some", OPNsenseCarpInterfaceSensor),
+        ("carp.status_summary", OPNsenseCarpStatusSensor),
         ("gateway.gw1.status", OPNsenseGatewaySensor),
         ("interface.lan.status", OPNsenseInterfaceSensor),
         ("telemetry.temps.sensor1", OPNsenseTempSensor),
@@ -246,7 +248,7 @@ def test_gateway_sensor_missing_and_missing_prop(make_config_entry):
 
 
 @pytest.mark.parametrize(
-    "carp_entry,expected_value,expect_down_icon,expect_keys",
+    ("carp_entry", "expected_value", "expected_icon", "expect_keys"),
     [
         (
             {
@@ -258,27 +260,34 @@ def test_gateway_sensor_missing_and_missing_prop(make_config_entry):
                 "advbase": 0,
                 "subnet_bits": 24,
                 "descr": "test carp",
+                "mode": "carp",
             },
             "BACKUP",
-            True,
-            ("interface", "vhid", "advskew", "advbase", "subnet_bits", "subnet", "descr"),
+            "mdi:backup-restore",
+            ("interface", "vhid", "advskew", "advbase", "subnet_bits", "subnet", "descr", "mode"),
         ),
         (
             {"subnet": "10.0.0.1", "status": "MASTER"},
             "MASTER",
-            False,
+            "mdi:check-network",
+            (),
+        ),
+        (
+            {"subnet": "10.0.0.3", "status": "INIT"},
+            "INIT",
+            "mdi:close-network-outline",
             (),
         ),
     ],
 )
 def test_carp_sensor_attributes_and_icon(
-    carp_entry, expected_value, expect_down_icon, expect_keys, make_config_entry
+    carp_entry, expected_value, expected_icon, expect_keys, make_config_entry
 ):
     """Parameterized attribute and icon checks for CARP sensor."""
     entry = make_config_entry()
 
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"carp_interfaces": [carp_entry]}
+    coord.data = {"carp": {"interfaces": [carp_entry]}}
 
     desc = MagicMock()
     desc.key = f"carp.interface.{sensor_module.slugify(carp_entry['subnet'])}"
@@ -292,22 +301,193 @@ def test_carp_sensor_attributes_and_icon(
 
     assert s.available is True
     assert s.native_value == expected_value
-    if expect_down_icon:
-        assert s.icon == "mdi:close-network-outline"
-    else:
-        assert s.icon != "mdi:close-network-outline"
+    assert s.icon == expected_icon
     for key in expect_keys:
         assert key in s.extra_state_attributes
 
 
 @pytest.mark.parametrize(
-    "desc_key,cls,main_check,extra_check",
+    ("summary", "expected_value", "expected_icon"),
+    [
+        (
+            {
+                "state": "healthy",
+                "enabled": True,
+                "maintenance_mode": False,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 2,
+                "master_count": 1,
+                "backup_count": 1,
+                "other_count": 0,
+                "interfaces": ["lan", "wan"],
+                "vips": [{"interface": "wan", "subnet": "1.2.3.4", "status": "MASTER"}],
+            },
+            "healthy",
+            "mdi:check-network",
+        ),
+        (
+            {
+                "state": "maintenance",
+                "enabled": True,
+                "maintenance_mode": True,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 1,
+                "master_count": 1,
+                "backup_count": 0,
+                "other_count": 0,
+                "interfaces": ["wan"],
+                "vips": [],
+            },
+            "maintenance",
+            "mdi:backup-restore",
+        ),
+        (
+            {
+                "state": "degraded",
+                "enabled": True,
+                "maintenance_mode": False,
+                "demotion": 3,
+                "status_message": "demoted",
+                "vip_count": 1,
+                "master_count": 0,
+                "backup_count": 0,
+                "other_count": 1,
+                "interfaces": ["wan"],
+                "vips": [],
+            },
+            "degraded",
+            "mdi:close-network-outline",
+        ),
+        (
+            {
+                "state": "disabled",
+                "enabled": False,
+                "maintenance_mode": False,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 1,
+                "master_count": 0,
+                "backup_count": 0,
+                "other_count": 1,
+                "interfaces": ["wan"],
+                "vips": [{"interface": "wan", "subnet": "1.2.3.5", "status": "INIT"}],
+            },
+            "disabled",
+            "mdi:close-network-outline",
+        ),
+        (
+            {
+                "state": "not_configured",
+                "enabled": True,
+                "maintenance_mode": False,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 0,
+                "master_count": 0,
+                "backup_count": 0,
+                "other_count": 0,
+                "interfaces": [],
+                "vips": [],
+            },
+            "not_configured",
+            "mdi:backup-restore",
+        ),
+        (
+            {
+                "state": "unknown",
+                "enabled": False,
+                "maintenance_mode": False,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 0,
+                "master_count": 0,
+                "backup_count": 0,
+                "other_count": 0,
+                "interfaces": [],
+                "vips": [],
+            },
+            "unknown",
+            "mdi:gauge",
+        ),
+    ],
+)
+def test_carp_status_sensor_states_and_attributes(
+    summary: dict[str, Any],
+    expected_value: str,
+    expected_icon: str,
+    make_config_entry,
+) -> None:
+    """Validate aggregate CARP status sensor state, icon, and attributes."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"carp": {"status_summary": summary}}
+
+    desc = MagicMock()
+    desc.key = "carp.status_summary"
+    desc.name = "CARP Status"
+    desc.icon = "mdi:gauge"
+
+    sensor = OPNsenseCarpStatusSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.carp_status"
+    sensor.async_write_ha_state = lambda: None
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == expected_value
+    assert sensor.icon == expected_icon
+    assert sensor.extra_state_attributes.get("vip_count") == summary.get("vip_count")
+    assert sensor.extra_state_attributes.get("interfaces") == summary.get("interfaces")
+
+
+@pytest.mark.asyncio
+async def test_compile_carp_interface_sensor_name_includes_interface(make_config_entry) -> None:
+    """Compiled CARP interface sensor names should include interface and VIP address."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    state = {
+        "interfaces": {"wan": {"name": "WAN", "interface": "wan", "device": "igc0"}},
+        "carp": {
+            "interfaces": [
+                {
+                    "subnet": "203.0.113.10",
+                    "interface": "wan",
+                    "status": "MASTER",
+                    "descr": "Primary WAN VIP",
+                }
+            ]
+        },
+    }
+    coordinator.data = state
+
+    entities = await sensor_module._compile_carp_interface_sensors(entry, coordinator, state)
+    assert len(entities) == 1
+    assert (
+        entities[0].entity_description.name
+        == "CARP Interface Status WAN 203.0.113.10 (Primary WAN VIP)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("desc_key", "cls", "main_check", "extra_check"),
     [
         (
             f"carp.interface.{sensor_module.slugify('10.0.0.1')}",
             OPNsenseCarpInterfaceSensor,
             lambda s: s.native_value == "MASTER",
-            lambda s: s.icon != "mdi:close-network-outline",
+            lambda s: s.icon == "mdi:check-network",
+        ),
+        (
+            "carp.status_summary",
+            OPNsenseCarpStatusSensor,
+            lambda s: s.native_value == "healthy",
+            lambda s: s.icon == "mdi:check-network",
         ),
         (
             "gateway.gw1.delay",
@@ -333,9 +513,24 @@ def test_carp_sensor_attributes_and_icon(
 def test_compiled_sensor_variants(desc_key, cls, main_check, extra_check, make_config_entry):
     """Table-driven checks for several sensor types using a common sample state."""
     state = {
-        "carp_interfaces": [
-            {"subnet": "10.0.0.1", "status": "MASTER", "interface": "lan0", "vhid": 1}
-        ],
+        "carp": {
+            "interfaces": [
+                {"subnet": "10.0.0.1", "status": "MASTER", "interface": "lan0", "vhid": 1}
+            ],
+            "status_summary": {
+                "state": "healthy",
+                "enabled": True,
+                "maintenance_mode": False,
+                "demotion": 0,
+                "status_message": "",
+                "vip_count": 1,
+                "master_count": 1,
+                "backup_count": 0,
+                "other_count": 0,
+                "interfaces": ["lan0"],
+                "vips": [{"interface": "lan0", "subnet": "10.0.0.1", "status": "MASTER"}],
+            },
+        },
         "gateways": {"gw1": {"name": "gw1", "delay": "12ms", "loss": "0", "status": "online"}},
         "openvpn": {
             "servers": {
@@ -374,7 +569,14 @@ def test_compiled_sensor_variants(desc_key, cls, main_check, extra_check, make_c
 
 
 @pytest.mark.parametrize(
-    "state,desc_key,expected_available,expected_value,expect_clients,expect_extra_keys",
+    (
+        "state",
+        "desc_key",
+        "expected_available",
+        "expected_value",
+        "expect_clients",
+        "expect_extra_keys",
+    ),
     [
         # missing instance -> unavailable
         (
@@ -1199,15 +1401,17 @@ async def test_compile_and_handle_many_entities(make_config_entry):
                 "status": "online",
             }
         },
-        "carp_interfaces": [
-            {
-                "subnet": "192.0.2.1",
-                "status": "BACKUP",
-                "interface": "lan0",
-                "vhid": 2,
-                "advskew": 100,
-            }
-        ],
+        "carp": {
+            "interfaces": [
+                {
+                    "subnet": "192.0.2.1",
+                    "status": "BACKUP",
+                    "interface": "lan0",
+                    "vhid": 2,
+                    "advskew": 100,
+                }
+            ]
+        },
         "openvpn": {
             "servers": {
                 "s1": {"name": "ovpn1", "status": "up", "clients": [{"name": "c1", "status": "up"}]}


### PR DESCRIPTION
This pull request refactors how CARP (Common Address Redundancy Protocol) status is handled in the OPNsense Home Assistant integration. It removes the binary sensor for CARP status, introduces a new aggregate CARP status sensor, improves handling of CARP interface sensors, and adds utility helpers for boolean and token normalization. Documentation and test fixtures are updated to match these changes.

**CARP status and interface sensor improvements:**

- Removed the `OPNsenseCarpStatusBinarySensor` and replaced it with a new aggregate CARP status sensor (`OPNsenseCarpStatusSensor`) that provides richer state and attributes, including enabled status, maintenance mode, demotion count, and summary counts. The new sensor uses improved icon logic and state handling. (`[[1]](diffhunk://#diff-3c10fa953ce6b6a66776f465c327384108175ab1ff1bc2ac250490a560ef22d8L35-L49)`, `[[2]](diffhunk://#diff-3c10fa953ce6b6a66776f465c327384108175ab1ff1bc2ac250490a560ef22d8L94-L115)`, `[[3]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R424-R459)`, `[[4]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R832)`, `[[5]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L1119-R1254)`)
- Refactored CARP interface sensors to be more robust against malformed data and to provide more descriptive names. Now uses `carp.interfaces` from state and improved error handling. (`[[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L377-R414)`, `[[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L1086-R1164)`)
- The coordinator now fetches CARP data via a single `get_carp` call, simplifying state management. (`[custom_components/opnsense/coordinator.pyL175-R175](diffhunk://#diff-a50b56206be39ea89eb36484c42f02177be0dd9883ee46ac99bf0ada97598e1cL175-R175)`)

**Helpers and utilities:**

- Added `coerce_bool` and `normalize_lookup_token` utility functions to handle common data normalization tasks across the integration. (`[[1]](diffhunk://#diff-6aa06e6a8aa1a447ab0239ca38fbc75097f6921607e4930cf4094cee36367b80R40-R57)`, `[[2]](diffhunk://#diff-deda83701777dd97975ebad6b69381106c3a0a876f4af946095613a93f2632dfR224-R255)`)
- Updated code to use these helpers where appropriate, including in the vnstat parser and sensor logic. (`[[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L49-R49)`, `[[2]](diffhunk://#diff-fcc9e13cfcd2bc1711e587d37cef6fbd50cae1c17a9dc5c599dcfc7ce8d06317L11-R11)`, `[[3]](diffhunk://#diff-fcc9e13cfcd2bc1711e587d37cef6fbd50cae1c17a9dc5c599dcfc7ce8d06317L64-R64)`, `[[4]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70R1187)`)

**Workflow and dependency management:**

- Changed the GitHub workflow to pin the `aiopnsense` dependency to an exact version instead of a minimum version, updating commit messages and PR body accordingly. (`[[1]](diffhunk://#diff-dbc0ac39afd33125d25d045198103cde0102cb47dc4893b90c16aae4b05de282L79-R79)`, `[[2]](diffhunk://#diff-dbc0ac39afd33125d25d045198103cde0102cb47dc4893b90c16aae4b05de282L180-R187)`)

**Documentation and tests:**

- Updated the README to reflect the new aggregate CARP status sensor and clarify available entities. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R181)`)
- Added a test fixture for the new CARP payload structure. (`[tests/conftest.pyR705-R723](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R705-R723)`)
- Added `aiopnsense` to the test dependencies. (`[pyproject.tomlR18](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R18)`)