### PR TITLE
Update aiopnsense Github Action

### DIFF
--- a/.github/workflows/update_aiopnsense_manifest.yml
+++ b/.github/workflows/update_aiopnsense_manifest.yml
@@ -1,4 +1,4 @@
-name: Update aiopnsense manifest requirement
+name: Update aiopnsense in manifest
 
 on:
   schedule:
@@ -121,6 +121,12 @@ jobs:
               return 0;
             }
 
+            function sanitizeReleaseBody(body) {
+              return body
+                .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
+                .replace(/(^|\s)@([A-Za-z0-9-]+)/g, "$1$2");
+            }
+
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner: releaseOwner,
               repo: releaseRepo,
@@ -157,7 +163,9 @@ jobs:
             } else {
               notes = selected
                 .map((release) => {
-                  const body = (release.body || "No release body provided.").trim();
+                  const body = sanitizeReleaseBody(
+                    (release.body || "No release body provided.").trim(),
+                  );
                   return [
                     `### ${release.name || release.tag_name} (${release.tag_name})`,
                     release.html_url,
@@ -177,8 +185,8 @@ jobs:
         with:
           branch: chore/update-aiopnsense-manifest
           delete-branch: true
-          commit-message: 'chore(deps): bump aiopnsense to ==${{ steps.versions.outputs.latest }}'
-          title: 'chore(deps): bump aiopnsense to ==${{ steps.versions.outputs.latest }}'
+          commit-message: 'chore(deps): bump aiopnsense to ${{ steps.versions.outputs.latest }}'
+          title: 'chore(deps): bump aiopnsense to ${{ steps.versions.outputs.latest }}'
           labels: dependencies,aiopnsense-auto-update
           body: |
             Automated update of `custom_components/opnsense/manifest.json`.


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for automatically updating the `aiopnsense` dependency in the manifest. The main improvements are focused on cleaning up the release notes formatting and making minor naming and message adjustments.

**Release notes sanitization:**

* Added a `sanitizeReleaseBody` function to remove GitHub username mentions and links from release notes in the workflow, ensuring cleaner and more readable PR descriptions. [[1]](diffhunk://#diff-dbc0ac39afd33125d25d045198103cde0102cb47dc4893b90c16aae4b05de282R124-R129) [[2]](diffhunk://#diff-dbc0ac39afd33125d25d045198103cde0102cb47dc4893b90c16aae4b05de282L160-R168)

**Workflow naming and messaging:**

* Updated the workflow name from "Update aiopnsense manifest requirement" to "Update aiopnsense in manifest" for better clarity.
* Simplified the commit message and PR title by removing unnecessary `==` before the version number.