### PR TITLE
Update aiopnsense GitHub action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,32 +4,33 @@ changelog:
       - ignore-for-release
       - dependencies
   categories:
-    - title: "💥 Breaking Changes"
+    - title: '💥 Breaking Changes'
       labels:
         - Semver-Major
         - breaking-change
-    - title: "✨ New Features"
+    - title: '✨ New Features'
       labels:
         - feature
-    - title: "🚀 Enhancements"
+    - title: '🚀 Enhancements'
       labels:
         - Semver-Minor
         - enhancement
-    - title: "🐛 Bug Fixes"
+    - title: '🐛 Bug Fixes'
       labels:
         - fix
         - bugfix
         - bug
-    - title: "📚 Documentation"
+    - title: '📚 Documentation'
       labels:
         - documentation
-    - title: "🎓 Code Quality"
+    - title: '🎓 Code Quality'
       labels:
         - code-quality
-    - title: "🧰 Maintenance"
+    - title: '🧰 Maintenance'
       labels:
         - chore
         - github_actions
-    - title: "Other Changes"
+        - aiopnsense-auto-update
+    - title: 'Other Changes'
       labels:
-        - "*"
+        - '*'

--- a/.github/workflows/update_aiopnsense_manifest.yml
+++ b/.github/workflows/update_aiopnsense_manifest.yml
@@ -185,10 +185,10 @@ jobs:
         with:
           branch: chore/update-aiopnsense-manifest
           delete-branch: true
-          commit-message: 'chore(deps): bump aiopnsense to ${{ steps.versions.outputs.latest }}'
-          title: 'chore(deps): bump aiopnsense to ${{ steps.versions.outputs.latest }}'
+          commit-message: 'Bump aiopnsense to ${{ steps.versions.outputs.latest }}'
+          title: 'Bump aiopnsense to ${{ steps.versions.outputs.latest }}'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          labels: dependencies,aiopnsense-auto-update
+          labels: aiopnsense-auto-update
           body: |
             Automated update of `custom_components/opnsense/manifest.json`.
 


### PR DESCRIPTION
This pull request makes minor updates to GitHub workflow and release configuration files, mostly focused on standardizing label usage and commit messages for automation. The changes primarily improve consistency in labeling and messaging related to the `aiopnsense` dependency updates.

Labeling and workflow improvements:

* Standardized the use of single quotes for category titles and label wildcards in `.github/release.yml`, and added the `aiopnsense-auto-update` label to the "Other Changes" category for better classification of automated updates.
* Updated the commit message and pull request title formats in `.github/workflows/update_aiopnsense_manifest.yml` to remove the `chore(deps):` prefix, and restricted automated PR labels to only `aiopnsense-auto-update` for clarity.