### PR TITLE
Update Exception Names

### DIFF
--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -55,7 +55,7 @@ from .const import (
     TRACKED_MACS,
 )
 from .helpers import is_private_ip
-from .pyopnsense import UnknownFirmware
+from .pyopnsense import OPNsenseUnknownFirmware
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -320,7 +320,7 @@ async def validate_input(
             key="below_min_firmware",
             message=f"OPNsense Firmware of {user_input.get(CONF_FIRMWARE_VERSION)} is below the minimum supported version of {OPNSENSE_MIN_FIRMWARE}",
         )
-    except UnknownFirmware:
+    except OPNsenseUnknownFirmware:
         _log_and_set_error(
             errors=errors,
             key="unknown_firmware",
@@ -521,7 +521,7 @@ async def _handle_user_input(
         expected_id: Expected device unique ID for reconfigure/options validation.
 
     Raises:
-        UnknownFirmware: Firmware could not be parsed or compared safely.
+        OPNsenseUnknownFirmware: Firmware could not be parsed or compared safely.
         BelowMinFirmware: Firmware is below the minimum supported version.
         PluginMissing: Plugin is required for enabled sync options but not installed.
         MissingDeviceUniqueID: Backend did not return a device unique ID.
@@ -540,7 +540,7 @@ async def _handle_user_input(
             TypeError,
             ValueError,
         ) as e:
-            raise UnknownFirmware from e
+            raise OPNsenseUnknownFirmware from e
 
         await client.set_use_snake_case(initial=True)
 
@@ -562,7 +562,7 @@ async def _handle_user_input(
             TypeError,
             ValueError,
         ) as e:
-            raise UnknownFirmware from e
+            raise OPNsenseUnknownFirmware from e
 
         _LOGGER.debug(
             "[handle_user_input] config_step: %s, require_plugin_check: %s",

--- a/custom_components/opnsense/pyopnsense/__init__.py
+++ b/custom_components/opnsense/pyopnsense/__init__.py
@@ -1,10 +1,10 @@
 """pyopnsense package to manage OPNsense from HA."""
 
 from .client import OPNsenseClient
-from .exceptions import UnknownFirmware, VoucherServerError
+from .exceptions import OPNsenseUnknownFirmware, OPNsenseVoucherServerError
 
 __all__ = [
     "OPNsenseClient",
-    "UnknownFirmware",
-    "VoucherServerError",
+    "OPNsenseUnknownFirmware",
+    "OPNsenseVoucherServerError",
 ]

--- a/custom_components/opnsense/pyopnsense/client_base.py
+++ b/custom_components/opnsense/pyopnsense/client_base.py
@@ -16,7 +16,7 @@ import aiohttp
 import awesomeversion
 
 from .const import DEFAULT_CACHE_TTL_SECONDS, DEFAULT_REQUEST_TIMEOUT_SECONDS
-from .exceptions import UnknownFirmware
+from .exceptions import OPNsenseUnknownFirmware
 from .helpers import _LOGGER, _xmlrpc_timeout
 
 
@@ -260,7 +260,7 @@ $toreturn["real"] = json_encode($toreturn_real);
                 firmware,
             )
             if initial:
-                raise UnknownFirmware from e
+                raise OPNsenseUnknownFirmware from e
 
     async def _get_from_stream(self, path: str) -> dict[str, Any]:
         """Queue a streaming GET request and return the parsed payload.

--- a/custom_components/opnsense/pyopnsense/exceptions.py
+++ b/custom_components/opnsense/pyopnsense/exceptions.py
@@ -1,9 +1,9 @@
 """Custom exceptions for pyopnsense."""
 
 
-class VoucherServerError(Exception):
+class OPNsenseVoucherServerError(Exception):
     """Error from Voucher Server."""
 
 
-class UnknownFirmware(Exception):
+class OPNsenseUnknownFirmware(Exception):
     """Unknown current firmware version."""

--- a/custom_components/opnsense/pyopnsense/vouchers.py
+++ b/custom_components/opnsense/pyopnsense/vouchers.py
@@ -5,7 +5,7 @@ from typing import Any
 from urllib.parse import quote
 
 from ._typing import PyOPNsenseClientProtocol
-from .exceptions import VoucherServerError
+from .exceptions import OPNsenseVoucherServerError
 from .helpers import _LOGGER, human_friendly_duration, timestamp_to_datetime, try_to_int
 
 
@@ -29,9 +29,9 @@ class VouchersMixin(PyOPNsenseClientProtocol):
             else:
                 servers = await self._safe_list_get("/api/captiveportal/voucher/listProviders")
             if len(servers) == 0:
-                raise VoucherServerError("No voucher servers exist")
+                raise OPNsenseVoucherServerError("No voucher servers exist")
             if len(servers) != 1:
-                raise VoucherServerError(
+                raise OPNsenseVoucherServerError(
                     "More than one voucher server. Must specify voucher server name"
                 )
             server = servers[0]

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -31,7 +31,7 @@ from .const import (
     SERVICE_SYSTEM_REBOOT,
     SERVICE_TOGGLE_ALIAS,
 )
-from .pyopnsense import VoucherServerError
+from .pyopnsense import OPNsenseVoucherServerError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
@@ -549,7 +549,7 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
     for client in clients:
         try:
             vouchers: list = await client.generate_vouchers(call.data)
-        except VoucherServerError as e:
+        except OPNsenseVoucherServerError as e:
             _LOGGER.error("Error getting vouchers from %s. %s", client.name, e)
             raise ServiceValidationError(f"Error getting vouchers from {client.name}. {e}") from e
         _LOGGER.debug(

--- a/tests/pyopnsense/test_client_base.py
+++ b/tests/pyopnsense/test_client_base.py
@@ -1262,7 +1262,7 @@ async def test_reset_and_get_query_counts():
 
 @pytest.mark.asyncio
 async def test_set_use_snake_case_unknown_firmware_raise(monkeypatch, make_client) -> None:
-    """set_use_snake_case should raise UnknownFirmware when initial True and compare fails."""
+    """set_use_snake_case should raise OPNsenseUnknownFirmware when initial True and compare fails."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = make_client(session=session)
     client._firmware_version = "25.x"
@@ -1281,6 +1281,6 @@ async def test_set_use_snake_case_unknown_firmware_raise(monkeypatch, make_clien
             raise awesomeversion.exceptions.AwesomeVersionCompareException("bad")
 
     monkeypatch.setattr(pyopnsense_client_base.awesomeversion, "AwesomeVersion", BadAV)
-    with pytest.raises(pyopnsense.UnknownFirmware):
+    with pytest.raises(pyopnsense.OPNsenseUnknownFirmware):
         await client.set_use_snake_case(initial=True)
     await client.async_close()

--- a/tests/pyopnsense/test_exceptions.py
+++ b/tests/pyopnsense/test_exceptions.py
@@ -6,6 +6,6 @@ from custom_components.opnsense import pyopnsense
 
 
 def test_voucher_server_error() -> None:
-    """Raise VoucherServerError to ensure the exception class exists."""
-    with pytest.raises(pyopnsense.VoucherServerError):
-        raise pyopnsense.VoucherServerError
+    """Raise OPNsenseVoucherServerError to ensure the exception class exists."""
+    with pytest.raises(pyopnsense.OPNsenseVoucherServerError):
+        raise pyopnsense.OPNsenseVoucherServerError

--- a/tests/pyopnsense/test_vouchers.py
+++ b/tests/pyopnsense/test_vouchers.py
@@ -12,8 +12,8 @@ from custom_components.opnsense import pyopnsense
 @pytest.mark.parametrize(
     "safe_get_ret,safe_post_ret,data,expect_exc,expect_username,expect_extras",
     [
-        ([], None, {}, pyopnsense.VoucherServerError, None, None),
-        (["s1", "s2"], None, {}, pyopnsense.VoucherServerError, None, None),
+        ([], None, {}, pyopnsense.OPNsenseVoucherServerError, None, None),
+        (["s1", "s2"], None, {}, pyopnsense.OPNsenseVoucherServerError, None, None),
         (
             None,
             [

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -147,7 +147,7 @@ async def test_validate_input_exception_mapping(monkeypatch, exc_key, expected):
     if exc_key == "below_min":
         exc = cf_mod.BelowMinFirmware()
     elif exc_key == "unknown_fw":
-        exc = cf_mod.UnknownFirmware()
+        exc = cf_mod.OPNsenseUnknownFirmware()
     elif exc_key == "missing_external_dep":
         exc = cf_mod.MissingExternalAiopnsenseDependency()
     elif exc_key == "missing_id":

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from custom_components.opnsense import services as services_mod
 from custom_components.opnsense.const import DOMAIN, SERVICE_GET_VNSTAT_METRICS
-from custom_components.opnsense.pyopnsense import VoucherServerError
+from custom_components.opnsense.pyopnsense import OPNsenseVoucherServerError
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 
@@ -329,7 +329,7 @@ async def test_generate_vouchers_success_and_server_error(monkeypatch, ph_hass):
     assert all(v.get("client") == "svc1" for v in resp["vouchers"])
 
     # server error should raise ServiceValidationError
-    c1.generate_vouchers = AsyncMock(side_effect=VoucherServerError("boom"))
+    c1.generate_vouchers = AsyncMock(side_effect=OPNsenseVoucherServerError("boom"))
     with pytest.raises(ServiceValidationError):
         await services_mod._service_generate_vouchers(hass, call)
 


### PR DESCRIPTION
This pull request standardizes exception class names throughout the OPNsense Home Assistant integration by renaming `VoucherServerError` to `OPNsenseVoucherServerError` and `UnknownFirmware` to `OPNsenseUnknownFirmware`. The changes affect both the core codebase and associated tests, ensuring consistency and clarity in exception handling.

**Exception renaming and code updates:**

* Renamed the exception `VoucherServerError` to `OPNsenseVoucherServerError` and updated all imports, raises, and exception handling logic in `pyopnsense` modules, including `vouchers.py`, `exceptions.py`, `client_base.py`, and `services.py`. [[1]](diffhunk://#diff-88247b2b0d25c860380f6845a9078e132b2d66051af2d1aba90b7559ab815831L4-R8) [[2]](diffhunk://#diff-8c17aa085f48fc258c9fb706d8a3809b01918e426bf63b0bd44b497a6c7a2ff6L8-R8) [[3]](diffhunk://#diff-8c17aa085f48fc258c9fb706d8a3809b01918e426bf63b0bd44b497a6c7a2ff6L32-R34) [[4]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L4-R9) [[5]](diffhunk://#diff-00a81b15e23f2d5137a24436de681a6824778108cc296e9747b25f1cd7ea6752L34-R34) [[6]](diffhunk://#diff-00a81b15e23f2d5137a24436de681a6824778108cc296e9747b25f1cd7ea6752L552-R552)
* Renamed the exception `UnknownFirmware` to `OPNsenseUnknownFirmware` and updated all relevant imports, raises, and exception handling in `config_flow.py`, `client_base.py`, and `pyopnsense/__init__.py`. [[1]](diffhunk://#diff-88247b2b0d25c860380f6845a9078e132b2d66051af2d1aba90b7559ab815831L4-R8) [[2]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L58-R58) [[3]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L323-R323) [[4]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L524-R524) [[5]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L543-R543) [[6]](diffhunk://#diff-f92834a1ea002da85cc96be68621d33319228d3d962da15eb04533f32be6d542L565-R565) [[7]](diffhunk://#diff-a1849d59a8e94ffaec88964ff785c0ed7f5808abf72ac12b7e218bc597ede8d2L4-R9) [[8]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L19-R19) [[9]](diffhunk://#diff-a92dc668bf915f03ae0a117158cd690f27b7df12275e9c989509ffb82a679d28L263-R263)

**Test updates:**

* Updated all tests to use the new exception names, including parameterizations, exception assertions, and docstrings in `test_client_base.py`, `test_exceptions.py`, `test_vouchers.py`, `test_config_flow.py`, and `test_services.py`. [[1]](diffhunk://#diff-974ddbf985d498f95dfdb12bd46d127f88e41a66425abb04ac6608b0d114178dL1265-R1265) [[2]](diffhunk://#diff-974ddbf985d498f95dfdb12bd46d127f88e41a66425abb04ac6608b0d114178dL1284-R1284) [[3]](diffhunk://#diff-024d233d25e46810932f1a31d998b8822a17a6fd1566a445764c7ecbed886c58L9-R11) [[4]](diffhunk://#diff-6eef075210b1e3087a9868c1a80cf3eb5a28187ec666a46ca726f1bfd0da1aaaL15-R16) [[5]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L150-R150) [[6]](diffhunk://#diff-caee650c3003842e9277d696a063ab724d42606e64cbf44cf1deb9d1d67d1d98L14-R14) [[7]](diffhunk://#diff-caee650c3003842e9277d696a063ab724d42606e64cbf44cf1deb9d1d67d1d98L332-R332)