### PR TITLE
Fix Granular Sync Typo

### DIFF
--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -43,7 +43,7 @@
           "sync_carp": "CARP information",
           "sync_services": "Service switches",
           "sync_notices": "Notice information",
-          "sync_filters_and_nat": "Firewall filter and NAT switches",
+          "sync_filters_and_nat": "Firewall and NAT rules switches",
           "sync_unbound": "Unbound blocklist switches",
           "sync_certificates": "Security certificate information",
           "sync_vnstat": "vnStat bandwidth usage",


### PR DESCRIPTION
This pull request makes a minor update to the English translations for the OPNsense integration. The change clarifies the label for firewall and NAT switches to better reflect their purpose.

- Updated the translation for `sync_filters_and_nat` from "Firewall filter and NAT switches" to "Firewall and NAT rules switches" in `en.json` for improved clarity.

#566 