### PR TITLE
Create lock_closed_issues.yml

### DIFF
--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -1,0 +1,26 @@
+name: 'Lock Closed Issues'
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v6
+        with:
+          issue-inactive-days: '7'
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+          issue-lock-reason: 'resolved'
+          process-only: 'issues'
+          log-output: true


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically lock closed issues after a period of inactivity. The workflow is scheduled to run daily and helps keep the issue tracker organized by preventing further comments on stale closed issues.

**Automation and repository hygiene:**

* Added `.github/workflows/lock_closed_issues.yml` to automatically lock closed issues after 7 days of inactivity, with a comment explaining the action and the lock reason set to 'resolved'. The workflow runs daily and can also be triggered manually.