### PR TITLE
Update lock_closed_issues.yml

### DIFF
--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -18,9 +18,6 @@ jobs:
       - uses: dessant/lock-threads@v6
         with:
           issue-inactive-days: '7'
-          issue-comment: >
-            This issue has been automatically locked since there
-            has not been any recent activity after it was closed.
           issue-lock-reason: 'resolved'
           process-only: 'issues'
           log-output: true


### PR DESCRIPTION
This pull request makes a minor update to the issue locking workflow by removing the automatic comment that was previously posted when issues were locked due to inactivity.

- Workflow update:
  * [`.github/workflows/lock_closed_issues.yml`](diffhunk://#diff-9f687b69666640da890c9d9abaafb18b3976d3a6ac939cd8a005bfededccc142L21-L23): Removed the `issue-comment` message so that locked issues will no longer receive an automated comment when being locked.