### PR TITLE
Add prek autoupdate GitHub Action

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -1,0 +1,35 @@
+name: prek Autoupdate
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Run prek
+        uses: j178/prek-action@v2
+        with:
+          extra-args: autoupdate --cooldown-days 7
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        id: cpr
+        with:
+          commit-message: 'chore: update prek hooks'
+          title: 'Bump prek Hooks'
+          branch: chore/prek-updates
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          labels: dependencies
+          delete-branch: true
+          add-paths: |
+            prek.toml
+            .pre-commit-config.yaml


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the updating of prek hooks on a scheduled basis. This helps ensure that the project's pre-commit hooks remain current with minimal manual intervention.

**Automation and CI/CD:**

* Added a new workflow file `.github/workflows/prek_autoupdate.yml` that runs weekly and on manual dispatch to automatically update prek hooks and create a pull request with the changes.
* The workflow uses the `j178/prek-action` to perform the update and the `peter-evans/create-pull-request` action to open a pull request with the updated files (`prek.toml`, `.pre-commit-config.yaml`).