### PR TITLE
Fix prek autoupdate

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -15,10 +15,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Run prek
-        uses: j178/prek-action@v2
+      - name: Install prek
+        uses: taiki-e/install-action@v2
         with:
-          extra-args: autoupdate --cooldown-days 7
+          tool: prek
+
+      - name: Run prek auto-update
+        run: |
+          prek autoupdate --cooldown-days 7
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
This pull request updates the workflow for running the `prek` tool in the `.github/workflows/prek_autoupdate.yml` file. The main change is switching from using the `j178/prek-action` to explicitly installing `prek` with `taiki-e/install-action`, and then running the tool via a shell command. This provides more control and flexibility over how `prek` is installed and executed.

Workflow improvements:

* Replaced the `j178/prek-action@v2` usage with `taiki-e/install-action@v2` to install `prek`, and updated the workflow to run `prek autoupdate` using a shell command instead of an action step. (.github/workflows/prek_autoupdate.yml)