### PR TITLE
GitHub Action Cleanup

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,10 +4,13 @@ on:
 
 jobs:
   labeler:
+    name: Pull Request Labeler
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+
     steps:
       - name: Pull Request Labeler
         uses: srvaroa/labeler@v1.14.0

--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   action:
+    name: Lock Closed Issues
     runs-on: ubuntu-latest
     steps:
       - name: Lock closed issues

--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update-hooks:
+    name: Update prek Hooks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,17 @@ on:
 
 jobs:
   update_version_and_create_zip:
+    name: Update Version and Create Zip on Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          # Use the release branch when available so git-auto-commit can push
+          # back cleanly; otherwise keep the workflow's triggering ref.
+          ref: ${{ github.event_name == 'release' && github.event.release.target_commitish || github.ref }}
 
       - name: Debug GitHub Variables
         run: |

--- a/.github/workflows/update_aiopnsense_manifest.yml
+++ b/.github/workflows/update_aiopnsense_manifest.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   update-aiopnsense:
+    name: Update aiopnsense
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve clarity and maintainability by adding explicit job names and, in one case, enhancing the release workflow to ensure proper branch usage during releases.

**Workflow job naming improvements:**

* Added explicit `name` fields to jobs in the following workflow files for better readability and identification in the Actions UI:
  * [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bR7-R13): Job named "Pull Request Labeler"
  * [`.github/workflows/lock_closed_issues.yml`](diffhunk://#diff-9f687b69666640da890c9d9abaafb18b3976d3a6ac939cd8a005bfededccc142R16): Job named "Lock Closed Issues"
  * [`.github/workflows/prek_autoupdate.yml`](diffhunk://#diff-a46adacdf6d6cf9bf43ca6393fd92b2c6b2ce3dd949028c0e00b9763c1e025edR13): Job named "Update prek Hooks"
  * [`.github/workflows/update_aiopnsense_manifest.yml`](diffhunk://#diff-dbc0ac39afd33125d25d045198103cde0102cb47dc4893b90c16aae4b05de282R27): Job named "Update aiopnsense"
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R9-R19): Job named "Update Version and Create Zip on Release"

**Release workflow enhancement:**

* In `.github/workflows/release.yml`, updated the checkout step to use the release branch when available, ensuring that git-auto-commit can push changes back cleanly during release events