### PR TITLE
Harden Kea DHCP lease sensor null payload handling

### DIFF
--- a/custom_components/opnsense/manifest.json
+++ b/custom_components/opnsense/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "python-dateutil",
     "awesomeversion",
-    "aiopnsense==1.0.9"
+    "aiopnsense==1.0.8"
   ],
   "version":"v0.6.7"
 }

--- a/custom_components/opnsense/manifest.json
+++ b/custom_components/opnsense/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "python-dateutil",
     "awesomeversion",
-    "aiopnsense==1.0.8"
+    "aiopnsense==1.0.9"
   ],
   "version":"v0.6.7"
 }

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1546,9 +1546,14 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
             return
         if_name: str = self.entity_description.key.split(".")[1].strip()
         # _LOGGER.debug(f"[OPNsenseDHCPLeasesSensor handle_coordinator_update] if_name: {if_name}")
+        dhcp_leases = state.get("dhcp_leases")
+        if not isinstance(dhcp_leases, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
         if if_name.lower() == "all":
-            leases = state.get("dhcp_leases", {}).get("leases", {})
-            lease_interfaces = state.get("dhcp_leases", {}).get("lease_interfaces", {})
+            leases = dhcp_leases.get("leases", {})
+            lease_interfaces = dhcp_leases.get("lease_interfaces", {})
             # _LOGGER.debug(f"[OPNsenseDHCPLeasesSensor handle_coordinator_update] lease_interfaces: {lease_interfaces}")
             # _LOGGER.debug(f"[OPNsenseDHCPLeasesSensor handle_coordinator_update] leases: {leases}")
             if not isinstance(leases, MutableMapping) or not isinstance(
@@ -1583,7 +1588,12 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
             self._attr_native_value = total_lease_count
 
         else:
-            interface = state.get("dhcp_leases", {}).get("leases", {}).get(if_name, [])
+            leases = dhcp_leases.get("leases", {})
+            if not isinstance(leases, MutableMapping):
+                self._available = False
+                self.async_write_ha_state()
+                return
+            interface = leases.get(if_name, [])
             if not isinstance(interface, list):
                 self._available = False
                 self.async_write_ha_state()

--- a/prek.toml
+++ b/prek.toml
@@ -70,7 +70,7 @@ additional_dependencies = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.13"
+rev = "v0.15.15"
 
 [[repos.hooks]]
 id = "ruff-check"

--- a/tests/pyopnsense/test_pyopnsense.py
+++ b/tests/pyopnsense/test_pyopnsense.py
@@ -6,16 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
+
 from custom_components.opnsense import (
     device_tracker as device_tracker_mod,
-)
-from custom_components.opnsense import (
     pyopnsense,
-)
-from custom_components.opnsense import (
     sensor as sensor_mod,
-)
-from custom_components.opnsense import (
     switch as switch_mod,
 )
 from custom_components.opnsense.const import CONF_SYNC_FIREWALL_AND_NAT

--- a/tests/pyopnsense/test_pyopnsense.py
+++ b/tests/pyopnsense/test_pyopnsense.py
@@ -6,15 +6,19 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
-
 from custom_components.opnsense import (
     device_tracker as device_tracker_mod,
+)
+from custom_components.opnsense import (
     pyopnsense,
+)
+from custom_components.opnsense import (
     sensor as sensor_mod,
+)
+from custom_components.opnsense import (
     switch as switch_mod,
 )
 from custom_components.opnsense.const import CONF_SYNC_FIREWALL_AND_NAT
-from tests.utilities import stub_async_write_ha_state
 
 
 @pytest.mark.asyncio
@@ -261,7 +265,7 @@ async def test_scanner_entity_handle_coordinator_update_missing_state_sets_unava
     )
     # ensure async_write_ha_state won't raise due to missing hass during unit test
     ent.hass = MagicMock()
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
     ent._handle_coordinator_update()
     assert ent._available is False
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -838,6 +838,14 @@ async def test_validate_input_user_respects_granular_flag_for_plugin_check(
         # Prevent HA internals from being accessed if the flow reaches update/abort paths
         flow.hass.config_entries = MagicMock()
         flow.hass.config_entries.async_update_entry = MagicMock()
+        object.__setattr__(
+            flow,
+            "async_update_reload_and_abort",
+            lambda *args, **kwargs: {
+                "type": "abort",
+                "reason": "reconfigure_successful",
+            },
+        )
         await flow.async_step_reconfigure(user_input={})
     else:
         raise ValueError(f"unknown config_step: {config_step}")

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -306,7 +306,9 @@ async def test_async_added_to_hass_calls_restore(monkeypatch, coordinator, make_
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_state_not_mapping(ph_hass, coordinator, make_config_entry):
+async def test_async_setup_entry_state_not_mapping(
+    monkeypatch, ph_hass, coordinator, make_config_entry, fake_reg_factory
+):
     """Setup exits early when coordinator state is not a mapping."""
     # coordinator.data is not a mapping -> async_setup_entry should return early and not add entities
     coordinator.data = "not-a-mapping"
@@ -317,6 +319,8 @@ async def test_async_setup_entry_state_not_mapping(ph_hass, coordinator, make_co
     hass = ph_hass
     hass.data = {}
     hass.config_entries.async_update_entry = MagicMock()
+    fake = fake_reg_factory(device_exists=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
 
     await dt_mod.async_setup_entry(hass, entry, added.extend)
     assert len(added) == 0
@@ -431,7 +435,7 @@ def test_handle_coordinator_update_expired_preserve_last_known_ip(coordinator, m
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_from_arp_entries(
-    monkeypatch, ph_hass, coordinator, make_config_entry
+    monkeypatch, ph_hass, coordinator, make_config_entry, fake_reg_factory
 ):
     """Setup from ARP entries creates device trackers for present ARP rows."""
     # when CONF_DEVICES not set but device tracker enabled, create entity per arp entry
@@ -445,6 +449,8 @@ async def test_async_setup_entry_from_arp_entries(
     hass = ph_hass
     hass.data = {}
     hass.config_entries.async_update_entry = MagicMock()
+    fake = fake_reg_factory(device_exists=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
 
     added = []
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1292,6 +1292,35 @@ def test_dhcp_leases_sensor_handles_none_payload(key, make_config_entry) -> None
     assert writes == [False]
 
 
+@pytest.mark.parametrize("leases", [None, []])
+def test_dhcp_leases_interface_sensor_handles_non_mapping_leases(leases, make_config_entry) -> None:
+    """DHCP interface leases sensor should be unavailable when leases are not a mapping."""
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"dhcp_leases": {"leases": leases}}
+
+    desc = MagicMock()
+    desc.key = "dhcp_leases.lan"
+    desc.name = "DHCP LAN"
+
+    s = OPNsenseDHCPLeasesSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.dhcp_lan"
+
+    writes: list[bool] = []
+
+    def collector() -> None:
+        """Collect availability when the entity state is written."""
+        writes.append(bool(getattr(s, "_available", None)))
+
+    object.__setattr__(s, "async_write_ha_state", collector)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+    assert writes == [False]
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_dhcp_leases_handles_exceptions(exc_type, make_config_entry):
     """DHCP lease aggregation marks the sensor unavailable on lease errors.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1263,6 +1263,35 @@ def test_dhcp_leases_all_non_mapping(leases_val, lease_interfaces_val, make_conf
     assert s.available is False
 
 
+@pytest.mark.parametrize("key", ["dhcp_leases.all", "dhcp_leases.lan"])
+def test_dhcp_leases_sensor_handles_none_payload(key, make_config_entry) -> None:
+    """DHCP leases sensors should be unavailable when coordinator data contains a null DHCP payload."""
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"dhcp_leases": None}
+
+    desc = MagicMock()
+    desc.key = key
+    desc.name = "DHCP Leases"
+
+    s = OPNsenseDHCPLeasesSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.dhcp_leases"
+
+    writes: list[bool] = []
+
+    def collector():
+        """Collect availability when the entity state is written."""
+        writes.append(bool(getattr(s, "_available", None)))
+
+    object.__setattr__(s, "async_write_ha_state", collector)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+    assert writes == [False]
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_dhcp_leases_handles_exceptions(exc_type, make_config_entry):
     """DHCP lease aggregation marks the sensor unavailable on lease errors.

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,12 +5,13 @@ async setup flows for the integration's switch platform.
 """
 
 import asyncio
-import contextlib
 from collections.abc import Callable, MutableMapping, Sequence
+import contextlib
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from custom_components.opnsense import switch as switch_mod
 from custom_components.opnsense.const import (
     ATTR_NAT_OUTBOUND,
@@ -45,7 +46,6 @@ from custom_components.opnsense.switch import (
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
-
 from tests.utilities import stub_async_write_ha_state
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,13 +5,12 @@ async setup flows for the integration's switch platform.
 """
 
 import asyncio
-from collections.abc import Callable, MutableMapping, Sequence
 import contextlib
+from collections.abc import Callable, MutableMapping, Sequence
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from custom_components.opnsense import switch as switch_mod
 from custom_components.opnsense.const import (
     ATTR_NAT_OUTBOUND,
@@ -46,6 +45,7 @@ from custom_components.opnsense.switch import (
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
+
 from tests.utilities import stub_async_write_ha_state
 
 
@@ -1135,7 +1135,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord(state)
             ent.entity_id = f"switch.{ent._attr_unique_id}"
-            stub_async_write_ha_state(ent)
+            object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
             def _fake_get_rule_filter() -> int:
                 """Return a non-mapping value to exercise filter error handling."""
@@ -1154,7 +1154,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord({})
             ent.entity_id = "switch.nat"
-            stub_async_write_ha_state(ent)
+            object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
             def _fake_get_rule_nat() -> MutableMapping[str, Any] | None:
                 """Return a non-mapping value to exercise NAT error handling."""
@@ -1173,7 +1173,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord({})
             ent.entity_id = "switch.svc"
-            stub_async_write_ha_state(ent)
+            object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
             def _fake_get_service() -> MutableMapping[str, Any] | None:
                 """Return a non-mapping value to exercise service error handling."""
@@ -1324,7 +1324,7 @@ async def test_vpn_toggle_parametrized(
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     # attach a client and set its toggle_vpn_instance to a simple AsyncMock
     # that returns the desired toggle_return value for the test case.
     ent._client = MagicMock()
@@ -1579,7 +1579,7 @@ async def test_nat_handle_missing_rule_returns_none(coordinator, ph_hass, make_c
     ent.hass = hass
     ent.coordinator = make_coord({})
     ent.entity_id = "switch.missing"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     # calling _handle_coordinator_update should not raise
     ent._handle_coordinator_update()
     assert isinstance(ent.available, bool)
@@ -1598,7 +1598,7 @@ async def test_unbound_turn_on_off_failure_logs(coordinator, ph_hass, make_confi
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     # simulate client failure
     ent._client = MagicMock()
     ent._client.enable_unbound_blocklist = AsyncMock(return_value=False)
@@ -1648,7 +1648,7 @@ async def test_client_failure_does_not_set_on(
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     # Ensure service data is populated from coordinator so the turn method
     # exercises the client call path (otherwise _client won't be invoked).
     ent._handle_coordinator_update()
@@ -1694,7 +1694,7 @@ def test_vpn_handle_coordinator_update_state_not_mapping(coordinator, make_confi
     )
     # coordinator.data is None -> unavailable
     coordinator.data = None
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     ent._handle_coordinator_update()
     assert ent.available is False
 
@@ -1743,7 +1743,7 @@ def test_vpn_instance_non_mapping_sets_unavailable(coordinator, make_config_entr
         "openvpn": {"clients": {"c1": "not-a-dict"}},
         "wireguard": {"clients": {}, "servers": {}},
     }
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     ent._handle_coordinator_update()
     assert ent.available is False
 
@@ -1761,7 +1761,7 @@ async def test_service_async_turn_on_off_failure(coordinator, ph_hass, make_conf
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     # simulate failure to start/stop
     ent._client = MagicMock()
     ent._client.start_service = AsyncMock(return_value=False)
@@ -1786,7 +1786,7 @@ async def test_vpn_toggle_failure_does_not_set_on(coordinator, ph_hass, make_con
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
     ent._client = MagicMock()
     ent._client.toggle_vpn_instance = AsyncMock(return_value=False)
     # attempt to turn on should not set is_on when client returns False
@@ -1907,7 +1907,7 @@ def test_filter_handle_exceptions_sets_unavailable(
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.coordinator = make_coord({})
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
     # prepare a mapping-like object whose get() raises the desired exception
     class BadGet(dict):
@@ -1949,7 +1949,7 @@ def test_nat_handle_exceptions_sets_unavailable(exc_type, coordinator, make_conf
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.coordinator = make_coord({})
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
     # create a mapping whose __contains__ raises the exception when checking 'disabled'
     class BadContains(dict):
@@ -1983,7 +1983,7 @@ def test_vpn_handle_exceptions_sets_unavailable(exc_type, coordinator, make_conf
     )
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
     # instance must be a MutableMapping so the code reaches the try/except block;
     # create a dict subclass that raises when __getitem__ is used for ['enabled']
@@ -2023,7 +2023,7 @@ def test_service_handle_exceptions_sets_unavailable(
     )
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    stub_async_write_ha_state(ent)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
     # create an object that raises when __getitem__ is used (service[prop])
     class BadIndex(dict):


### PR DESCRIPTION
## Summary
Fixes Kea DHCP lease sensors so malformed or null DHCP lease payloads mark the sensor unavailable instead of raising during coordinator updates.

## What Changed
- Guard DHCP lease sensor handling when `dhcp_leases` is not a mapping.
- Guard per-interface DHCP lease sensors when `dhcp_leases["leases"]` is not a mapping.
- Add regression coverage for null DHCP payloads and malformed per-interface lease payloads.
- Update test harness stubs for current Home Assistant typing and registry behavior.
- Bump the `ruff-pre-commit` hook revision used by `prek`.

## Why
OPNsense can return unexpected Kea DHCP lease payload shapes, including null or non-mapping values. Treating those payloads as unavailable sensor data avoids crashes while preserving normal lease counting for valid payloads.
