### PR TITLE
test: consolidate parameterized coverage

### DIFF
--- a/tests/pyopnsense/test_helpers.py
+++ b/tests/pyopnsense/test_helpers.py
@@ -82,7 +82,7 @@ def test_timestamp_to_datetime() -> None:
         pytest.param(None, 7, 7, id="none-default"),
     ],
 )
-def test_try_to_int(value: Any, default: int, expected: int) -> None:
+def test_try_to_int(value: object, default: int, expected: int) -> None:
     """Coerce numeric-like values to integers with defaults."""
     assert pyopnsense_helpers.try_to_int(value, default) == expected
 
@@ -94,7 +94,7 @@ def test_try_to_int(value: Any, default: int, expected: int) -> None:
         pytest.param(None, 3.3, 3.3, id="none-default"),
     ],
 )
-def test_try_to_float(value: Any, default: float, expected: float) -> None:
+def test_try_to_float(value: object, default: float, expected: float) -> None:
     """Coerce numeric-like values to floats with defaults."""
     assert pyopnsense_helpers.try_to_float(value, default) == expected
 
@@ -115,7 +115,7 @@ def test_try_to_float(value: Any, default: float, expected: float) -> None:
         pytest.param(None, False, id="none"),
     ],
 )
-def test_coerce_bool(value: Any, expected: bool) -> None:
+def test_coerce_bool(value: object, expected: bool) -> None:
     """Verify ``coerce_bool`` handles common bool-like edge cases."""
     assert pyopnsense_helpers.coerce_bool(value) is expected
 
@@ -129,7 +129,7 @@ def test_coerce_bool(value: Any, expected: bool) -> None:
         pytest.param(None, "", id="none"),
     ],
 )
-def test_normalize_lookup_token(value: Any, expected: str) -> None:
+def test_normalize_lookup_token(value: object, expected: str) -> None:
     """Verify ``normalize_lookup_token`` lower-cases and trims lookup values."""
     assert pyopnsense_helpers.normalize_lookup_token(value) == expected
 

--- a/tests/pyopnsense/test_helpers.py
+++ b/tests/pyopnsense/test_helpers.py
@@ -14,47 +14,46 @@ from custom_components.opnsense.pyopnsense import helpers as pyopnsense_helpers
 TEST_PASSWORD = "p"
 
 
-def test_human_friendly_duration() -> None:
-    """Convert seconds into a human-friendly duration string."""
-    assert pyopnsense_helpers.human_friendly_duration(65) == "1 minute, 5 seconds"
-    assert pyopnsense_helpers.human_friendly_duration(0) == "0 seconds"
-    assert "month" in pyopnsense_helpers.human_friendly_duration(2419200)
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        pytest.param(0, "0 seconds", id="zero"),
+        pytest.param(1, "1 second", id="singular-second"),
+        pytest.param(2, "2 seconds", id="plural-seconds"),
+        pytest.param(60, "1 minute", id="singular-minute"),
+        pytest.param(61, "1 minute, 1 second", id="minute-and-second"),
+        pytest.param(65, "1 minute, 5 seconds", id="minute-and-seconds"),
+        pytest.param(3600, "1 hour", id="singular-hour"),
+        pytest.param(7200, "2 hours", id="plural-hours"),
+        pytest.param(86400, "1 day", id="singular-day"),
+        pytest.param(604800, "1 week", id="singular-week"),
+        pytest.param(1209600, "2 weeks", id="plural-weeks"),
+        pytest.param(2419200, "1 month", id="singular-month"),
+        pytest.param(4838400, "2 months", id="plural-months"),
+    ],
+)
+def test_human_friendly_duration(seconds: int, expected: str) -> None:
+    """Convert seconds into human-friendly duration strings."""
+    assert pyopnsense_helpers.human_friendly_duration(seconds) == expected
 
 
-def test_human_friendly_duration_singular_and_plural() -> None:
-    """Verify singular and plural forms for all supported units. This covers seconds, minutes, hours, days, weeks and months and ensures the function emits the singular form when the value is 1 and plural otherwise."""
-    # seconds
-    assert pyopnsense_helpers.human_friendly_duration(1) == "1 second"
-    assert pyopnsense_helpers.human_friendly_duration(2) == "2 seconds"
-
-    # minutes + seconds
-    assert pyopnsense_helpers.human_friendly_duration(60) == "1 minute"
-    assert pyopnsense_helpers.human_friendly_duration(61) == "1 minute, 1 second"
-
-    # hours
-    assert pyopnsense_helpers.human_friendly_duration(3600) == "1 hour"
-    assert pyopnsense_helpers.human_friendly_duration(7200) == "2 hours"
-
-    # days
-    assert pyopnsense_helpers.human_friendly_duration(86400) == "1 day"
-
-    # weeks
-    assert pyopnsense_helpers.human_friendly_duration(604800) == "1 week"
-    assert pyopnsense_helpers.human_friendly_duration(1209600) == "2 weeks"
-
-    # months (28-day month used in implementation)
-    assert pyopnsense_helpers.human_friendly_duration(2419200) == "1 month"
-    assert pyopnsense_helpers.human_friendly_duration(4838400) == "2 months"
-
-
-def test_get_ip_key() -> None:
+@pytest.mark.parametrize(
+    ("item", "expected_type", "expected"),
+    [
+        pytest.param({"address": "192.168.1.1"}, 0, None, id="ipv4"),
+        pytest.param({"address": "::1"}, 1, None, id="ipv6"),
+        pytest.param({"address": "notanip"}, 2, (2, ""), id="invalid"),
+        pytest.param({}, 3, (3, ""), id="missing"),
+    ],
+)
+def test_get_ip_key(
+    item: dict[str, str], expected_type: int, expected: tuple[int, str] | None
+) -> None:
     """Compute sorting key for IP addresses across IPv4, IPv6, and invalid forms."""
-    assert pyopnsense_helpers.get_ip_key({"address": "192.168.1.1"})[0] == 0
-    assert pyopnsense_helpers.get_ip_key({"address": "::1"})[0] == 1
-    assert pyopnsense_helpers.get_ip_key({"address": "notanip"})[0] == 2
-    assert pyopnsense_helpers.get_ip_key({"address": "notanip"}) == (2, "")
-    assert pyopnsense_helpers.get_ip_key({})[0] == 3
-    assert pyopnsense_helpers.get_ip_key({}) == (3, "")
+    key = pyopnsense_helpers.get_ip_key(item)
+    assert key[0] == expected_type
+    if expected is not None:
+        assert key == expected
 
 
 def test_dict_get() -> None:
@@ -76,35 +75,63 @@ def test_timestamp_to_datetime() -> None:
     assert pyopnsense_helpers.timestamp_to_datetime(None) is None
 
 
-def test_try_to_int_and_float() -> None:
-    """Coerce numeric-like strings to int/float with defaults."""
-    assert pyopnsense_helpers.try_to_int("5") == 5
-    assert pyopnsense_helpers.try_to_int(None, 7) == 7
-    assert pyopnsense_helpers.try_to_float("5.5") == 5.5
-    assert pyopnsense_helpers.try_to_float(None, 3.3) == 3.3
+@pytest.mark.parametrize(
+    ("value", "default", "expected"),
+    [
+        pytest.param("5", 0, 5, id="numeric-string"),
+        pytest.param(None, 7, 7, id="none-default"),
+    ],
+)
+def test_try_to_int(value: Any, default: int, expected: int) -> None:
+    """Coerce numeric-like values to integers with defaults."""
+    assert pyopnsense_helpers.try_to_int(value, default) == expected
 
 
-def test_coerce_bool() -> None:
+@pytest.mark.parametrize(
+    ("value", "default", "expected"),
+    [
+        pytest.param("5.5", 0.0, 5.5, id="numeric-string"),
+        pytest.param(None, 3.3, 3.3, id="none-default"),
+    ],
+)
+def test_try_to_float(value: Any, default: float, expected: float) -> None:
+    """Coerce numeric-like values to floats with defaults."""
+    assert pyopnsense_helpers.try_to_float(value, default) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(True, True, id="true"),
+        pytest.param(False, False, id="false"),
+        pytest.param(1, True, id="int-one"),
+        pytest.param(0, False, id="int-zero"),
+        pytest.param(0.0, False, id="float-zero"),
+        pytest.param("1", True, id="string-one"),
+        pytest.param("true", True, id="string-true"),
+        pytest.param("yes", True, id="string-yes"),
+        pytest.param("on", True, id="string-on"),
+        pytest.param("", False, id="empty-string"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_coerce_bool(value: Any, expected: bool) -> None:
     """Verify ``coerce_bool`` handles common bool-like edge cases."""
-    assert pyopnsense_helpers.coerce_bool(True) is True
-    assert pyopnsense_helpers.coerce_bool(False) is False
-    assert pyopnsense_helpers.coerce_bool(1) is True
-    assert pyopnsense_helpers.coerce_bool(0) is False
-    assert pyopnsense_helpers.coerce_bool(0.0) is False
-    assert pyopnsense_helpers.coerce_bool("1") is True
-    assert pyopnsense_helpers.coerce_bool("true") is True
-    assert pyopnsense_helpers.coerce_bool("yes") is True
-    assert pyopnsense_helpers.coerce_bool("on") is True
-    assert pyopnsense_helpers.coerce_bool("") is False
-    assert pyopnsense_helpers.coerce_bool(None) is False
+    assert pyopnsense_helpers.coerce_bool(value) is expected
 
 
-def test_normalize_lookup_token() -> None:
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("Hello", "hello", id="lowercase"),
+        pytest.param("  WORLD  ", "world", id="strip"),
+        pytest.param(42, "42", id="coerce-int"),
+        pytest.param(None, "", id="none"),
+    ],
+)
+def test_normalize_lookup_token(value: Any, expected: str) -> None:
     """Verify ``normalize_lookup_token`` lower-cases and trims lookup values."""
-    assert pyopnsense_helpers.normalize_lookup_token("Hello") == "hello"
-    assert pyopnsense_helpers.normalize_lookup_token("  WORLD  ") == "world"
-    assert pyopnsense_helpers.normalize_lookup_token(42) == "42"
-    assert pyopnsense_helpers.normalize_lookup_token(None) == ""
+    assert pyopnsense_helpers.normalize_lookup_token(value) == expected
 
 
 def test_get_ip_key_sorting() -> None:
@@ -152,8 +179,15 @@ async def test_log_errors_decorator_re_raise_and_suppress() -> None:
 
 
 @pytest.mark.asyncio
-async def test_log_errors_timeout_re_raise_and_suppress() -> None:
-    """_log_errors should re-raise TimeoutError when client._initial is True and suppress when False."""
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(TimeoutError("boom"), id="timeout"),
+        pytest.param(aiohttp.ServerTimeoutError("srv"), id="server-timeout"),
+    ],
+)
+async def test_log_errors_timeout_re_raise_and_suppress(exception: Exception) -> None:
+    """_log_errors should re-raise timeouts when initial and suppress them otherwise."""
     session = MagicMock(spec=aiohttp.ClientSession)
     client = pyopnsense.OPNsenseClient(
         url="http://x", username="u", password=TEST_PASSWORD, session=session
@@ -168,55 +202,22 @@ async def test_log_errors_timeout_re_raise_and_suppress() -> None:
                 **kwargs: Additional keyword arguments forwarded by the function.
 
             Raises:
-                TimeoutError: Always raised to test timeout suppression and re-raise behavior.
+                Exception: Always raised to test timeout suppression and re-raise behavior.
             """
-            raise TimeoutError("boom")
+            raise exception
 
         # wrap the coroutine with the decorator
         decorated = pyopnsense_helpers._log_errors(raising_timeout)
 
         # When initial is True we expect the TimeoutError to propagate
         client._initial = True
-        with pytest.raises(TimeoutError):
+        with pytest.raises(type(exception)):
             await decorated(client)
 
         # When initial is False the decorator should suppress TimeoutError and return None
         client._initial = False
         res = await decorated(client)
         assert res is None
-    finally:
-        await client.async_close()
-
-
-@pytest.mark.asyncio
-async def test_log_errors_server_timeout_re_raise_and_suppress() -> None:
-    """_log_errors should re-raise aiohttp.ServerTimeoutError when client._initial is True and suppress when False."""
-    session = MagicMock(spec=aiohttp.ClientSession)
-    client = pyopnsense.OPNsenseClient(
-        url="http://x", username="u", password=TEST_PASSWORD, session=session
-    )
-    try:
-
-        async def raising_server_timeout(*args, **kwargs) -> Never:
-            """Raise ``ServerTimeoutError`` for the server-timeout error branch.
-
-            Args:
-                *args: Additional positional arguments forwarded by the function.
-                **kwargs: Additional keyword arguments forwarded by the function.
-
-            Raises:
-                aiohttp.ServerTimeoutError: Always raised to test server-timeout handling.
-            """
-            raise aiohttp.ServerTimeoutError("srv")
-
-        decorated = pyopnsense_helpers._log_errors(raising_server_timeout)
-
-        client._initial = True
-        with pytest.raises(aiohttp.ServerTimeoutError):
-            await decorated(client)
-
-        client._initial = False
-        assert await decorated(client) is None
     finally:
         await client.async_close()
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -214,62 +214,55 @@ async def test_compile_interface_enabled_binary_sensors_skips_malformed_interfac
     assert entities[0].entity_description.key == "interface.wan.enabled"
 
 
-def test_interface_enabled_binary_sensor_state(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Interface enabled binary sensor should expose the interface enabled state."""
-    entry = make_config_entry()
-    desc = BinarySensorEntityDescription(key="interface.wan.enabled", name="Interface WAN Enabled")
-
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"interfaces": {"wan": {"name": "WAN", "enabled": False}}}
-    sensor = OPNsenseInterfaceEnabledBinarySensor(
-        config_entry=entry, coordinator=coord, entity_description=desc
-    )
-    sensor.hass = MagicMock()
-    sensor.entity_id = "binary_sensor.wan_enabled"
-    stub_async_write_ha_state(sensor)
-
-    sensor._handle_coordinator_update()
-
-    assert sensor.available is True
-    assert sensor.is_on is False
-
-
-def test_interface_enabled_binary_sensor_unavailable_when_enabled_unknown(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Interface enabled binary sensor should be unavailable when enabled state is unknown."""
-    entry = make_config_entry()
-    desc = BinarySensorEntityDescription(key="interface.wan.enabled", name="Interface WAN Enabled")
-
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"interfaces": {"wan": {"name": "WAN", "enabled": None}}}
-    sensor = OPNsenseInterfaceEnabledBinarySensor(
-        config_entry=entry, coordinator=coord, entity_description=desc
-    )
-    sensor.hass = MagicMock()
-    sensor.entity_id = "binary_sensor.wan_enabled"
-    stub_async_write_ha_state(sensor)
-
-    sensor._handle_coordinator_update()
-
-    assert sensor.available is False
-
-
 @pytest.mark.parametrize(
-    ("desc_key", "coord_data"),
+    ("desc_key", "coord_data", "expected_available", "expected_is_on"),
     [
-        ("bad.key", {"interfaces": {"wan": {"enabled": True}}}),
-        ("interface.wan.enabled", None),
-        ("interface.wan.enabled", {"interfaces": {"wan": {}}}),
-        ("interface.wan.enabled", {"interfaces": {"wan": []}}),
+        pytest.param(
+            "interface.wan.enabled",
+            {"interfaces": {"wan": {"name": "WAN", "enabled": False}}},
+            True,
+            False,
+            id="disabled",
+        ),
+        pytest.param(
+            "interface.wan.enabled",
+            {"interfaces": {"wan": {"name": "WAN", "enabled": None}}},
+            False,
+            None,
+            id="unknown",
+        ),
+        pytest.param(
+            "bad.key",
+            {"interfaces": {"wan": {"enabled": True}}},
+            False,
+            None,
+            id="bad-key",
+        ),
+        pytest.param("interface.wan.enabled", None, False, None, id="missing-state"),
+        pytest.param(
+            "interface.wan.enabled",
+            {"interfaces": {"wan": {}}},
+            False,
+            None,
+            id="missing-enabled",
+        ),
+        pytest.param(
+            "interface.wan.enabled",
+            {"interfaces": {"wan": []}},
+            False,
+            None,
+            id="malformed-interface",
+        ),
     ],
 )
-def test_interface_enabled_binary_sensor_unavailable_for_invalid_payloads(
-    desc_key: Any, coord_data: Any, make_config_entry: Callable[..., MockConfigEntry]
+def test_interface_enabled_binary_sensor_state_handling(
+    desc_key: Any,
+    coord_data: Any,
+    expected_available: bool,
+    expected_is_on: bool | None,
+    make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Mark interface enabled binary sensor unavailable for invalid payloads."""
+    """Interface enabled binary sensor should expose or reject enabled state payloads."""
     entry = make_config_entry()
     desc = BinarySensorEntityDescription(key=desc_key, name="Interface WAN Enabled")
 
@@ -284,7 +277,9 @@ def test_interface_enabled_binary_sensor_unavailable_for_invalid_payloads(
 
     sensor._handle_coordinator_update()
 
-    assert sensor.available is False
+    assert sensor.available is expected_available
+    if expected_is_on is not None:
+        assert sensor.is_on is expected_is_on
 
 
 def test_interface_enabled_binary_sensor_extra_attributes(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1287,10 +1287,15 @@ def test_interface_sensor_enabled_state_handling(
     sensor._handle_coordinator_update()
 
     assert sensor.available is expected_available
-    if expected_native_value is not None:
+    if expected_native_value is None:
+        assert sensor.native_value is None
+    else:
         assert sensor.native_value == expected_native_value
-    if expected_enabled_attribute is not None:
-        attrs = sensor.extra_state_attributes
+
+    attrs = sensor.extra_state_attributes
+    if expected_enabled_attribute is None:
+        assert attrs is None or "enabled" not in attrs
+    else:
         assert attrs is not None
         assert attrs["enabled"] is expected_enabled_attribute
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1213,46 +1213,61 @@ def test_interface_status_icon_up(make_config_entry: Callable[..., MockConfigEnt
     assert s.icon != "mdi:close-network-outline"
 
 
-def test_interface_status_preserves_false_enabled_attribute(
+@pytest.mark.parametrize(
+    (
+        "description_key",
+        "description_name",
+        "interface_values",
+        "expected_available",
+        "expected_native_value",
+        "expected_enabled_attribute",
+    ),
+    [
+        pytest.param(
+            "interface.wan.status",
+            "WAN Status",
+            {"status": "up", "enabled": False},
+            False,
+            None,
+            False,
+            id="status-disabled-preserves-enabled-attribute",
+        ),
+        pytest.param(
+            "interface.wan.inbytes",
+            "WAN In Bytes",
+            {"status": "up", "enabled": False, "inbytes": 2048},
+            False,
+            None,
+            None,
+            id="metric-disabled",
+        ),
+        pytest.param(
+            "interface.wan.status",
+            "WAN Status",
+            {"status": "up", "enabled": None},
+            True,
+            "up",
+            None,
+            id="status-enabled-unknown",
+        ),
+    ],
+)
+def test_interface_sensor_enabled_state_handling(
+    description_key: str,
+    description_name: str,
+    interface_values: dict[str, Any],
+    expected_available: bool,
+    expected_native_value: Any,
+    expected_enabled_attribute: bool | None,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Interface status sensor should expose false enabled attributes."""
-    state = {
-        "interfaces": {"wan": {"name": "WAN", "status": "up", "enabled": False, "interface": "wan"}}
-    }
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = state
-    entry = make_config_entry()
-
-    desc = MagicMock()
-    desc.key = "interface.wan.status"
-    desc.name = "WAN Status"
-
-    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
-    sensor.hass = MagicMock()
-    sensor.entity_id = "sensor.wan_status"
-    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
-
-    sensor._handle_coordinator_update()
-
-    assert sensor.available is False
-    attrs = sensor.extra_state_attributes
-    assert attrs is not None
-    assert attrs["enabled"] is False
-
-
-def test_interface_sensor_unavailable_when_interface_disabled(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Interface sensors should be unavailable when the interface is disabled."""
+    """Interface sensors should handle false and unknown enabled states."""
     state = {
         "interfaces": {
             "wan": {
                 "name": "WAN",
-                "status": "up",
-                "enabled": False,
                 "interface": "wan",
-                "inbytes": 2048,
+                **interface_values,
             }
         }
     }
@@ -1261,50 +1276,23 @@ def test_interface_sensor_unavailable_when_interface_disabled(
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = "interface.wan.inbytes"
-    desc.name = "WAN In Bytes"
+    desc.key = description_key
+    desc.name = description_name
 
     sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
     sensor.hass = MagicMock()
-    sensor.entity_id = "sensor.wan_inbytes"
+    sensor.entity_id = f"sensor.{description_key.replace('.', '_')}"
     object.__setattr__(sensor, "async_write_ha_state", lambda: None)
 
     sensor._handle_coordinator_update()
 
-    assert sensor.available is False
-
-
-def test_interface_sensor_available_when_enabled_unknown(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Interface sensors should stay available when enabled state is unknown."""
-    state = {
-        "interfaces": {
-            "wan": {
-                "name": "WAN",
-                "status": "up",
-                "enabled": None,
-                "interface": "wan",
-            }
-        }
-    }
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = state
-    entry = make_config_entry()
-
-    desc = MagicMock()
-    desc.key = "interface.wan.status"
-    desc.name = "WAN Status"
-
-    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
-    sensor.hass = MagicMock()
-    sensor.entity_id = "sensor.wan_status"
-    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
-
-    sensor._handle_coordinator_update()
-
-    assert sensor.available is True
-    assert sensor.native_value == "up"
+    assert sensor.available is expected_available
+    if expected_native_value is not None:
+        assert sensor.native_value == expected_native_value
+    if expected_enabled_attribute is not None:
+        attrs = sensor.extra_state_attributes
+        assert attrs is not None
+        assert attrs["enabled"] is expected_enabled_attribute
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,10 +14,19 @@ from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID
 from custom_components.opnsense.update import OPNsenseFirmwareUpdatesAvailableUpdate
 
 
-def test_is_update_available_false_when_missing(
-    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
+@pytest.mark.parametrize(
+    "coordinator_data",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param({"firmware_update_info": {"status": "error"}}, id="error-status"),
+    ],
+)
+def test_is_update_available_false_for_missing_or_error_state(
+    coordinator_data: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
 ) -> None:
-    """Update entity should be unavailable when coordinator data is missing."""
+    """Update entity should be unavailable when firmware update state is unusable."""
     entry = make_config_entry()
     coord = dummy_coordinator
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
@@ -29,27 +38,7 @@ def test_is_update_available_false_when_missing(
     )
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
-    # state missing or malformed
-    coord.data = None
-    ent._handle_coordinator_update()
-    assert ent.available is False
-
-
-def test_is_update_available_false_when_error(
-    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
-) -> None:
-    """Update entity should be unavailable when coordinator reports an error status."""
-    entry = make_config_entry()
-    coord = dummy_coordinator
-    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
-        config_entry=entry,
-        coordinator=coord,
-        entity_description=UpdateEntityDescription(
-            key="firmware.update_available", name="Firmware"
-        ),
-    )
-    object.__setattr__(ent, "async_write_ha_state", lambda: None)
-    coord.data = {"firmware_update_info": {"status": "error"}}
+    coord.data = coordinator_data
     ent._handle_coordinator_update()
     assert ent.available is False
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -249,14 +249,32 @@ def test_handle_coordinator_update_sets_attributes(
     assert attrs.get("opnsense_last_check") == 1
 
 
+@pytest.mark.parametrize(
+    (
+        "product_version",
+        "product_latest",
+        "product_series",
+        "upgrade_major_version",
+        "expected_url_path",
+    ),
+    [
+        pytest.param("2.0.0", "2_0_1", "2.1", "2.1.3", "community/2.1", id="community"),
+        pytest.param("3.0.0", "3_0_1", "2.4", "2.4.1", "business/2.4", id="business"),
+    ],
+)
 def test_handle_coordinator_update_upgrade_sets_release_url(
-    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
+    product_version: str,
+    product_latest: str,
+    product_series: str,
+    upgrade_major_version: str,
+    expected_url_path: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
 ) -> None:
     """Upgrade state should compute a release URL and provide release notes.
 
-    This also asserts normalization of ``product_latest`` and correct
-    derivation of ``series_minor`` from ``product_series``, which affects the
-    generated release URL.
+    This also asserts correct product class derivation from ``product_series``,
+    which affects the generated release URL.
     """
     entry = make_config_entry()
     coord = dummy_coordinator
@@ -271,26 +289,22 @@ def test_handle_coordinator_update_upgrade_sets_release_url(
         "firmware_update_info": {
             "status": "upgrade",
             "product": {
-                "product_version": "2.0.0",
-                "product_latest": "2_0_1",
-                "product_series": "2.1",
+                "product_version": product_version,
+                "product_latest": product_latest,
+                "product_series": product_series,
             },
-            "upgrade_major_version": "2.1.3",
+            "upgrade_major_version": upgrade_major_version,
         }
     }
     ent.coordinator.data = state
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
     ent._handle_coordinator_update()
 
-    # For upgrade status, latest_version should reflect the upgrade_major_version
-    assert ent.latest_version == "2.1.3"
+    assert ent.latest_version == upgrade_major_version
 
-    # product_series '2.1' => series_minor '1' => product_class community -> use github URL
     assert ent.release_url is not None
-    assert "community/2.1" in ent.release_url
-
-    # Ensure the upgrade_major_version appears in release_url
-    assert "2.1.3" in ent.release_url
+    assert expected_url_path in ent.release_url
+    assert upgrade_major_version in ent.release_url
 
 
 @pytest.mark.asyncio
@@ -388,37 +402,6 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
 
     expected = entry.data.get("url") + "/ui/core/firmware#changelog"
     assert ent.release_url == expected
-
-
-def test_handle_coordinator_update_upgrade_sets_business_release_url(
-    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
-) -> None:
-    """Business product series should generate business release URL."""
-    entry = make_config_entry()
-    coord = dummy_coordinator
-    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
-        config_entry=entry,
-        coordinator=coord,
-        entity_description=UpdateEntityDescription(
-            key="firmware.update_available", name="Firmware"
-        ),
-    )
-    state = {
-        "firmware_update_info": {
-            "status": "upgrade",
-            "product": {
-                "product_version": "3.0.0",
-                "product_latest": "3_0_1",
-                "product_series": "2.4",
-            },
-            "upgrade_major_version": "2.4.1",
-        }
-    }
-    ent.coordinator.data = state
-    object.__setattr__(ent, "async_write_ha_state", lambda: None)
-    ent._handle_coordinator_update()
-    assert ent.release_url and "business/2.4" in ent.release_url
-    assert "2.4.1" in ent.release_url
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -22,7 +22,7 @@ from custom_components.opnsense.update import OPNsenseFirmwareUpdatesAvailableUp
     ],
 )
 def test_is_update_available_false_for_missing_or_error_state(
-    coordinator_data: Any,
+    coordinator_data: dict[str, Any] | None,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:


### PR DESCRIPTION
## Summary
Consolidates several repetitive test groups by parameterizing equivalent cases across pyopnsense helpers, interface entities, and firmware update coverage. This keeps the same behavioral coverage while reducing duplicate test code.

## What Changed
- Parameterized repeated pyopnsense helper assertions for truncation, address filtering, and voucher cleanup payloads.
- Consolidated interface sensor and binary sensor enabled-state coverage into table-driven cases.
- Parameterized firmware release URL and unavailable-state update tests.
- Addressed AI review follow-up in the affected test helpers.

## Why
The branch reduces duplicated tests without changing integration runtime behavior, making future test maintenance easier while preserving coverage for the same scenarios.

## Validation
- `./.venv/bin/python -m prek run -a`
- `./.venv/bin/python -m pytest`
