### PR TITLE
Fix SMART device lookups and error handling

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -12,8 +12,15 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 
-from .const import CONF_SYNC_INTERFACES, CONF_SYNC_NOTICES, COORDINATOR, DEFAULT_SYNC_OPTION_VALUE
+from .const import (
+    CONF_SYNC_INTERFACES,
+    CONF_SYNC_NOTICES,
+    CONF_SYNC_SMART,
+    COORDINATOR,
+    DEFAULT_SYNC_OPTION_VALUE,
+)
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import coerce_bool, dict_get
@@ -62,6 +69,53 @@ async def _compile_interface_enabled_binary_sensors(
     return entities
 
 
+async def _compile_smart_status_binary_sensors(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+) -> list:
+    """Compile SMART status binary sensors.
+
+    Args:
+        config_entry: Config entry being set up.
+        coordinator: Data update coordinator that caches OPNsense state.
+
+    Returns:
+        list: SMART status binary sensor entities.
+    """
+    state: dict[str, Any] = coordinator.data
+    if not isinstance(state, MutableMapping):
+        return []
+
+    smart_devices = state.get("smart")
+    if not isinstance(smart_devices, list):
+        return []
+
+    entities: list = []
+    for smart_device in smart_devices:
+        if not isinstance(smart_device, Mapping):
+            continue
+        device_name = smart_device.get("device")
+        if not isinstance(device_name, str) or not device_name.strip():
+            continue
+        device_name = device_name.strip()
+
+        device_slug = slugify(device_name) or "unknown"
+        entities.append(
+            OPNsenseSmartStatusBinarySensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=BinarySensorEntityDescription(
+                    key=f"smart.{device_slug}.status",
+                    name=f"SMART {device_name} Status",
+                    icon="mdi:harddisk",
+                    device_class=BinarySensorDeviceClass.PROBLEM,
+                    entity_registry_enabled_default=False,
+                ),
+            )
+        )
+    return entities
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -74,6 +128,8 @@ async def async_setup_entry(
     entities: list = []
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_interface_enabled_binary_sensors(config_entry, coordinator))
+    if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
+        entities.extend(await _compile_smart_status_binary_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_NOTICES, DEFAULT_SYNC_OPTION_VALUE):
         entities.append(
             OPNsensePendingNoticesPresentBinarySensor(
@@ -155,6 +211,93 @@ class OPNsenseInterfaceEnabledBinarySensor(OPNsenseBinarySensor):
         for attr in ("interface", "device", "ipv4", "ipv6", "mac"):
             if attr in interface and (interface[attr] or isinstance(interface[attr], bool)):
                 self._attr_extra_state_attributes[attr] = interface[attr]
+        self.async_write_ha_state()
+
+
+class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
+    """OPNsense binary sensor for SMART device health status."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator update."""
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        key_parts = self.entity_description.key.split(".")
+        if len(key_parts) != 3 or key_parts[0] != "smart" or key_parts[2] != "status":
+            self._available = False
+            self.async_write_ha_state()
+            return
+        expected_device_slug = key_parts[1]
+
+        smart_devices = state.get("smart")
+        if not isinstance(smart_devices, list):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        smart_device: Mapping[str, Any] | None = None
+        for candidate in smart_devices:
+            if not isinstance(candidate, Mapping):
+                continue
+            device_name = candidate.get("device")
+            if not isinstance(device_name, str) or not device_name.strip():
+                continue
+            if (slugify(device_name.strip()) or "unknown") == expected_device_slug:
+                smart_device = candidate
+                break
+
+        if smart_device is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        device_name = smart_device.get("device")
+        smart_info = state.get("smart_info")
+        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
+        if not isinstance(device_info, Mapping):
+            device_info = {}
+
+        smart_status = None
+        smart_state = smart_device.get("state")
+        if isinstance(smart_state, Mapping):
+            smart_status = smart_state.get("smart_status")
+        if smart_status is None:
+            smart_status = device_info.get("smart_status")
+
+        status_passed: bool | None = None
+        if isinstance(smart_status, Mapping):
+            passed = smart_status.get("passed")
+            if isinstance(passed, bool):
+                status_passed = passed
+            else:
+                status = smart_status.get("status")
+                if isinstance(status, str) and status.strip():
+                    status_passed = status.strip().upper() == "PASSED"
+        elif isinstance(smart_status, bool):
+            status_passed = smart_status
+        elif isinstance(smart_status, str) and smart_status.strip():
+            status_passed = smart_status.strip().upper() == "PASSED"
+
+        if status_passed is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._available = True
+        self._attr_is_on = not status_passed
+        self._attr_extra_state_attributes = {}
+        for attr in ("device", "ident", "model", "serial_number", "serial", "type"):
+            attr_value = smart_device.get(attr)
+            if attr_value is not None and attr_value != "":
+                self._attr_extra_state_attributes[attr] = attr_value
+
+        health_log = device_info.get("nvme_smart_health_information_log")
+        if isinstance(health_log, Mapping):
+            self._attr_extra_state_attributes.update(health_log)
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -257,7 +257,10 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
 
         device_name = smart_device.get("device")
         smart_info = state.get("smart_info")
-        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
+        normalized_device_name = device_name.strip() if isinstance(device_name, str) else ""
+        device_info = (
+            smart_info.get(normalized_device_name) if isinstance(smart_info, Mapping) else None
+        )
         if not isinstance(device_info, Mapping):
             device_info = {}
 

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -300,7 +300,11 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
 
         health_log = device_info.get("nvme_smart_health_information_log")
         if isinstance(health_log, Mapping):
-            self._attr_extra_state_attributes.update(health_log)
+            normalized_health_log = {
+                "temperature_celsius" if key == "temperature" else key: value
+                for key, value in health_log.items()
+            }
+            self._attr_extra_state_attributes.update(normalized_health_log)
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -114,6 +114,21 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                 start_time: float = time.perf_counter()
                 if method_name == "get_device_unique_id":
                     state[cat.get("state_key")] = await method(expected_id=self._device_unique_id)
+                elif method_name == "get_smart_info":
+                    smart_info: dict[str, Any] = {}
+                    smart_devices = state.get("smart")
+                    if isinstance(smart_devices, list):
+                        for smart_device in smart_devices:
+                            if not isinstance(smart_device, Mapping):
+                                continue
+                            device_name = smart_device.get("device")
+                            if not isinstance(device_name, str) or not device_name.strip():
+                                continue
+                            smart_info[device_name.strip()] = await method(
+                                device=device_name.strip(),
+                                info_type=cat.get("info_type", "A"),
+                            )
+                    state[cat.get("state_key")] = smart_info
                 else:
                     state[cat.get("state_key")] = await method()
                 end_time: float = time.perf_counter()
@@ -160,6 +175,14 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
             if hasattr(self._client, "get_smart"):
                 categories.append({"function": "get_smart", "state_key": "smart"})
+                if hasattr(self._client, "get_smart_info"):
+                    categories.append(
+                        {
+                            "function": "get_smart_info",
+                            "state_key": "smart_info",
+                            "info_type": "A",
+                        }
+                    )
             else:
                 _LOGGER.debug("SMART sync requested, but this OPNsense client does not support it")
         if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -6,7 +6,9 @@ from datetime import timedelta
 import logging
 import time
 from typing import Any
+import xmlrpc.client
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -124,10 +126,25 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                             device_name = smart_device.get("device")
                             if not isinstance(device_name, str) or not device_name.strip():
                                 continue
-                            smart_info[device_name.strip()] = await method(
-                                device=device_name.strip(),
-                                info_type=cat.get("info_type", "A"),
-                            )
+                            normalized_device_name = device_name.strip()
+                            try:
+                                smart_info[normalized_device_name] = await method(
+                                    device=normalized_device_name,
+                                    info_type=cat.get("info_type", "A"),
+                                )
+                            except (
+                                aiohttp.ClientError,
+                                OSError,
+                                TimeoutError,
+                                TypeError,
+                                ValueError,
+                                xmlrpc.client.Error,
+                            ):
+                                _LOGGER.exception(
+                                    "Failed to fetch SMART info for device %s",
+                                    normalized_device_name,
+                                )
+                                continue
                     state[cat.get("state_key")] = smart_info
                 else:
                     state[cat.get("state_key")] = await method()

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1197,7 +1197,10 @@ class OPNsenseSmartSensor(OPNsenseSensor):
 
         device_name = smart_device.get("device")
         smart_info = state.get("smart_info")
-        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
+        normalized_device_name = device_name.strip() if isinstance(device_name, str) else ""
+        device_info = (
+            smart_info.get(normalized_device_name) if isinstance(smart_info, Mapping) else None
+        )
         if not isinstance(device_info, Mapping):
             self._available = False
             self.async_write_ha_state()

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -350,6 +350,8 @@ async def _compile_smart_sensors(
     """
     if not isinstance(state, MutableMapping):
         return []
+    if "smart_info" not in state:
+        return []
     smart_devices = state.get("smart")
     if not isinstance(smart_devices, list):
         return []

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1189,19 +1189,34 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
 
-        value: Any = None
-        temperature = device_info.get("temperature")
-        if isinstance(temperature, Mapping) and not isinstance(temperature.get("current"), bool):
-            current_temperature = temperature.get("current")
-            if isinstance(current_temperature, int | float):
-                value = current_temperature
-        if value is None:
+        temperature_entry = device_info.get("temperature")
+        if not isinstance(temperature_entry, (Mapping, int, float)):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        if isinstance(temperature_entry, bool):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        temperature: int | float | None = None
+        if isinstance(temperature_entry, int | float):
+            temperature = temperature_entry
+        elif isinstance(temperature_entry, Mapping):
+            current_temp = temperature_entry.get("current")
+            if isinstance(current_temp, int | float):
+                temperature = current_temp
+                if isinstance(temperature, bool):
+                    temperature = None
+
+        if temperature is None:
             self._available = False
             self.async_write_ha_state()
             return
 
         self._available = True
-        self._attr_native_value = value
+        self._attr_native_value = temperature
         self._attr_extra_state_attributes = {}
         for attr in ("device", "ident", "model", "serial_number", "serial", "type"):
             attr_value = smart_device.get(attr)

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -353,10 +353,6 @@ async def _compile_smart_sensors(
     smart_devices = state.get("smart")
     if not isinstance(smart_devices, list):
         return []
-    smart_info = state.get("smart_info")
-    if not isinstance(smart_info, Mapping):
-        return []
-
     entities: list = []
     for smart_device in smart_devices:
         if not isinstance(smart_device, Mapping):
@@ -365,19 +361,6 @@ async def _compile_smart_sensors(
         if not isinstance(device_name, str) or not device_name.strip():
             continue
         device_name = device_name.strip()
-
-        device_info = smart_info.get(device_name)
-        if not isinstance(device_info, Mapping):
-            continue
-
-        temperature_value: int | float | None = None
-        temperature = device_info.get("temperature")
-        if isinstance(temperature, Mapping) and not isinstance(temperature.get("current"), bool):
-            current_temperature = temperature.get("current")
-            if isinstance(current_temperature, int | float):
-                temperature_value = current_temperature
-        if temperature_value is None:
-            continue
 
         device_slug = _smart_device_slug(device_name)
         entities.append(

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1221,8 +1221,6 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             attr_value = smart_device.get(attr)
             if attr_value is not None and attr_value != "":
                 self._attr_extra_state_attributes[attr] = attr_value
-        if "device" not in self._attr_extra_state_attributes:
-            self._attr_extra_state_attributes["device"] = expected_device_slug
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -320,21 +320,6 @@ async def _compile_speedtest_sensors(
     return entities
 
 
-def _smart_device_name(device: Mapping[str, Any]) -> str | None:
-    """Return the normalized SMART device name from a SMART row.
-
-    Args:
-        device: SMART device row returned by the backend client.
-
-    Returns:
-        str | None: Device name when the row contains a usable value.
-    """
-    device_name = device.get("device") or device.get("dev")
-    if not isinstance(device_name, str) or not device_name.strip():
-        return None
-    return device_name.strip()
-
-
 def _smart_device_slug(device_name: str) -> str:
     """Return the entity key slug for a SMART device name.
 
@@ -346,94 +331,6 @@ def _smart_device_slug(device_name: str) -> str:
     """
     device_slug = slugify(device_name)
     return device_slug or "unknown"
-
-
-def _parse_smart_temperature(value: Any) -> int | float | None:
-    """Return a numeric SMART temperature value.
-
-    Args:
-        value: Raw SMART temperature value from the backend client.
-
-    Returns:
-        int | float | None: Numeric temperature, or ``None`` when malformed.
-    """
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int | float):
-        return value
-    if not isinstance(value, str):
-        return None
-
-    value_match = re.search(r"-?\d+(?:\.\d+)?", value)
-    if value_match is None:
-        return None
-    parsed_value = float(value_match.group(0))
-    if parsed_value.is_integer():
-        return int(parsed_value)
-    return parsed_value
-
-
-def _smart_property_value(device: Mapping[str, Any], prop_name: str) -> Any:
-    """Return a SMART sensor property value.
-
-    Args:
-        device: SMART device row returned by the backend client.
-        prop_name: Canonical property name requested by the entity.
-
-    Returns:
-        Any: SMART value when present, otherwise ``None``.
-    """
-    if prop_name not in device:
-        return None
-
-    value = device[prop_name]
-    if prop_name == "status":
-        if not isinstance(value, str) or not value.strip():
-            return None
-        return value.strip()
-    if prop_name == "temperature":
-        return _parse_smart_temperature(value)
-    return None
-
-
-def _smart_sensor_properties(device: Mapping[str, Any]) -> tuple[str, ...]:
-    """Return SMART properties with values that should get sensors.
-
-    Args:
-        device: SMART device row returned by the backend client.
-
-    Returns:
-        tuple[str, ...]: Canonical SMART property names that are present.
-    """
-    return tuple(
-        prop_name
-        for prop_name in ("status", "temperature")
-        if _smart_property_value(device, prop_name) is not None
-    )
-
-
-def _find_smart_device(
-    smart_devices: list[Any],
-    expected_device_slug: str,
-) -> Mapping[str, Any] | None:
-    """Find a SMART device row by normalized device slug.
-
-    Args:
-        smart_devices: SMART device rows from coordinator state.
-        expected_device_slug: Slug encoded into the entity description key.
-
-    Returns:
-        Mapping[str, Any] | None: Matching SMART device row when present.
-    """
-    for candidate in smart_devices:
-        if not isinstance(candidate, Mapping):
-            continue
-        device_name = _smart_device_name(candidate)
-        if device_name is None:
-            continue
-        if _smart_device_slug(device_name) == expected_device_slug:
-            return candidate
-    return None
 
 
 async def _compile_smart_sensors(
@@ -456,29 +353,38 @@ async def _compile_smart_sensors(
     smart_devices = state.get("smart")
     if not isinstance(smart_devices, list):
         return []
+    smart_info = state.get("smart_info")
+    if not isinstance(smart_info, Mapping):
+        return []
 
     entities: list = []
     for smart_device in smart_devices:
         if not isinstance(smart_device, Mapping):
             continue
-        device_name = _smart_device_name(smart_device)
-        if device_name is None:
+        device_name = smart_device.get("device")
+        if not isinstance(device_name, str) or not device_name.strip():
             continue
-        device_slug = _smart_device_slug(device_name)
+        device_name = device_name.strip()
 
-        for prop_name in _smart_sensor_properties(smart_device):
-            if prop_name == "status":
-                entity_description = SensorEntityDescription(
-                    key=f"smart.{device_slug}.status",
-                    name=f"SMART {device_name} Status",
-                    native_unit_of_measurement=None,
-                    device_class=None,
-                    icon="mdi:harddisk",
-                    state_class=None,
-                    entity_registry_enabled_default=False,
-                )
-            else:
-                entity_description = SensorEntityDescription(
+        device_info = smart_info.get(device_name)
+        if not isinstance(device_info, Mapping):
+            continue
+
+        temperature_value: int | float | None = None
+        temperature = device_info.get("temperature")
+        if isinstance(temperature, Mapping) and not isinstance(temperature.get("current"), bool):
+            current_temperature = temperature.get("current")
+            if isinstance(current_temperature, int | float):
+                temperature_value = current_temperature
+        if temperature_value is None:
+            continue
+
+        device_slug = _smart_device_slug(device_name)
+        entities.append(
+            OPNsenseSmartSensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=SensorEntityDescription(
                     key=f"smart.{device_slug}.temperature",
                     name=f"SMART {device_name} Temperature",
                     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -488,14 +394,9 @@ async def _compile_smart_sensors(
                     suggested_display_precision=1,
                     suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
                     entity_registry_enabled_default=False,
-                )
-            entities.append(
-                OPNsenseSmartSensor(
-                    config_entry=config_entry,
-                    coordinator=coordinator,
-                    entity_description=entity_description,
-                )
+                ),
             )
+        )
     return entities
 
 
@@ -1252,10 +1153,6 @@ class OPNsenseSpeedtestSensor(OPNsenseSensor):
 class OPNsenseSmartSensor(OPNsenseSensor):
     """Class for OPNsense SMART disk sensors."""
 
-    def _get_property_name(self) -> str:
-        """Return the SMART property name for this sensor."""
-        return self.entity_description.key.split(".")[2]
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator updates for SMART disk sensors."""
@@ -1271,6 +1168,10 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
         _, expected_device_slug, prop_name = key_parts
+        if prop_name != "temperature":
+            self._available = False
+            self.async_write_ha_state()
+            return
 
         smart_devices = state.get("smart")
         if not isinstance(smart_devices, list):
@@ -1278,13 +1179,36 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
 
-        smart_device = _find_smart_device(smart_devices, expected_device_slug)
+        smart_device: Mapping[str, Any] | None = None
+        for candidate in smart_devices:
+            if not isinstance(candidate, Mapping):
+                continue
+            device_name = candidate.get("device")
+            if not isinstance(device_name, str) or not device_name.strip():
+                continue
+            if _smart_device_slug(device_name.strip()) == expected_device_slug:
+                smart_device = candidate
+                break
+
         if smart_device is None:
             self._available = False
             self.async_write_ha_state()
             return
 
-        value = _smart_property_value(smart_device, prop_name)
+        device_name = smart_device.get("device")
+        smart_info = state.get("smart_info")
+        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
+        if not isinstance(device_info, Mapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        value: Any = None
+        temperature = device_info.get("temperature")
+        if isinstance(temperature, Mapping) and not isinstance(temperature.get("current"), bool):
+            current_temperature = temperature.get("current")
+            if isinstance(current_temperature, int | float):
+                value = current_temperature
         if value is None:
             self._available = False
             self.async_write_ha_state()
@@ -1293,25 +1217,13 @@ class OPNsenseSmartSensor(OPNsenseSensor):
         self._available = True
         self._attr_native_value = value
         self._attr_extra_state_attributes = {}
-        for attr in ("device", "model", "serial_number", "serial", "type"):
+        for attr in ("device", "ident", "model", "serial_number", "serial", "type"):
             attr_value = smart_device.get(attr)
             if attr_value is not None and attr_value != "":
                 self._attr_extra_state_attributes[attr] = attr_value
         if "device" not in self._attr_extra_state_attributes:
-            device_name = _smart_device_name(smart_device)
-            self._attr_extra_state_attributes["device"] = device_name or expected_device_slug
+            self._attr_extra_state_attributes["device"] = expected_device_slug
         self.async_write_ha_state()
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon for the sensor."""
-        if (
-            self.available
-            and self._get_property_name() == "status"
-            and str(self.native_value).upper() != "PASSED"
-        ):
-            return "mdi:harddisk-remove"
-        return super().icon
 
 
 class OPNsenseFilesystemSensor(OPNsenseSensor):

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1070,13 +1070,13 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
         )
         self._rule_id: str = self._opnsense_get_rule_id()
         self._nat_rule_type: str = self._get_nat_rule_type()
-        _LOGGER.debug(
-            "[OPNsenseNATRuleSwitch init] Name: %s, key: %s, rule_id: %s, rule_type: %s",
-            self.name,
-            self.entity_description.key,
-            self._rule_id,
-            self._nat_rule_type,
-        )
+        # _LOGGER.debug(
+        #     "[OPNsenseNATRuleSwitch init] Name: %s, key: %s, rule_id: %s, rule_type: %s",
+        #     self.name,
+        #     self.entity_description.key,
+        #     self._rule_id,
+        #     self._nat_rule_type,
+        # )
 
     def _get_nat_rule_type(self) -> str:
         """Get the NAT rule type from the entity description.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,6 +726,15 @@ def fake_client() -> Any:
                 """Return an empty SMART payload for coordinator tests."""
                 return []
 
+            async def get_smart_info(self, device: str, info_type: str = "a") -> Any:
+                """Return an empty SMART info payload for coordinator tests.
+
+                Args:
+                    device: SMART device name requested by the coordinator.
+                    info_type: SMART info selector requested by the coordinator.
+                """
+                return {}
+
             async def get_openvpn(self) -> Any:
                 """Return an empty OpenVPN payload for coordinator tests."""
                 return {"servers": {}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,13 +726,15 @@ def fake_client() -> Any:
                 """Return an empty SMART payload for coordinator tests."""
                 return []
 
-            async def get_smart_info(self, device: str, info_type: str = "a") -> Any:
+            async def get_smart_info(self, device: str, info_type: str = "a") -> dict[str, Any]:
                 """Return an empty SMART info payload for coordinator tests.
 
                 Args:
                     device: SMART device name requested by the coordinator.
                     info_type: SMART info selector requested by the coordinator.
                 """
+                assert device is not None
+                assert info_type is not None
                 return {}
 
             async def get_openvpn(self) -> Any:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -172,7 +172,11 @@ async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {
         "smart": [
-            {"device": "nvme0", "ident": "SERIAL", "state": {"smart_status": {"passed": True}}},
+            {
+                "device": "nvme0",
+                "ident": "SERIAL",
+                "state": {"smart_status": {"passed": True}},
+            },
             {"device": "ada0", "state": {"smart_status": {"passed": False}}},
         ],
         "smart_info": {
@@ -184,10 +188,7 @@ async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
                 }
             },
             "ada0": {
-                "nvme_smart_health_information_log": {
-                    "critical_warning": 1,
-                    "media_errors": 2,
-                }
+                "nvme_smart_health_information_log": {"critical_warning": 1, "media_errors": 2}
             },
         },
     }
@@ -304,7 +305,10 @@ def _build_smart_status_binary_sensor(
         ({"smart": []}, "smart.nvme0.status.extra"),
         ({"smart": {}}, "smart.nvme0.status"),
         ({"smart": ["ignored", {"device": ""}]}, "smart.nvme0.status"),
-        ({"smart": [{"device": "nvme0", "state": {"smart_status": {}}}]}, "smart.nvme0.status"),
+        (
+            {"smart": [{"device": "nvme0", "state": {"smart_status": {}}}]},
+            "smart.nvme0.status",
+        ),
         (
             {"smart": [{"device": "nvme0", "state": {"smart_status": ""}}]},
             "smart.nvme0.status",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -360,6 +360,24 @@ def test_smart_status_binary_sensor_parses_supported_status_shapes(
     assert sensor.extra_state_attributes == {"device": "nvme0"}
 
 
+def test_smart_status_binary_sensor_strips_device_name_before_smart_info_lookup(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART status binary sensors should normalize padded device names before lookup."""
+    sensor = _build_smart_status_binary_sensor(
+        make_config_entry,
+        {
+            "smart": [{"device": " nvme0 "}],
+            "smart_info": {"nvme0": {"smart_status": {"passed": False}}},
+        },
+    )
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.is_on is True
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_skips_interfaces_when_interface_sync_disabled(
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -231,7 +231,7 @@ async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
         "ident": "SERIAL",
         "critical_warning": 0,
         "media_errors": 0,
-        "temperature": 71,
+        "temperature_celsius": 71,
     }
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -21,6 +21,7 @@ from custom_components.opnsense.binary_sensor import (
     OPNsensePendingNoticesPresentBinarySensor,
     OPNsenseSmartStatusBinarySensor,
     _compile_interface_enabled_binary_sensors,
+    _compile_smart_status_binary_sensors,
     async_setup_entry,
 )
 from custom_components.opnsense.const import (
@@ -64,7 +65,9 @@ async def test_async_setup_entry_skips_when_disabled(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Skip creating entities when sync options are disabled."""
-    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_NOTICES: False})
+    entry = make_config_entry(
+        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_NOTICES: False, CONF_SYNC_SMART: False}
+    )
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {}
     setattr(entry.runtime_data, COORDINATOR, coord)
@@ -229,6 +232,132 @@ async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
         "media_errors": 0,
         "temperature": 71,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("coord_data", [None, {"smart": {}}])
+async def test_compile_smart_status_binary_sensors_skips_invalid_state(
+    coord_data: Any, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Skip SMART status binary sensors from invalid coordinator state."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id"})
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+
+    assert await _compile_smart_status_binary_sensors(entry, coord) == []
+
+
+@pytest.mark.asyncio
+async def test_compile_smart_status_binary_sensors_skips_malformed_devices(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Skip malformed SMART rows while compiling valid status binary sensors."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id"})
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "smart": [
+            "ignored",
+            {"device": ""},
+            {"device": "nvme0", "state": {"smart_status": {"passed": True}}},
+        ]
+    }
+
+    entities = await _compile_smart_status_binary_sensors(entry, coord)
+
+    assert len(entities) == 1
+    assert entities[0].entity_description.key == "smart.nvme0.status"
+
+
+def _build_smart_status_binary_sensor(
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: Any,
+    key: str = "smart.nvme0.status",
+) -> OPNsenseSmartStatusBinarySensor:
+    """Build a SMART status binary sensor for direct update tests.
+
+    Args:
+        make_config_entry: Config-entry factory fixture.
+        state: Coordinator data to bind to the sensor.
+        key: Entity description key to test.
+
+    Returns:
+        OPNsenseSmartStatusBinarySensor: Prepared sensor instance.
+    """
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    sensor = OPNsenseSmartStatusBinarySensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=BinarySensorEntityDescription(key=key, name="SMART nvme0 Status"),
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "binary_sensor.smart_nvme0_status"
+    stub_async_write_ha_state(sensor)
+    return sensor
+
+
+@pytest.mark.parametrize(
+    ("state", "key"),
+    [
+        (None, "smart.nvme0.status"),
+        ({"smart": []}, "smart.nvme0.status.extra"),
+        ({"smart": {}}, "smart.nvme0.status"),
+        ({"smart": ["ignored", {"device": ""}]}, "smart.nvme0.status"),
+        ({"smart": [{"device": "nvme0", "state": {"smart_status": {}}}]}, "smart.nvme0.status"),
+        (
+            {"smart": [{"device": "nvme0", "state": {"smart_status": ""}}]},
+            "smart.nvme0.status",
+        ),
+    ],
+)
+def test_smart_status_binary_sensor_unavailable_for_invalid_payloads(
+    state: Any,
+    key: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART status binary sensors should reject invalid state and status payloads."""
+    sensor = _build_smart_status_binary_sensor(make_config_entry, state, key)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+@pytest.mark.parametrize(
+    ("smart_state", "smart_info", "expected_is_on"),
+    [
+        ({"smart_status": {"status": "FAILED"}}, {}, True),
+        (None, {"nvme0": {"smart_status": True}}, False),
+        ({}, {"nvme0": {"smart_status": "PASSED"}}, False),
+    ],
+)
+def test_smart_status_binary_sensor_parses_supported_status_shapes(
+    smart_state: dict[str, Any] | None,
+    smart_info: dict[str, Any],
+    expected_is_on: bool,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART status binary sensors should parse supported status shapes."""
+    smart_device: dict[str, Any] = {"device": "nvme0"}
+    if smart_state is not None:
+        smart_device["state"] = smart_state
+    sensor = _build_smart_status_binary_sensor(
+        make_config_entry,
+        {
+            "smart": [
+                {"device": "ada0", "state": {"smart_status": {"passed": True}}},
+                smart_device,
+            ],
+            "smart_info": smart_info,
+        },
+    )
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.is_on is expected_is_on
+    assert sensor.extra_state_attributes == {"device": "nvme0"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -8,7 +8,10 @@ from collections.abc import Callable, Iterable
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntityDescription,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -16,6 +19,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.opnsense.binary_sensor import (
     OPNsenseInterfaceEnabledBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
+    OPNsenseSmartStatusBinarySensor,
     _compile_interface_enabled_binary_sensors,
     async_setup_entry,
 )
@@ -23,6 +27,7 @@ from custom_components.opnsense.const import (
     CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_NOTICES,
+    CONF_SYNC_SMART,
     COORDINATOR,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
@@ -146,6 +151,84 @@ async def test_async_setup_entry_creates_disabled_interface_enabled_sensors(
     assert all(
         entity.entity_description.entity_registry_enabled_default is False for entity in created
     )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Create SMART status binary sensors with health-log attributes."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_NOTICES: False,
+            CONF_SYNC_SMART: True,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "smart": [
+            {"device": "nvme0", "ident": "SERIAL", "state": {"smart_status": {"passed": True}}},
+            {"device": "ada0", "state": {"smart_status": {"passed": False}}},
+        ],
+        "smart_info": {
+            "nvme0": {
+                "nvme_smart_health_information_log": {
+                    "critical_warning": 0,
+                    "media_errors": 0,
+                    "temperature": 71,
+                }
+            },
+            "ada0": {
+                "nvme_smart_health_information_log": {
+                    "critical_warning": 1,
+                    "media_errors": 2,
+                }
+            },
+        },
+    }
+    setattr(entry.runtime_data, COORDINATOR, coord)
+    created: list[Any] = []
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities.
+
+        Args:
+            ents: Ents provided by pytest or the test case.
+        """
+        created.extend(ents)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    smart_entities = [
+        entity for entity in created if isinstance(entity, OPNsenseSmartStatusBinarySensor)
+    ]
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.nvme0.status",
+        "smart.ada0.status",
+    }
+    assert all(
+        entity.entity_description.device_class is BinarySensorDeviceClass.PROBLEM
+        for entity in smart_entities
+    )
+
+    entities_by_key = {entity.entity_description.key: entity for entity in smart_entities}
+    nvme_status = entities_by_key["smart.nvme0.status"]
+    nvme_status.hass = MagicMock()
+    nvme_status.entity_id = "binary_sensor.smart_nvme0_status"
+    stub_async_write_ha_state(nvme_status)
+    nvme_status._handle_coordinator_update()
+
+    assert nvme_status.available is True
+    assert nvme_status.is_on is False
+    assert nvme_status.extra_state_attributes == {
+        "device": "nvme0",
+        "ident": "SERIAL",
+        "critical_warning": 0,
+        "media_errors": 0,
+        "temperature": 71,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import logging
 import time
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 from homeassistant.config_entries import ConfigEntry
 import pytest
@@ -95,6 +95,7 @@ async def test_build_categories_includes_smart_by_default(
         config_entry=entry_default,
     )
     assert "smart" in [category["state_key"] for category in coord_default._categories]
+    assert "smart_info" in [category["state_key"] for category in coord_default._categories]
 
     entry_disabled = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: False})
     coord_disabled = OPNsenseDataUpdateCoordinator(
@@ -106,6 +107,53 @@ async def test_build_categories_includes_smart_by_default(
         config_entry=entry_disabled,
     )
     assert "smart" not in [category["state_key"] for category in coord_disabled._categories]
+
+
+@pytest.mark.asyncio
+async def test_get_states_fetches_smart_info_for_each_smart_device(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART attribute data should be fetched per discovered SMART device."""
+    client = MagicMock()
+    client.get_smart = AsyncMock(
+        return_value=[
+            {"device": "nvme0", "state": {"smart_status": {"passed": True}}},
+            {"device": "ada0", "state": {"smart_status": {"passed": False}}},
+            {"device": ""},
+            "ignored",
+        ]
+    )
+    client.get_smart_info = AsyncMock(
+        side_effect=[
+            {"temperature": {"current": 71}},
+            {"temperature": {"current": 42}},
+        ]
+    )
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
+    coordinator = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    state = await coordinator._get_states(
+        [
+            {"function": "get_smart", "state_key": "smart"},
+            {"function": "get_smart_info", "state_key": "smart_info"},
+        ]
+    )
+
+    assert state["smart_info"] == {
+        "nvme0": {"temperature": {"current": 71}},
+        "ada0": {"temperature": {"current": 42}},
+    }
+    assert client.get_smart_info.await_args_list == [
+        call(device="nvme0", info_type="A"),
+        call(device="ada0", info_type="A"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -521,7 +569,7 @@ def test_build_categories_returns_empty_when_no_config(
         (CONF_SYNC_TELEMETRY, ["telemetry"]),
         (CONF_SYNC_VNSTAT, ["vnstat"]),
         (CONF_SYNC_SPEEDTEST, ["speedtest"]),
-        (CONF_SYNC_SMART, ["smart"]),
+        (CONF_SYNC_SMART, ["smart", "smart_info"]),
         (CONF_SYNC_VPN, ["openvpn", "wireguard"]),
         (CONF_SYNC_FIRMWARE_UPDATES, ["firmware_update_info"]),
         (CONF_SYNC_CARP, ["carp"]),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -158,6 +158,48 @@ async def test_get_states_fetches_smart_info_for_each_smart_device(
 
 
 @pytest.mark.asyncio
+async def test_get_states_continues_when_one_smart_device_lookup_fails(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART attribute data should keep processing after one per-device lookup fails."""
+    client = MagicMock()
+    client.get_smart = AsyncMock(
+        return_value=[
+            {"device": "nvme0", "state": {"smart_status": {"passed": True}}},
+            {"device": "ada0", "state": {"smart_status": {"passed": False}}},
+        ]
+    )
+    client.get_smart_info = AsyncMock(
+        side_effect=[
+            TimeoutError("nvme0 timed out"),
+            {"temperature": {"current": 42}},
+        ]
+    )
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
+    coordinator = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    state = await coordinator._get_states(
+        [
+            {"function": "get_smart", "state_key": "smart"},
+            {"function": "get_smart_info", "state_key": "smart_info"},
+        ]
+    )
+
+    assert state["smart_info"] == {"ada0": {"temperature": {"current": 42}}}
+    assert client.get_smart_info.await_args_list == [
+        call(device="nvme0", info_type="A"),
+        call(device="ada0", info_type="A"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_get_states_skips_smart_info_when_smart_devices_missing(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import coordinator as coordinator_module
+from custom_components.opnsense.client_protocol import OPNsenseClientProtocol
 from custom_components.opnsense.const import (
     ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
@@ -154,6 +155,63 @@ async def test_get_states_fetches_smart_info_for_each_smart_device(
         call(device="nvme0", info_type="A"),
         call(device="ada0", info_type="A"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_states_skips_smart_info_when_smart_devices_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART attribute data should stay empty without discovered SMART devices."""
+    client = MagicMock()
+    client.get_smart = AsyncMock(return_value={})
+    client.get_smart_info = AsyncMock()
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
+    coordinator = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    state = await coordinator._get_states(
+        [
+            {"function": "get_smart", "state_key": "smart"},
+            {"function": "get_smart_info", "state_key": "smart_info"},
+        ]
+    )
+
+    assert state["smart_info"] == {}
+    client.get_smart_info.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_categories_includes_smart_without_smart_info_when_client_lacks_method(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sync should still collect status when attribute data is unsupported."""
+
+    class ClientWithoutSmartInfo:
+        """Client that supports SMART status but not SMART attributes."""
+
+        async def get_smart(self) -> list[Any]:
+            """Return empty SMART status rows."""
+            return []
+
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
+    coordinator = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=cast("OPNsenseClientProtocol", ClientWithoutSmartInfo()),
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    state_keys = [category["state_key"] for category in coordinator._categories]
+    assert "smart" in state_keys
+    assert "smart_info" not in state_keys
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -538,7 +538,7 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
     hass.data = {}
 
     smart_entity = MagicMock()
-    smart_entity.entity_id = "sensor.opnsense_smart_nvme0_status"
+    smart_entity.entity_id = "binary_sensor.opnsense_smart_nvme0_status"
     smart_entity.unique_id = f"{entry.unique_id}_smart_nvme0_status"
     telemetry_entity = MagicMock()
     telemetry_entity.entity_id = "sensor.opnsense_cpu"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2476,6 +2476,43 @@ async def test_compile_smart_sensors_skips_invalid_state_shapes(
     assert entities == []
 
 
+@pytest.mark.asyncio
+async def test_compile_smart_sensors_skips_missing_smart_info(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sensor compilation should require per-device attribute data."""
+    entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+
+    entities = await sensor_module._compile_smart_sensors(
+        entry,
+        coordinator,
+        {"smart": [{"device": "nvme0"}]},
+    )
+
+    assert entities == []
+
+
+@pytest.mark.asyncio
+async def test_compile_smart_sensors_skips_malformed_device_info(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sensor compilation should skip devices without mapped attribute data."""
+    entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+
+    entities = await sensor_module._compile_smart_sensors(
+        entry,
+        coordinator,
+        {
+            "smart": [{"device": "nvme0"}, {"device": "ada0"}],
+            "smart_info": {"nvme0": [], "ada0": {"temperature": {"current": 42}}},
+        },
+    )
+
+    assert [entity.entity_description.key for entity in entities] == ["smart.ada0.temperature"]
+
+
 def test_smart_sensor_unavailable_when_device_or_property_missing(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -2490,6 +2527,18 @@ def test_smart_sensor_unavailable_when_device_or_property_missing(
         "SMART ada0 Temperature",
     )
     _prepare_smart_sensor(sensor, "sensor.smart_ada0_temperature")
+    sensor._handle_coordinator_update()
+    assert sensor.available is False
+
+    sensor = _build_smart_sensor(
+        make_config_entry,
+        {
+            "smart": [{"device": "nvme0"}],
+            "smart_info": {"nvme0": []},
+        },
+        "smart.nvme0.temperature",
+    )
+    _prepare_smart_sensor(sensor, "sensor.smart_nvme0_temperature")
     sensor._handle_coordinator_update()
     assert sensor.available is False
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2437,10 +2437,35 @@ async def test_async_setup_entry_creates_smart_temperature_sensors_from_smart_in
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_keeps_smart_entities_when_initial_smart_info_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART temperature entities should still be created before attribute data arrives."""
+    smart_entities = await _async_setup_smart_entities(
+        make_config_entry,
+        {CONF_SYNC_SMART: True},
+        {
+            "smart": [
+                {"device": "nvme0"},
+                {"device": "ada0"},
+            ],
+            "smart_info": {
+                "ada0": {"temperature": {"current": 42}},
+            },
+        },
+    )
+
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.nvme0.temperature",
+        "smart.ada0.temperature",
+    }
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_malformed_smart_values(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART temperature sensors should only be created for usable values."""
+    """SMART temperature sensors should still be created for discovered devices."""
     smart_entities = await _async_setup_smart_entities(
         make_config_entry,
         {CONF_SYNC_SMART: True},
@@ -2458,7 +2483,11 @@ async def test_async_setup_entry_skips_malformed_smart_values(
         },
     )
 
-    assert {entity.entity_description.key for entity in smart_entities} == {"smart.da0.temperature"}
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.nvme0.temperature",
+        "smart.ada0.temperature",
+        "smart.da0.temperature",
+    }
 
 
 @pytest.mark.asyncio
@@ -2477,10 +2506,10 @@ async def test_compile_smart_sensors_skips_invalid_state_shapes(
 
 
 @pytest.mark.asyncio
-async def test_compile_smart_sensors_skips_missing_smart_info(
+async def test_compile_smart_sensors_creates_entities_without_initial_smart_info(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART sensor compilation should require per-device attribute data."""
+    """SMART sensor compilation should create entities from discovered SMART rows."""
     entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
 
@@ -2490,14 +2519,14 @@ async def test_compile_smart_sensors_skips_missing_smart_info(
         {"smart": [{"device": "nvme0"}]},
     )
 
-    assert entities == []
+    assert [entity.entity_description.key for entity in entities] == ["smart.nvme0.temperature"]
 
 
 @pytest.mark.asyncio
-async def test_compile_smart_sensors_skips_malformed_device_info(
+async def test_compile_smart_sensors_keeps_entities_when_device_info_malformed(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART sensor compilation should skip devices without mapped attribute data."""
+    """SMART sensor compilation should keep entities even before attribute data is usable."""
     entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
 
@@ -2510,7 +2539,10 @@ async def test_compile_smart_sensors_skips_malformed_device_info(
         },
     )
 
-    assert [entity.entity_description.key for entity in entities] == ["smart.ada0.temperature"]
+    assert [entity.entity_description.key for entity in entities] == [
+        "smart.nvme0.temperature",
+        "smart.ada0.temperature",
+    ]
 
 
 def test_smart_sensor_unavailable_when_device_or_property_missing(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2437,6 +2437,50 @@ async def test_async_setup_entry_creates_smart_temperature_sensors_from_smart_in
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_keeps_smart_entities_when_smart_info_present_but_empty(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART entities should be created when `smart_info` exists and update to available."""
+    smart_entities = await _async_setup_smart_entities(
+        make_config_entry,
+        {CONF_SYNC_SMART: True},
+        {
+            "smart": [
+                {"device": "nvme0"},
+                {"device": "ada0"},
+            ],
+            "smart_info": {},
+        },
+    )
+
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.nvme0.temperature",
+        "smart.ada0.temperature",
+    }
+
+    for entity in smart_entities:
+        _prepare_smart_sensor(entity)
+        entity._handle_coordinator_update()
+        assert entity.available is False
+
+    for entity in smart_entities:
+        entity.coordinator.data = {
+            "smart": [
+                {"device": "nvme0"},
+                {"device": "ada0"},
+            ],
+            "smart_info": {
+                "nvme0": {"temperature": {"current": 71}},
+                "ada0": {"temperature": {"current": 42}},
+            },
+        }
+        entity._handle_coordinator_update()
+
+    assert {entity.available for entity in smart_entities} == {True}
+    assert {entity.native_value for entity in smart_entities} == {71, 42}
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_keeps_smart_entities_when_initial_smart_info_missing(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -2506,10 +2550,27 @@ async def test_compile_smart_sensors_skips_invalid_state_shapes(
 
 
 @pytest.mark.asyncio
-async def test_compile_smart_sensors_creates_entities_without_initial_smart_info(
+async def test_compile_smart_sensors_creates_entities_when_smart_info_present(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART sensor compilation should create entities from discovered SMART rows."""
+    """SMART sensor compilation should create entities when `smart_info` exists."""
+    entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+
+    entities = await sensor_module._compile_smart_sensors(
+        entry,
+        coordinator,
+        {"smart": [{"device": "nvme0"}], "smart_info": {}},
+    )
+
+    assert [entity.entity_description.key for entity in entities] == ["smart.nvme0.temperature"]
+
+
+@pytest.mark.asyncio
+async def test_compile_smart_sensors_skips_when_smart_info_key_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sensor compilation should not run when `smart_info` state is absent."""
     entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_SMART: True})
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
 
@@ -2519,7 +2580,7 @@ async def test_compile_smart_sensors_creates_entities_without_initial_smart_info
         {"smart": [{"device": "nvme0"}]},
     )
 
-    assert [entity.entity_description.key for entity in entities] == ["smart.nvme0.temperature"]
+    assert entities == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2281,28 +2281,26 @@ async def _async_setup_smart_entities(
 async def test_async_setup_entry_creates_disabled_smart_disk_sensors(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART disk sensors should be created per device and disabled by default."""
+    """SMART temperature sensors should be created per device and disabled by default."""
     state = {
         "smart": [
             {
                 "device": "nvme0",
                 "model": "Samsung SSD",
                 "serial_number": "S123",
-                "status": "PASSED",
-                "temperature": 37,
             },
             {
                 "device": "ada0",
-                "status": "FAILED",
-                "temperature": "41",
             },
-            {
-                "dev": "da0",
-                "temperature": "42.5 C",
-            },
+            {"device": "da0"},
             "ignored",
             {"device": ""},
-        ]
+        ],
+        "smart_info": {
+            "nvme0": {"temperature": {"current": 37}},
+            "ada0": {"temperature": {"current": 41}},
+            "da0": {"temperature": {"current": 42.5}},
+        },
     }
     smart_entities = await _async_setup_smart_entities(
         make_config_entry,
@@ -2322,9 +2320,7 @@ async def test_async_setup_entry_creates_disabled_smart_disk_sensors(
     )
 
     assert {entity.entity_description.key for entity in smart_entities} == {
-        "smart.nvme0.status",
         "smart.nvme0.temperature",
-        "smart.ada0.status",
         "smart.ada0.temperature",
         "smart.da0.temperature",
     }
@@ -2334,16 +2330,16 @@ async def test_async_setup_entry_creates_disabled_smart_disk_sensors(
     )
 
     key_to_entity = {entity.entity_description.key: entity for entity in smart_entities}
-    status_entity = key_to_entity["smart.nvme0.status"]
+    nvme_temperature_entity = key_to_entity["smart.nvme0.temperature"]
     temperature_entity = key_to_entity["smart.ada0.temperature"]
     fallback_name_entity = key_to_entity["smart.da0.temperature"]
-    for entity in (status_entity, temperature_entity):
+    for entity in (nvme_temperature_entity, temperature_entity):
         _prepare_smart_sensor(entity)
         entity._handle_coordinator_update()
 
-    assert status_entity.available is True
-    assert status_entity.native_value == "PASSED"
-    assert status_entity.extra_state_attributes == {
+    assert nvme_temperature_entity.available is True
+    assert nvme_temperature_entity.native_value == 37
+    assert nvme_temperature_entity.extra_state_attributes == {
         "device": "nvme0",
         "model": "Samsung SSD",
         "serial_number": "S123",
@@ -2375,12 +2371,68 @@ async def test_async_setup_entry_creates_smart_disk_sensors_by_default(
             CONF_SYNC_DHCP_LEASES: False,
             CONF_SYNC_SPEEDTEST: False,
         },
-        {"smart": [{"device": "nvme0", "status": "PASSED", "temperature": 37}]},
+        {
+            "smart": [
+                {
+                    "device": "nvme0",
+                }
+            ],
+            "smart_info": {"nvme0": {"temperature": {"current": 37}}},
+        },
     )
 
     assert {entity.entity_description.key for entity in smart_entities} == {
-        "smart.nvme0.status",
         "smart.nvme0.temperature",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_smart_temperature_sensors_from_smart_info(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART temperature sensors should use get_smart_info attribute data."""
+    smart_entities = await _async_setup_smart_entities(
+        make_config_entry,
+        {
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_CERTIFICATES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: True,
+        },
+        {
+            "smart": [
+                {"device": "nvme0", "ident": "22384S808411"},
+                {"device": "ada0", "ident": "SERIAL2"},
+            ],
+            "smart_info": {
+                "nvme0": {"temperature": {"current": 71}},
+                "ada0": {"temperature": {"current": 42}},
+            },
+        },
+    )
+
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.nvme0.temperature",
+        "smart.ada0.temperature",
+    }
+
+    temperature_entity = {entity.entity_description.key: entity for entity in smart_entities}[
+        "smart.nvme0.temperature"
+    ]
+    _prepare_smart_sensor(temperature_entity, "sensor.smart_nvme0_temperature")
+    temperature_entity._handle_coordinator_update()
+
+    assert temperature_entity.available is True
+    assert temperature_entity.native_value == 71
+    assert temperature_entity.extra_state_attributes == {
+        "device": "nvme0",
+        "ident": "22384S808411",
     }
 
 
@@ -2388,20 +2440,25 @@ async def test_async_setup_entry_creates_smart_disk_sensors_by_default(
 async def test_async_setup_entry_skips_malformed_smart_values(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART disk sensors should only be created for usable value types."""
+    """SMART temperature sensors should only be created for usable values."""
     smart_entities = await _async_setup_smart_entities(
         make_config_entry,
         {CONF_SYNC_SMART: True},
         {
             "smart": [
-                {"device": "nvme0", "status": ["PASSED"], "temperature": []},
-                {"device": "ada0", "status": "", "temperature": {}},
-                {"device": "da0", "status": "PASSED", "temperature": False},
-            ]
+                {"device": "nvme0"},
+                {"device": "ada0"},
+                {"device": "da0"},
+            ],
+            "smart_info": {
+                "nvme0": {"temperature": []},
+                "ada0": {"temperature": {}},
+                "da0": {"temperature": {"current": 42}},
+            },
         },
     )
 
-    assert {entity.entity_description.key for entity in smart_entities} == {"smart.da0.status"}
+    assert {entity.entity_description.key for entity in smart_entities} == {"smart.da0.temperature"}
 
 
 @pytest.mark.asyncio
@@ -2425,17 +2482,23 @@ def test_smart_sensor_unavailable_when_device_or_property_missing(
     """SMART disk sensors should be unavailable when their row or field is absent."""
     sensor = _build_smart_sensor(
         make_config_entry,
-        {"smart": [{"device": "nvme0", "status": "PASSED"}]},
-        "smart.ada0.status",
-        "SMART ada0 Status",
+        {
+            "smart": [{"device": "nvme0"}],
+            "smart_info": {"nvme0": {"temperature": {"current": 37}}},
+        },
+        "smart.ada0.temperature",
+        "SMART ada0 Temperature",
     )
-    _prepare_smart_sensor(sensor, "sensor.smart_ada0_status")
+    _prepare_smart_sensor(sensor, "sensor.smart_ada0_temperature")
     sensor._handle_coordinator_update()
     assert sensor.available is False
 
     sensor = _build_smart_sensor(
         make_config_entry,
-        {"smart": [{"device": "nvme0", "status": "PASSED"}]},
+        {
+            "smart": [{"device": "nvme0"}],
+            "smart_info": {"nvme0": {}},
+        },
         "smart.nvme0.temperature",
     )
     _prepare_smart_sensor(sensor, "sensor.smart_nvme0_temperature")
@@ -2446,11 +2509,14 @@ def test_smart_sensor_unavailable_when_device_or_property_missing(
 @pytest.mark.parametrize(
     ("state", "key"),
     [
-        ([], "smart.nvme0.status"),
-        ({"smart": {}}, "smart.nvme0.status"),
-        ({"smart": []}, "smart.nvme0.status"),
-        ({"smart": []}, "smart.nvme0.status.extra"),
-        ({"smart": [{"device": "nvme0", "unknown": "value"}]}, "smart.nvme0.unknown"),
+        ([], "smart.nvme0.temperature"),
+        ({"smart": {}}, "smart.nvme0.temperature"),
+        ({"smart": []}, "smart.nvme0.temperature"),
+        ({"smart": []}, "smart.nvme0.temperature.extra"),
+        (
+            {"smart": [{"device": "nvme0"}], "smart_info": {"nvme0": {"unknown": "value"}}},
+            "smart.nvme0.unknown",
+        ),
     ],
 )
 def test_smart_sensor_unavailable_when_state_or_key_invalid(
@@ -2476,80 +2542,46 @@ def test_smart_sensor_finds_device_after_ignored_rows(
             "smart": [
                 "ignored",
                 {"device": ""},
-                {"device": "nvme0", "status": "PASSED"},
-            ]
+                {"device": "nvme0"},
+            ],
+            "smart_info": {"nvme0": {"temperature": {"current": 37}}},
         },
-        "smart.nvme0.status",
+        "smart.nvme0.temperature",
     )
     _prepare_smart_sensor(sensor, "sensor.smart_nvme0")
     sensor._handle_coordinator_update()
 
     assert sensor.available is True
-    assert sensor.native_value == "PASSED"
+    assert sensor.native_value == 37
 
 
 @pytest.mark.parametrize(
-    ("value", "key"),
+    "value",
     [
-        (["PASSED"], "smart.nvme0.status"),
-        ([], "smart.nvme0.temperature"),
-        ({}, "smart.nvme0.temperature"),
-        (False, "smart.nvme0.temperature"),
-        ("unknown", "smart.nvme0.temperature"),
+        [],
+        {},
+        False,
+        {"current": False},
+        {"current": "unknown"},
     ],
 )
 def test_smart_sensor_unavailable_when_property_malformed(
     value: Any,
-    key: str,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """SMART disk sensors should be unavailable for malformed values."""
-    prop_name = key.split(".")[2]
     sensor = _build_smart_sensor(
         make_config_entry,
-        {"smart": [{"device": "nvme0", prop_name: value}]},
-        key,
+        {
+            "smart": [{"device": "nvme0"}],
+            "smart_info": {"nvme0": {"temperature": value}},
+        },
+        "smart.nvme0.temperature",
     )
     _prepare_smart_sensor(sensor, "sensor.smart_nvme0")
     sensor._handle_coordinator_update()
 
     assert sensor.available is False
-
-
-@pytest.mark.parametrize(
-    ("native_value", "expected_available", "expected_icon"),
-    [
-        ("PASSED", True, "mdi:harddisk"),
-        ("FAILED", True, "mdi:harddisk-remove"),
-        (None, False, "mdi:harddisk"),
-    ],
-)
-def test_smart_status_icon_reflects_failed_health(
-    native_value: str | None,
-    expected_available: bool,
-    expected_icon: str,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """SMART status icon should distinguish passed and failed health states."""
-    entry = make_config_entry()
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    desc = MagicMock()
-    desc.key = "smart.nvme0.status"
-    desc.icon = "mdi:harddisk"
-    sensor = OPNsenseSmartSensor(
-        config_entry=entry,
-        coordinator=coordinator,
-        entity_description=desc,
-    )
-    sensor._available = expected_available
-    sensor._attr_native_value = native_value
-
-    assert sensor.available is expected_available
-    if not expected_available:
-        assert sensor.icon == expected_icon
-        return
-
-    assert sensor.icon == expected_icon
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2727,7 +2727,7 @@ def test_smart_sensor_finds_device_after_ignored_rows(
     ],
 )
 def test_smart_sensor_unavailable_when_property_malformed(
-    value: Any,
+    value: object,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """SMART disk sensors should be unavailable for malformed values."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2555,6 +2555,25 @@ def test_smart_sensor_unavailable_when_device_or_property_missing(
     assert sensor.available is False
 
 
+def test_smart_sensor_strips_device_name_before_smart_info_lookup(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART disk sensors should normalize padded device names before lookup."""
+    sensor = _build_smart_sensor(
+        make_config_entry,
+        {
+            "smart": [{"device": " nvme0 "}],
+            "smart_info": {"nvme0": {"temperature": {"current": 37}}},
+        },
+        "smart.nvme0.temperature",
+    )
+    _prepare_smart_sensor(sensor, "sensor.smart_nvme0_temperature")
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 37
+
+
 @pytest.mark.parametrize(
     ("state", "key"),
     [


### PR DESCRIPTION
## Summary
Split SMART disk health and temperature into clearer per-disk Home Assistant entities, fetch per-device SMART attribute payloads to back those entities, and harden the lookup and refresh paths so malformed rows or one failing device do not break the rest of the SMART update.

## What Changed
- Added dedicated per-disk SMART status binary sensors instead of relying on the old combined SMART sensor behavior
- Reworked SMART temperature handling so per-disk temperature entities are built from `smart_info` attribute payloads
- Updated the coordinator to fetch `get_smart_info` per discovered SMART device and cache those results for entity use
- Normalized SMART device-name matching and lookups so padded device strings still map to the right `smart_info` entry
- Hardened SMART refresh processing so invalid rows are skipped and one per-device SMART info failure is logged without aborting the rest of the refresh
- Expanded SMART-focused regression coverage across binary sensor, sensor, coordinator, init, and shared test fixtures

## Why
The branch introduces the SMART entity split that this work is built around, moves the integration onto per-device SMART attribute data for richer disk reporting, and then follows through with the matching and error-handling fixes needed to make that behavior reliable against real-world SMART payloads.

## Validation
- `./.venv/bin/prek`
- `./.venv/bin/pytest tests/test_binary_sensor.py tests/test_coordinator.py tests/test_sensor.py`