### PR TITLE
Refactor platform compilation

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -29,7 +29,14 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 def _smart_device_slug(device_name: str) -> str:
-    """Return the entity key slug for a SMART device name."""
+    """Return the entity key slug for a SMART device name.
+
+    Args:
+        device_name: SMART device name to normalize.
+
+    Returns:
+        The slugified device name, or ``unknown`` when slugification fails.
+    """
     return slugify(device_name) or "unknown"
 
 
@@ -37,7 +44,15 @@ def _build_interface_enabled_binary_sensor_description(
     interface_name: str,
     interface: Mapping[str, Any],
 ) -> BinarySensorEntityDescription:
-    """Build an interface enabled-state binary sensor description."""
+    """Build an interface enabled-state binary sensor description.
+
+    Args:
+        interface_name: Interface identifier from the OPNsense state.
+        interface: Interface data used to derive the display name.
+
+    Returns:
+        A binary sensor description for the interface enabled state.
+    """
     return BinarySensorEntityDescription(
         key=f"interface.{interface_name}.enabled",
         name=f"Interface {interface.get('name', interface_name)} Enabled",
@@ -49,7 +64,14 @@ def _build_interface_enabled_binary_sensor_description(
 def _build_smart_status_binary_sensor_description(
     device_name: str,
 ) -> BinarySensorEntityDescription:
-    """Build a SMART status binary sensor description."""
+    """Build a SMART status binary sensor description.
+
+    Args:
+        device_name: SMART device name used for the entity key and label.
+
+    Returns:
+        A binary sensor description for SMART health state.
+    """
     return BinarySensorEntityDescription(
         key=f"smart.{_smart_device_slug(device_name)}.status",
         name=f"SMART {device_name} Status",
@@ -60,7 +82,11 @@ def _build_smart_status_binary_sensor_description(
 
 
 def _build_pending_notices_present_binary_sensor_description() -> BinarySensorEntityDescription:
-    """Build the pending notices presence binary sensor description."""
+    """Build the pending notices presence binary sensor description.
+
+    Returns:
+        A binary sensor description for the pending notices indicator.
+    """
     return BinarySensorEntityDescription(
         key="notices.pending_notices_present",
         name="Pending Notices Present",
@@ -154,7 +180,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the OPNsense binary sensors."""
+    """Set up the OPNsense binary sensors.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Config entry being set up.
+        async_add_entities: Callback used to register new entities.
+    """
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     config: Mapping[str, Any] = config_entry.data
 
@@ -183,7 +215,13 @@ class OPNsenseBinarySensor(OPNsenseEntity, BinarySensorEntity):
         coordinator: OPNsenseDataUpdateCoordinator,
         entity_description: BinarySensorEntityDescription,
     ) -> None:
-        """Initialize OPNsense Binary Sensor entity."""
+        """Initialize OPNsense Binary Sensor entity.
+
+        Args:
+            config_entry: Config entry owning the entity.
+            coordinator: Shared OPNsense data coordinator.
+            entity_description: Description that defines the entity identity.
+        """
         name_suffix: str | None = (
             entity_description.name if isinstance(entity_description.name, str) else None
         )

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -28,6 +28,48 @@ from .helpers import coerce_bool, dict_get
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _smart_device_slug(device_name: str) -> str:
+    """Return the entity key slug for a SMART device name."""
+    return slugify(device_name) or "unknown"
+
+
+def _build_interface_enabled_binary_sensor_description(
+    interface_name: str,
+    interface: Mapping[str, Any],
+) -> BinarySensorEntityDescription:
+    """Build an interface enabled-state binary sensor description."""
+    return BinarySensorEntityDescription(
+        key=f"interface.{interface_name}.enabled",
+        name=f"Interface {interface.get('name', interface_name)} Enabled",
+        icon="mdi:network",
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_smart_status_binary_sensor_description(
+    device_name: str,
+) -> BinarySensorEntityDescription:
+    """Build a SMART status binary sensor description."""
+    return BinarySensorEntityDescription(
+        key=f"smart.{_smart_device_slug(device_name)}.status",
+        name=f"SMART {device_name} Status",
+        icon="mdi:harddisk",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_pending_notices_present_binary_sensor_description() -> BinarySensorEntityDescription:
+    """Build the pending notices presence binary sensor description."""
+    return BinarySensorEntityDescription(
+        key="notices.pending_notices_present",
+        name="Pending Notices Present",
+        icon="mdi:alert",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_registry_enabled_default=True,
+    )
+
+
 async def _compile_interface_enabled_binary_sensors(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -58,11 +100,9 @@ async def _compile_interface_enabled_binary_sensors(
             OPNsenseInterfaceEnabledBinarySensor(
                 config_entry=config_entry,
                 coordinator=coordinator,
-                entity_description=BinarySensorEntityDescription(
-                    key=f"interface.{interface_name}.enabled",
-                    name=f"Interface {interface.get('name', interface_name)} Enabled",
-                    icon="mdi:network",
-                    entity_registry_enabled_default=False,
+                entity_description=_build_interface_enabled_binary_sensor_description(
+                    interface_name,
+                    interface,
                 ),
             )
         )
@@ -99,18 +139,11 @@ async def _compile_smart_status_binary_sensors(
             continue
         device_name = device_name.strip()
 
-        device_slug = slugify(device_name) or "unknown"
         entities.append(
             OPNsenseSmartStatusBinarySensor(
                 config_entry=config_entry,
                 coordinator=coordinator,
-                entity_description=BinarySensorEntityDescription(
-                    key=f"smart.{device_slug}.status",
-                    name=f"SMART {device_name} Status",
-                    icon="mdi:harddisk",
-                    device_class=BinarySensorDeviceClass.PROBLEM,
-                    entity_registry_enabled_default=False,
-                ),
+                entity_description=_build_smart_status_binary_sensor_description(device_name),
             )
         )
     return entities
@@ -135,14 +168,7 @@ async def async_setup_entry(
             OPNsensePendingNoticesPresentBinarySensor(
                 config_entry=config_entry,
                 coordinator=coordinator,
-                entity_description=BinarySensorEntityDescription(
-                    key="notices.pending_notices_present",
-                    name="Pending Notices Present",
-                    icon="mdi:alert",
-                    device_class=BinarySensorDeviceClass.PROBLEM,
-                    # entity_category=entity_category,
-                    entity_registry_enabled_default=True,
-                ),
+                entity_description=_build_pending_notices_present_binary_sensor_description(),
             ),
         )
     async_add_entities(entities)
@@ -246,7 +272,7 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
             device_name = candidate.get("device")
             if not isinstance(device_name, str) or not device_name.strip():
                 continue
-            if (slugify(device_name.strip()) or "unknown") == expected_device_slug:
+            if _smart_device_slug(device_name.strip()) == expected_device_slug:
                 smart_device = candidate
                 break
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -79,6 +79,47 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
     return devices, mac_addresses
 
 
+def _non_empty_string(value: Any) -> str | None:
+    """Return a non-empty string value, if available."""
+    return value if isinstance(value, str) and value else None
+
+
+def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
+    """Return the normalized hostname from an ARP entry."""
+    hostname = entry.get("hostname")
+    if not isinstance(hostname, str):
+        return None
+    hostname = hostname.strip("?")
+    return hostname or None
+
+
+def _arp_expires_attribute(value: Any) -> str | datetime | None:
+    """Return the Home Assistant attribute value for an ARP expiry."""
+    if value == -1:
+        return "Never"
+    if isinstance(value, int | float):
+        return datetime.now().astimezone() + timedelta(seconds=value)
+    return None
+
+
+def _update_arp_extra_state_attributes(
+    attributes: dict[str, Any],
+    entry: MutableMapping[str, Any],
+) -> None:
+    """Update optional ARP extra state attributes from a coordinator entry."""
+    interface = entry.get("intf_description")
+    if interface:
+        attributes["interface"] = interface
+
+    expires = _arp_expires_attribute(entry.get("expires"))
+    if expires is not None:
+        attributes["expires"] = expires
+
+    arp_type = entry.get("type")
+    if arp_type:
+        attributes["type"] = arp_type
+
+
 def _compile_tracked_devices(
     config_entry: ConfigEntry,
     arp_entries: list[Any],
@@ -236,22 +277,12 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                 break
         if not entry:
             entry = {}
-        try:
-            self._attr_ip_address = entry.get("ip") if len(entry.get("ip", 0)) > 0 else None
-        except TypeError, KeyError, AttributeError:
-            self._attr_ip_address = None
+        self._attr_ip_address = _non_empty_string(entry.get("ip"))
 
         if self._attr_ip_address:
             self._last_known_ip = self._attr_ip_address
 
-        try:
-            self._attr_hostname = (
-                entry.get("hostname", "").strip("?")
-                if len(entry.get("hostname", "").strip("?")) > 0
-                else None
-            )
-        except TypeError, KeyError, AttributeError:
-            self._attr_hostname = None
+        self._attr_hostname = _hostname_from_arp_entry(entry)
 
         if self._attr_hostname:
             self._last_known_hostname = self._attr_hostname
@@ -277,26 +308,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                 )
             self._is_connected = True
 
-        ha_to_opnsense: dict[str, Any] = {
-            "interface": "intf_description",
-            "expires": "expires",
-            "type": "type",
-        }
-        try:
-            for prop_name in ("interface", "expires", "type"):
-                prop = entry.get(ha_to_opnsense[prop_name])
-                if prop:
-                    if prop_name == "expires":
-                        if prop == -1:
-                            self._attr_extra_state_attributes[prop_name] = "Never"
-                        else:
-                            self._attr_extra_state_attributes[prop_name] = (
-                                datetime.now().astimezone() + timedelta(seconds=prop)
-                            )
-                    else:
-                        self._attr_extra_state_attributes[prop_name] = prop
-        except TypeError, KeyError, AttributeError:
-            pass
+        _update_arp_extra_state_attributes(self._attr_extra_state_attributes, entry)
 
         if self._attr_hostname is None and self._last_known_hostname:
             self._attr_extra_state_attributes["last_known_hostname"] = self._last_known_hostname
@@ -313,10 +325,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                 self._last_known_connected_time
             )
 
-        try:
-            self._attr_icon = "mdi:lan-connect" if self.is_connected else "mdi:lan-disconnect"
-        except TypeError, KeyError, AttributeError:
-            self._attr_icon = "mdi:lan-disconnect"
+        self._attr_icon = "mdi:lan-connect" if self.is_connected else "mdi:lan-disconnect"
 
         self.async_write_ha_state()
 
@@ -337,17 +346,16 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             return
 
         state = last_state.attributes
+        if not isinstance(state, MutableMapping):
+            return
 
         self._last_known_hostname = state.get("last_known_hostname", None)
         self._last_known_ip = state.get("last_known_ip", None)
 
-        try:
-            for attr in ("interface", "expires", "type"):
-                value = state.get(attr, None)
-                if value:
-                    self._attr_extra_state_attributes[attr] = value
-        except TypeError, KeyError, AttributeError:
-            pass
+        for attr in ("interface", "expires", "type"):
+            value = state.get(attr, None)
+            if value:
+                self._attr_extra_state_attributes[attr] = value
 
         lkct = state.get("last_known_connected_time", None)
         if isinstance(lkct, datetime):

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -50,11 +50,21 @@ def _device_data_from_arp_entry(
         A device dictionary populated with the MAC address and metadata.
     """
     device: dict[str, Any] = {"mac": mac_address}
-    for attr in ("hostname", "manufacturer"):
-        value = arp_entry.get(attr)
-        if value:
-            device[attr] = value
+
+    hostname = _hostname_from_arp_entry(arp_entry)
+    if hostname is not None:
+        device["hostname"] = hostname
+
+    manufacturer = _non_empty_string(arp_entry.get("manufacturer"))
+    if manufacturer is not None:
+        device["manufacturer"] = manufacturer
+
     return device
+
+
+def _mac_matches(mac_a: object, mac_b: object) -> bool:
+    """Compare MAC addresses case-insensitively when both values are strings."""
+    return isinstance(mac_a, str) and isinstance(mac_b, str) and mac_a.lower() == mac_b.lower()
 
 
 def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str, Any]:
@@ -71,7 +81,7 @@ def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
             continue
-        if mac_address != arp_entry.get("mac", ""):
+        if not _mac_matches(mac_address, arp_entry.get("mac")):
             continue
         device.update(_device_data_from_arp_entry(mac_address, arp_entry))
         break
@@ -102,7 +112,7 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
     return devices, mac_addresses
 
 
-def _non_empty_string(value: Any) -> str | None:
+def _non_empty_string(value: object) -> str | None:
     """Return a non-empty string value, if available.
 
     Args:
@@ -130,7 +140,7 @@ def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
     return hostname or None
 
 
-def _arp_expires_attribute(value: Any) -> str | datetime | None:
+def _arp_expires_attribute(value: object) -> str | datetime | None:
     """Return the Home Assistant attribute value for an ARP expiry.
 
     Args:
@@ -156,6 +166,9 @@ def _update_arp_extra_state_attributes(
         attributes: Entity attributes to mutate in place.
         entry: ARP entry providing optional metadata.
     """
+    for attr in ("interface", "expires", "type"):
+        attributes.pop(attr, None)
+
     interface = entry.get("intf_description")
     if interface:
         attributes["interface"] = interface
@@ -372,7 +385,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         for arp_entry in arp_table:
             if not isinstance(arp_entry, MutableMapping):
                 continue
-            if arp_entry.get("mac", "").lower() == self._attr_mac_address:
+            if _mac_matches(self._attr_mac_address, arp_entry.get("mac")):
                 entry = arp_entry
                 break
         if not entry:

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -1,6 +1,6 @@
 """Support for tracking for OPNsense devices."""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 import contextlib
 from datetime import datetime, timedelta, timezone
 import logging
@@ -346,7 +346,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             return
 
         state = last_state.attributes
-        if not isinstance(state, MutableMapping):
+        if not isinstance(state, Mapping):
             return
 
         self._last_known_hostname = state.get("last_known_hostname", None)
@@ -358,13 +358,18 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                 self._attr_extra_state_attributes[attr] = value
 
         lkct = state.get("last_known_connected_time", None)
+        parsed_last_known_connected_time: datetime | None = None
         if isinstance(lkct, datetime):
-            self._attr_extra_state_attributes["last_known_connected_time"] = lkct
+            parsed_last_known_connected_time = lkct
         elif isinstance(lkct, str):
             with contextlib.suppress(ValueError):
-                self._attr_extra_state_attributes["last_known_connected_time"] = (
-                    datetime.fromisoformat(lkct)
-                )
+                parsed_last_known_connected_time = datetime.fromisoformat(lkct)
+
+        if parsed_last_known_connected_time is not None:
+            self._last_known_connected_time = parsed_last_known_connected_time
+            self._attr_extra_state_attributes["last_known_connected_time"] = (
+                parsed_last_known_connected_time
+            )
 
     async def async_added_to_hass(self) -> None:
         """Commands to run after entity is created."""

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -36,6 +36,68 @@ from .helpers import dict_get
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str, Any]:
+    """Build tracked device data from a configured MAC and matching ARP entry."""
+    device: dict[str, Any] = {"mac": mac_address}
+    for arp_entry in arp_entries:
+        if not isinstance(arp_entry, MutableMapping):
+            continue
+        if mac_address != arp_entry.get("mac", ""):
+            continue
+        for attr in ("hostname", "manufacturer"):
+            value = arp_entry.get(attr)
+            if value:
+                device[attr] = value
+        break
+    return device
+
+
+def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Build tracked device data from unique ARP table MAC addresses."""
+    devices: list[dict[str, Any]] = []
+    mac_addresses: list[str] = []
+
+    for arp_entry in arp_entries:
+        if not isinstance(arp_entry, MutableMapping):
+            continue
+        mac_address = arp_entry.get("mac")
+        if not mac_address or mac_address in mac_addresses:
+            continue
+        device: dict[str, Any] = {"mac": mac_address}
+        for attr in ("hostname", "manufacturer"):
+            value = arp_entry.get(attr)
+            if value:
+                device[attr] = value
+        mac_addresses.append(mac_address)
+        devices.append(device)
+
+    return devices, mac_addresses
+
+
+def _compile_tracked_devices(
+    config_entry: ConfigEntry,
+    arp_entries: list[Any],
+) -> tuple[list[dict[str, Any]], list[str], bool]:
+    """Compile device tracker source data from options and ARP entries."""
+    if not config_entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED):
+        return [], [], False
+
+    configured_mac_addresses = config_entry.options.get(CONF_DEVICES, [])
+    if configured_mac_addresses:
+        _LOGGER.debug(
+            "[device_tracker async_setup_entry] configured_mac_addresses: %s",
+            configured_mac_addresses,
+        )
+        devices = [
+            _device_from_arp_entry(mac_address, arp_entries)
+            for mac_address in configured_mac_addresses
+        ]
+        return devices, list(configured_mac_addresses), True
+
+    devices, mac_addresses = _devices_from_arp_entries(arp_entries)
+    return devices, mac_addresses, False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -52,54 +114,12 @@ async def async_setup_entry(
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in device tracker async_setup_entry")
         return
-    enabled_default = False
     entities: list = []
-    mac_addresses: list = []
 
-    # use configured mac addresses if setup, otherwise create an entity per arp entry
     arp_entries = dict_get(state, "arp_table")
     if not isinstance(arp_entries, list):
         arp_entries = []
-    devices: list = []
-    mac_addresses = []
-    configured_mac_addresses = config_entry.options.get(CONF_DEVICES, [])
-    if configured_mac_addresses and config_entry.options.get(
-        CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED
-    ):
-        _LOGGER.debug(
-            "[device_tracker async_setup_entry] configured_mac_addresses: %s",
-            configured_mac_addresses,
-        )
-        enabled_default = True
-        mac_addresses = configured_mac_addresses
-        for mac_address in mac_addresses:
-            device: dict[str, Any] = {"mac": mac_address}
-            for arp_entry in arp_entries:
-                if mac_address == arp_entry.get("mac", ""):
-                    try:
-                        for attr in ("hostname", "manufacturer"):
-                            value = arp_entry.get(attr, None)
-                            if value:
-                                device.update({attr: value})
-                    except TypeError, KeyError, AttributeError:
-                        pass
-
-            devices.append(device)
-    elif config_entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED):
-        for arp_entry in arp_entries:
-            mac_address = arp_entry.get("mac", None)
-            if mac_address and mac_address not in mac_addresses:
-                device = {"mac": mac_address}
-                try:
-                    for attr in ("hostname", "manufacturer"):
-                        value = arp_entry.get(attr, None)
-                        if value:
-                            device.update({attr: value})
-                except TypeError, KeyError, AttributeError:
-                    pass
-
-                mac_addresses.append(mac_address)
-                devices.append(device)
+    devices, mac_addresses, enabled_default = _compile_tracked_devices(config_entry, arp_entries)
 
     for device in devices:
         mac = device.get("mac")
@@ -114,12 +134,7 @@ async def async_setup_entry(
             hostname=device.get("hostname", None),
         )
         entities.append(entity)
-    # _LOGGER.debug(
-    #     "[device_tracker async_setup_entry] mac_addresses: %s, previous_mac_addresses: %s",
-    #     mac_addresses,
-    #     previous_mac_addresses,
-    # )
-    # Get the MACs that need to be removed and remove their devices
+
     for mac_address in list(set(previous_mac_addresses) - set(mac_addresses)):
         rem_device = dev_reg.async_get_device(connections={(CONNECTION_NETWORK_MAC, mac_address)})
         if rem_device:
@@ -207,14 +222,15 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             self.async_write_ha_state()
             return
         self._available = True
-        entry: dict[str, Any] | None = None
+        entry: MutableMapping[str, Any] | None = None
         for arp_entry in arp_table:
+            if not isinstance(arp_entry, MutableMapping):
+                continue
             if arp_entry.get("mac", "").lower() == self._attr_mac_address:
                 entry = arp_entry
                 break
         if not entry:
             entry = {}
-        # _LOGGER.debug(f"[OPNsenseScannerEntity handle_coordinator_update] entry: {entry}")
         try:
             self._attr_ip_address = entry.get("ip") if len(entry.get("ip", 0)) > 0 else None
         except TypeError, KeyError, AttributeError:
@@ -236,10 +252,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             self._last_known_hostname = self._attr_hostname
 
         if not isinstance(entry, MutableMapping) or not entry or entry.get("expired", False):
-            if self._last_known_ip:
-                # force a ping to _last_known_ip to possibly recreate arp entry?
-                pass
-
             self._is_connected = False
             device_tracker_consider_home = self.config_entry.options.get(
                 CONF_DEVICE_TRACKER_CONSIDER_HOME, DEFAULT_DEVICE_TRACKER_CONSIDER_HOME
@@ -252,8 +264,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                     self._is_connected = True
 
         else:
-            # Cache clearing is intentionally deferred until a stale-state case is identified.
-
             update_time = state.get("update_time")
             if isinstance(update_time, float):
                 self._last_known_connected_time = datetime.fromtimestamp(
@@ -304,16 +314,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             self._attr_icon = "mdi:lan-disconnect"
 
         self.async_write_ha_state()
-        # _LOGGER.debug(
-        #     f"[OPNsenseScannerEntity handle_coordinator_update] Name: {self.name}, "
-        #     f"unique_id: {self.unique_id}, attr_unique_id: {self._attr_unique_id}, "
-        #     f"available: {self.available}, is_connected: {self.is_connected}, "
-        #     f"hostname: {self.hostname}, ip_address: {self.ip_address}, "
-        # f"last_known_hostname: {self._last_known_hostname}, last_known_ip:
-        # {self._last_known_ip}, "
-        #     f"last_known_connected_time: {self._last_known_connected_time}, icon: {self.icon}, "
-        #     f"extra_state_attributes: {self.extra_state_attributes}"
-        # )
 
     @property  # type: ignore[misc] # overriding final from ScannerEntity
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -482,7 +482,11 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             with contextlib.suppress(ValueError):
                 parsed_last_known_connected_time = datetime.fromisoformat(lkct)
 
-        if parsed_last_known_connected_time is not None:
+        if (
+            parsed_last_known_connected_time is not None
+            and parsed_last_known_connected_time.tzinfo is not None
+            and parsed_last_known_connected_time.utcoffset() is not None
+        ):
             self._last_known_connected_time = parsed_last_known_connected_time
             self._attr_extra_state_attributes["last_known_connected_time"] = (
                 parsed_last_known_connected_time

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -36,6 +36,19 @@ from .helpers import dict_get
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _device_data_from_arp_entry(
+    mac_address: str,
+    arp_entry: MutableMapping[str, Any],
+) -> dict[str, Any]:
+    """Build tracked device data from an ARP table entry."""
+    device: dict[str, Any] = {"mac": mac_address}
+    for attr in ("hostname", "manufacturer"):
+        value = arp_entry.get(attr)
+        if value:
+            device[attr] = value
+    return device
+
+
 def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str, Any]:
     """Build tracked device data from a configured MAC and matching ARP entry."""
     device: dict[str, Any] = {"mac": mac_address}
@@ -44,10 +57,7 @@ def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str
             continue
         if mac_address != arp_entry.get("mac", ""):
             continue
-        for attr in ("hostname", "manufacturer"):
-            value = arp_entry.get(attr)
-            if value:
-                device[attr] = value
+        device.update(_device_data_from_arp_entry(mac_address, arp_entry))
         break
     return device
 
@@ -61,15 +71,10 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
         if not isinstance(arp_entry, MutableMapping):
             continue
         mac_address = arp_entry.get("mac")
-        if not mac_address or mac_address in mac_addresses:
+        if not isinstance(mac_address, str) or not mac_address or mac_address in mac_addresses:
             continue
-        device: dict[str, Any] = {"mac": mac_address}
-        for attr in ("hostname", "manufacturer"):
-            value = arp_entry.get(attr)
-            if value:
-                device[attr] = value
         mac_addresses.append(mac_address)
-        devices.append(device)
+        devices.append(_device_data_from_arp_entry(mac_address, arp_entry))
 
     return devices, mac_addresses
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -40,7 +40,15 @@ def _device_data_from_arp_entry(
     mac_address: str,
     arp_entry: MutableMapping[str, Any],
 ) -> dict[str, Any]:
-    """Build tracked device data from an ARP table entry."""
+    """Build tracked device data from an ARP table entry.
+
+    Args:
+        mac_address: MAC address used as the tracked-device identity.
+        arp_entry: ARP entry containing optional metadata.
+
+    Returns:
+        A device dictionary populated with the MAC address and metadata.
+    """
     device: dict[str, Any] = {"mac": mac_address}
     for attr in ("hostname", "manufacturer"):
         value = arp_entry.get(attr)
@@ -50,7 +58,15 @@ def _device_data_from_arp_entry(
 
 
 def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str, Any]:
-    """Build tracked device data from a configured MAC and matching ARP entry."""
+    """Build tracked device data from a configured MAC and matching ARP entry.
+
+    Args:
+        mac_address: Configured MAC address for the tracker entity.
+        arp_entries: Raw ARP entries returned by OPNsense.
+
+    Returns:
+        A device dictionary for the matching ARP entry, or a MAC-only fallback.
+    """
     device: dict[str, Any] = {"mac": mac_address}
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
@@ -63,7 +79,14 @@ def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str
 
 
 def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, Any]], list[str]]:
-    """Build tracked device data from unique ARP table MAC addresses."""
+    """Build tracked device data from unique ARP table MAC addresses.
+
+    Args:
+        arp_entries: Raw ARP entries returned by OPNsense.
+
+    Returns:
+        A tuple of device dictionaries and the unique MAC addresses found.
+    """
     devices: list[dict[str, Any]] = []
     mac_addresses: list[str] = []
 
@@ -80,12 +103,26 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
 
 
 def _non_empty_string(value: Any) -> str | None:
-    """Return a non-empty string value, if available."""
+    """Return a non-empty string value, if available.
+
+    Args:
+        value: Candidate value to inspect.
+
+    Returns:
+        The input string when it is non-empty, otherwise ``None``.
+    """
     return value if isinstance(value, str) and value else None
 
 
 def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
-    """Return the normalized hostname from an ARP entry."""
+    """Return the normalized hostname from an ARP entry.
+
+    Args:
+        entry: ARP entry to normalize.
+
+    Returns:
+        The stripped hostname, or ``None`` when no usable hostname exists.
+    """
     hostname = entry.get("hostname")
     if not isinstance(hostname, str):
         return None
@@ -94,7 +131,14 @@ def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
 
 
 def _arp_expires_attribute(value: Any) -> str | datetime | None:
-    """Return the Home Assistant attribute value for an ARP expiry."""
+    """Return the Home Assistant attribute value for an ARP expiry.
+
+    Args:
+        value: Raw expiry value from OPNsense.
+
+    Returns:
+        ``"Never"`` for permanent entries, a datetime for relative expiry, or ``None``.
+    """
     if value == -1:
         return "Never"
     if isinstance(value, int | float):
@@ -106,7 +150,12 @@ def _update_arp_extra_state_attributes(
     attributes: dict[str, Any],
     entry: MutableMapping[str, Any],
 ) -> None:
-    """Update optional ARP extra state attributes from a coordinator entry."""
+    """Update optional ARP extra state attributes from a coordinator entry.
+
+    Args:
+        attributes: Entity attributes to mutate in place.
+        entry: ARP entry providing optional metadata.
+    """
     interface = entry.get("intf_description")
     if interface:
         attributes["interface"] = interface
@@ -124,7 +173,15 @@ def _compile_tracked_devices(
     config_entry: ConfigEntry,
     arp_entries: list[Any],
 ) -> tuple[list[dict[str, Any]], list[str], bool]:
-    """Compile device tracker source data from options and ARP entries."""
+    """Compile device tracker source data from options and ARP entries.
+
+    Args:
+        config_entry: Config entry containing device-tracker options.
+        arp_entries: Raw ARP entries returned by OPNsense.
+
+    Returns:
+        A tuple of devices, MAC addresses, and the default enabled flag.
+    """
     if not config_entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED):
         return [], [], False
 
@@ -149,7 +206,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up device tracker for OPNsense component."""
+    """Set up device tracker entities for the OPNsense component.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Config entry being set up.
+        async_add_entities: Callback used to register new entities.
+    """
     dev_reg = async_get_dev_reg(hass)
 
     previous_mac_addresses: list = config_entry.data.get(TRACKED_MACS, [])
@@ -208,7 +271,16 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         mac_vendor: str | None,
         hostname: str | None,
     ) -> None:
-        """Set up the OPNsense scanner entity."""
+        """Set up the OPNsense scanner entity.
+
+        Args:
+            config_entry: Config entry owning the entity.
+            coordinator: Shared OPNsense data coordinator.
+            enabled_default: Whether the entity is enabled by default.
+            mac: MAC address tracked by the entity.
+            mac_vendor: Vendor name reported for the MAC address.
+            hostname: Hostname reported by OPNsense.
+        """
         super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_vendor: str | None = mac_vendor
         self._attr_name: str | None = f"{self.opnsense_device_name} {hostname or mac}"
@@ -225,42 +297,70 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
 
     @property
     def source_type(self) -> SourceType:
-        """Return the tracker source type."""
+        """Return the tracker source type.
+
+        Returns:
+            The source type reported to Home Assistant.
+        """
         return self._attr_source_type
 
     @property
     def is_connected(self) -> bool:
-        """Return if the tracker is connected."""
+        """Return if the tracker is connected.
+
+        Returns:
+            ``True`` when the device is currently considered connected.
+        """
         return self._is_connected
 
     @property
     def ip_address(self) -> str | None:
-        """Return the IP address."""
+        """Return the IP address.
+
+        Returns:
+            The current IP address, or ``None`` when unavailable.
+        """
         return self._attr_ip_address
 
     @property
     def mac_address(self) -> str | None:
-        """Return the MAC address."""
+        """Return the MAC address.
+
+        Returns:
+            The tracked MAC address, or ``None`` when unavailable.
+        """
         return self._attr_mac_address
 
     @property
     def hostname(self) -> str | None:
-        """Return the hostname."""
+        """Return the hostname.
+
+        Returns:
+            The current hostname, or ``None`` when unavailable.
+        """
         return self._attr_hostname
 
     @property
     def unique_id(self) -> str | None:
-        """Return the unique id."""
+        """Return the unique id.
+
+        Returns:
+            The Home Assistant entity unique ID.
+        """
         return self._attr_unique_id
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity registry is enabled by default."""
+        """Return if the entity registry is enabled by default.
+
+        Returns:
+            ``True`` when the entity should be enabled by default.
+        """
         return self._attr_entity_registry_enabled_default
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle coordinator update."""
+        """Refresh tracker state from the latest ARP table."""
         state: dict[str, Any] = self.coordinator.data
         arp_table = dict_get(state, "arp_table")
         if not isinstance(arp_table, list) or not isinstance(state, MutableMapping):
@@ -331,7 +431,11 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
 
     @property  # type: ignore[misc] # overriding final from ScannerEntity
     def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
+        """Return the device info.
+
+        Returns:
+            Device registry metadata for the tracked MAC address.
+        """
         return DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self.mac_address or "")},
             default_manufacturer=self._mac_vendor or "",
@@ -340,7 +444,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         )
 
     async def _restore_last_state(self) -> None:
-        """Restore last state."""
+        """Restore tracker state from Home Assistant's last saved snapshot."""
         last_state = await self.async_get_last_state()
         if last_state is None or last_state.attributes is None:
             return

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -33,7 +33,17 @@ def _create_switch[EntityT: OPNsenseSwitch](
     coordinator: OPNsenseDataUpdateCoordinator,
     entity_description: SwitchEntityDescription,
 ) -> EntityT:
-    """Create a switch entity from a description."""
+    """Create a switch entity from a description.
+
+    Args:
+        entity_cls: Switch entity class to instantiate.
+        config_entry: Config entry owning the entity.
+        coordinator: Shared OPNsense data coordinator.
+        entity_description: Description that defines the entity identity.
+
+    Returns:
+        A configured switch entity instance.
+    """
     return entity_cls(
         config_entry=config_entry,
         coordinator=coordinator,
@@ -42,7 +52,14 @@ def _create_switch[EntityT: OPNsenseSwitch](
 
 
 def _build_service_switch_description(service: Mapping[str, Any]) -> SwitchEntityDescription:
-    """Build the service switch description."""
+    """Build the service switch description.
+
+    Args:
+        service: Service record from the OPNsense state payload.
+
+    Returns:
+        A switch entity description for the service status toggle.
+    """
     prop_name = "status"
     service_id = service.get("id", service.get("name", "unknown"))
     service_name = service.get("description", service.get("name", "Unknown"))
@@ -61,7 +78,17 @@ def _build_vpn_switch_description(
     uuid: str,
     instance: Mapping[str, Any],
 ) -> SwitchEntityDescription:
-    """Build the VPN switch description."""
+    """Build the VPN switch description.
+
+    Args:
+        vpn_type: VPN family name, such as ``openvpn`` or ``wireguard``.
+        clients_servers: Section name identifying clients or servers.
+        uuid: Unique instance identifier from OPNsense.
+        instance: Instance metadata used to build the display name.
+
+    Returns:
+        A switch entity description for the VPN instance.
+    """
     return SwitchEntityDescription(
         key=f"{vpn_type}.{clients_servers}.{uuid}",
         name=(
@@ -75,7 +102,11 @@ def _build_vpn_switch_description(
 
 
 def _build_carp_maintenance_switch_description() -> SwitchEntityDescription:
-    """Build the CARP maintenance switch description."""
+    """Build the CARP maintenance switch description.
+
+    Returns:
+        A switch entity description for CARP persistent maintenance mode.
+    """
     return SwitchEntityDescription(
         key="carp.maintenance_mode",
         name="CARP Persistent Maintenance Mode",
@@ -86,7 +117,11 @@ def _build_carp_maintenance_switch_description() -> SwitchEntityDescription:
 
 
 def _build_unbound_legacy_switch_description() -> SwitchEntityDescription:
-    """Build the legacy Unbound blocklist switch description."""
+    """Build the legacy Unbound blocklist switch description.
+
+    Returns:
+        A switch entity description for the legacy Unbound blocklist toggle.
+    """
     return SwitchEntityDescription(
         key="unbound_blocklist.switch",
         name="Unbound Blocklist Switch",
@@ -98,7 +133,15 @@ def _build_unbound_legacy_switch_description() -> SwitchEntityDescription:
 def _build_unbound_switch_description(
     uuid: str, dnsbl: Mapping[str, Any]
 ) -> SwitchEntityDescription:
-    """Build an extended Unbound blocklist switch description."""
+    """Build an extended Unbound blocklist switch description.
+
+    Args:
+        uuid: DNSBL identifier from OPNsense.
+        dnsbl: DNSBL rule data used for naming.
+
+    Returns:
+        A switch entity description for the DNSBL rule.
+    """
     return SwitchEntityDescription(
         key=f"unbound_blocklist.switch.{uuid}",
         name=f"Unbound Blocklist {dnsbl.get('description', 'Unknown')}",
@@ -109,7 +152,14 @@ def _build_unbound_switch_description(
 
 
 def _build_firewall_rule_switch_description(rule: Mapping[str, Any]) -> SwitchEntityDescription:
-    """Build the firewall rule switch description."""
+    """Build the firewall rule switch description.
+
+    Args:
+        rule: Firewall rule data from the OPNsense payload.
+
+    Returns:
+        A switch entity description for the firewall rule toggle.
+    """
     interface = rule.get("%interface", rule.get("interface", ""))
     if not isinstance(interface, str):
         interface = ""
@@ -129,7 +179,16 @@ def _build_nat_rule_switch_description(
     name_prefix: str,
     rule: Mapping[str, Any],
 ) -> SwitchEntityDescription:
-    """Build a NAT rule switch description."""
+    """Build a NAT rule switch description.
+
+    Args:
+        nat_rule_type: NAT section name such as ``source_nat`` or ``d_nat``.
+        name_prefix: Human-readable prefix for the entity name.
+        rule: NAT rule data from the OPNsense payload.
+
+    Returns:
+        A switch entity description for the NAT rule toggle.
+    """
     return SwitchEntityDescription(
         key=f"firewall.nat.{nat_rule_type}.{rule.get('uuid', 'unknown')}",
         name=f"{name_prefix}: {rule.get('%interface', '')}: {rule.get('description', 'unknown')}",
@@ -336,7 +395,18 @@ async def _compile_nat_rule_switches(
     nat_rule_type: str,
     name_prefix: str,
 ) -> list:
-    """Compile NAT rule switches from OPNsense state."""
+    """Compile NAT rule switches from OPNsense state.
+
+    Args:
+        config_entry: Config entry owning the entities.
+        coordinator: Shared OPNsense data coordinator.
+        state: Current OPNsense state payload.
+        nat_rule_type: NAT section name such as ``source_nat`` or ``d_nat``.
+        name_prefix: Human-readable prefix for the generated entities.
+
+    Returns:
+        A list of NAT rule switch entities.
+    """
     rules = dict_get(state, f"firewall.nat.{nat_rule_type}")
     if not isinstance(rules, MutableMapping):
         return []
@@ -543,7 +613,11 @@ class OPNsenseSwitch(OPNsenseEntity, SwitchEntity):
             self._delay_update_remove()
 
         def _clear(_: Any) -> None:
-            """Clear."""
+            """Clear the update delay after the timer fires.
+
+            Args:
+                _: Timer callback timestamp, unused.
+            """
             self._delay_update = False
             self._delay_update_remove = None
 
@@ -561,7 +635,13 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
         coordinator: OPNsenseDataUpdateCoordinator,
         entity_description: SwitchEntityDescription,
     ) -> None:
-        """Initialize CARP maintenance switch state."""
+        """Initialize CARP maintenance switch state.
+
+        Args:
+            config_entry: Config entry owning the entity.
+            coordinator: Shared OPNsense data coordinator.
+            entity_description: Description that defines the entity identity.
+        """
         super().__init__(
             config_entry=config_entry,
             coordinator=coordinator,
@@ -629,7 +709,11 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
         self._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn CARP persistent maintenance mode on."""
+        """Turn CARP persistent maintenance mode on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._toggle_in_flight:
             return
         if self.delay_update:
@@ -653,7 +737,11 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
             self._toggle_in_flight = False
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn CARP persistent maintenance mode off."""
+        """Turn CARP persistent maintenance mode off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._toggle_in_flight:
             return
         if self.delay_update:
@@ -678,7 +766,11 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the entity."""
+        """Return the icon for the entity.
+
+        Returns:
+            Icon name for the entity, or the base icon when inactive.
+        """
         if self.available and self.is_on:
             return "mdi:server-network-off"
         return super().icon
@@ -767,7 +859,11 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
+        """Turn the entity on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._rule_id is None or not self._client:
             return
         result = await self._client.toggle_firewall_rule(self._rule_id, "on")
@@ -780,7 +876,11 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             _LOGGER.error("Failed to turn on firewall rule: %s", self.name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
+        """Turn the entity off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._rule_id is None or not self._client:
             return
         result = await self._client.toggle_firewall_rule(self._rule_id, "off")
@@ -794,7 +894,11 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the entity."""
+        """Return the icon for the entity.
+
+        Returns:
+            Icon name for the entity, or the base icon when inactive.
+        """
         if self.available and self.is_on:
             return "mdi:play-network"
         return super().icon
@@ -930,7 +1034,11 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
+        """Turn the entity on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._rule_id is None or not self._client:
             return
         result = await self._client.toggle_nat_rule(self._nat_rule_type, self._rule_id, "on")
@@ -943,7 +1051,11 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             _LOGGER.error("Failed to turn on NAT rule: %s", self.name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
+        """Turn the entity off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if self._rule_id is None or not self._client:
             return
         result = await self._client.toggle_nat_rule(self._nat_rule_type, self._rule_id, "off")
@@ -957,7 +1069,11 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the entity."""
+        """Return the icon for the entity.
+
+        Returns:
+            Icon name for the entity, or the base icon when inactive.
+        """
         if self.available and self.is_on:
             return "mdi:network"
         return super().icon
@@ -1042,7 +1158,11 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
+        """Turn the entity on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not isinstance(self._service, MutableMapping) or not self._client:
             return
 
@@ -1058,7 +1178,11 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             _LOGGER.error("Failed to turn on service: %s", self.name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
+        """Turn the entity off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not isinstance(self._service, MutableMapping) or not self._client:
             return
 
@@ -1075,7 +1199,11 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the entity."""
+        """Return the icon for the entity.
+
+        Returns:
+            Icon name for the entity, or the base icon when inactive.
+        """
         if self.available and self.is_on:
             return "mdi:application-cog"
         return super().icon
@@ -1113,7 +1241,11 @@ class OPNsenseUnboundBlocklistSwitchLegacy(OPNsenseSwitch):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
+        """Turn the entity on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not self._client:
             return
         result: bool = await self._client.enable_unbound_blocklist()
@@ -1126,7 +1258,11 @@ class OPNsenseUnboundBlocklistSwitchLegacy(OPNsenseSwitch):
             _LOGGER.error("Failed to turn on Unbound Blocklist: %s", self.name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
+        """Turn the entity off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not self._client:
             return
         result: bool = await self._client.disable_unbound_blocklist()
@@ -1198,7 +1334,11 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the entity on."""
+        """Turn the entity on.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not self._client:
             return
         result: bool = await self._client.enable_unbound_blocklist(self._uuid)
@@ -1211,7 +1351,11 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
             _LOGGER.error("Failed to turn on Unbound Blocklist: %s", self.name)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the entity off."""
+        """Turn the entity off.
+
+        Args:
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         if not self._client:
             return
         result: bool = await self._client.disable_unbound_blocklist(self._uuid)
@@ -1352,7 +1496,11 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the entity."""
+        """Return the icon for the entity.
+
+        Returns:
+            Icon name for the entity, or the base icon when inactive.
+        """
         if self.available and self.is_on:
             return "mdi:folder-key-network"
         return super().icon

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -27,6 +27,118 @@ from .helpers import coerce_bool, dict_get
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _create_switch[EntityT: OPNsenseSwitch](
+    entity_cls: type[EntityT],
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    entity_description: SwitchEntityDescription,
+) -> EntityT:
+    """Create a switch entity from a description."""
+    return entity_cls(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=entity_description,
+    )
+
+
+def _build_service_switch_description(service: Mapping[str, Any]) -> SwitchEntityDescription:
+    """Build the service switch description."""
+    prop_name = "status"
+    service_id = service.get("id", service.get("name", "unknown"))
+    service_name = service.get("description", service.get("name", "Unknown"))
+    return SwitchEntityDescription(
+        key=f"service.{service_id}.{prop_name}",
+        name=f"Service {service_name} {prop_name}",
+        icon="mdi:application-cog-outline",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_vpn_switch_description(
+    vpn_type: str,
+    clients_servers: str,
+    uuid: str,
+    instance: Mapping[str, Any],
+) -> SwitchEntityDescription:
+    """Build the VPN switch description."""
+    return SwitchEntityDescription(
+        key=f"{vpn_type}.{clients_servers}.{uuid}",
+        name=(
+            f"{'OpenVPN' if vpn_type == 'openvpn' else vpn_type.title()} "
+            f"{clients_servers.title().rstrip('s')} {instance['name']}"
+        ),
+        icon="mdi:folder-key-network-outline",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_carp_maintenance_switch_description() -> SwitchEntityDescription:
+    """Build the CARP maintenance switch description."""
+    return SwitchEntityDescription(
+        key="carp.maintenance_mode",
+        name="CARP Persistent Maintenance Mode",
+        icon="mdi:server-network",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_unbound_legacy_switch_description() -> SwitchEntityDescription:
+    """Build the legacy Unbound blocklist switch description."""
+    return SwitchEntityDescription(
+        key="unbound_blocklist.switch",
+        name="Unbound Blocklist Switch",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_unbound_switch_description(
+    uuid: str, dnsbl: Mapping[str, Any]
+) -> SwitchEntityDescription:
+    """Build an extended Unbound blocklist switch description."""
+    return SwitchEntityDescription(
+        key=f"unbound_blocklist.switch.{uuid}",
+        name=f"Unbound Blocklist {dnsbl.get('description', 'Unknown')}",
+        icon="mdi:folder-key-network-outline",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_firewall_rule_switch_description(rule: Mapping[str, Any]) -> SwitchEntityDescription:
+    """Build the firewall rule switch description."""
+    interface = rule.get("%interface", rule.get("interface", ""))
+    if not isinstance(interface, str):
+        interface = ""
+    if "," in interface or interface == "":
+        interface = "Floating"
+    return SwitchEntityDescription(
+        key=f"firewall.rule.{rule.get('uuid', 'unknown')}",
+        name=f"Firewall: {interface}: {rule.get('description', 'unknown')}",
+        icon="mdi:play-network-outline",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
+def _build_nat_rule_switch_description(
+    nat_rule_type: str,
+    name_prefix: str,
+    rule: Mapping[str, Any],
+) -> SwitchEntityDescription:
+    """Build a NAT rule switch description."""
+    return SwitchEntityDescription(
+        key=f"firewall.nat.{nat_rule_type}.{rule.get('uuid', 'unknown')}",
+        name=f"{name_prefix}: {rule.get('%interface', '')}: {rule.get('description', 'unknown')}",
+        icon="mdi:network-outline",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_registry_enabled_default=False,
+    )
+
+
 async def _compile_service_switches(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -46,25 +158,19 @@ async def _compile_service_switches(
         return []
 
     entities: list = []
-    # services
     for service in state.get("services", []):
+        if not isinstance(service, Mapping):
+            continue
         if service.get("locked", 1) == 1:
             continue
-        for prop_name in ["status"]:
-            entity = OPNsenseServiceSwitch(
-                config_entry=config_entry,
-                coordinator=coordinator,
-                entity_description=SwitchEntityDescription(
-                    key=f"service.{service.get('id', service.get('name', 'unknown'))}.{prop_name}",
-                    name=f"Service {service.get('description', service.get('name', 'Unknown'))} "
-                    f"{prop_name}",
-                    icon="mdi:application-cog-outline",
-                    # entity_category=ENTITY_CATEGORY_CONFIG,
-                    device_class=SwitchDeviceClass.SWITCH,
-                    entity_registry_enabled_default=False,
-                ),
+        entities.append(
+            _create_switch(
+                OPNsenseServiceSwitch,
+                config_entry,
+                coordinator,
+                _build_service_switch_description(service),
             )
-            entities.append(entity)
+        )
     return entities
 
 
@@ -95,20 +201,14 @@ async def _compile_vpn_switches(
                 ):
                     continue
 
-                entity = OPNsenseVPNSwitch(
-                    config_entry=config_entry,
-                    coordinator=coordinator,
-                    entity_description=SwitchEntityDescription(
-                        key=f"{vpn_type}.{clients_servers}.{uuid}",
-                        name=f"{'OpenVPN' if vpn_type == 'openvpn' else vpn_type.title()} "
-                        f"{clients_servers.title().rstrip('s')} {instance['name']}",
-                        icon="mdi:folder-key-network-outline",
-                        # entity_category=ENTITY_CATEGORY_CONFIG,
-                        device_class=SwitchDeviceClass.SWITCH,
-                        entity_registry_enabled_default=False,
-                    ),
+                entities.append(
+                    _create_switch(
+                        OPNsenseVPNSwitch,
+                        config_entry,
+                        coordinator,
+                        _build_vpn_switch_description(vpn_type, clients_servers, uuid, instance),
+                    )
                 )
-                entities.append(entity)
     return entities
 
 
@@ -133,16 +233,11 @@ async def _compile_carp_maintenance_switch(
         return []
 
     return [
-        OPNsenseCarpMaintenanceSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key="carp.maintenance_mode",
-                name="CARP Persistent Maintenance Mode",
-                icon="mdi:server-network",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
+        _create_switch(
+            OPNsenseCarpMaintenanceSwitch,
+            config_entry,
+            coordinator,
+            _build_carp_maintenance_switch_description(),
         )
     ]
 
@@ -171,17 +266,11 @@ async def _compile_unbound_switches(
     entities: list = []
     if isinstance(unbound_blocklist.get("legacy"), MutableMapping):
         entities.append(
-            OPNsenseUnboundBlocklistSwitchLegacy(
-                config_entry=config_entry,
-                coordinator=coordinator,
-                entity_description=SwitchEntityDescription(
-                    key="unbound_blocklist.switch",
-                    name="Unbound Blocklist Switch",
-                    # icon=icon,
-                    # entity_category=ENTITY_CATEGORY_CONFIG,
-                    device_class=SwitchDeviceClass.SWITCH,
-                    entity_registry_enabled_default=False,
-                ),
+            _create_switch(
+                OPNsenseUnboundBlocklistSwitchLegacy,
+                config_entry,
+                coordinator,
+                _build_unbound_legacy_switch_description(),
             )
         )
 
@@ -191,19 +280,14 @@ async def _compile_unbound_switches(
         if not isinstance(dnsbl, MutableMapping):
             continue
 
-        entity = OPNsenseUnboundBlocklistSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"unbound_blocklist.switch.{uuid}",
-                name=f"Unbound Blocklist {dnsbl.get('description', 'Unknown')}",
-                icon="mdi:folder-key-network-outline",
-                # entity_category=ENTITY_CATEGORY_CONFIG,
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
+        entities.append(
+            _create_switch(
+                OPNsenseUnboundBlocklistSwitch,
+                config_entry,
+                coordinator,
+                _build_unbound_switch_description(uuid, dnsbl),
+            )
         )
-        entities.append(entity)
 
     return entities
 
@@ -234,20 +318,41 @@ async def _compile_firewall_rules_switches(
         interface = rule.get("%interface", rule.get("interface", ""))
         if not isinstance(interface, str):
             continue
-        if "," in interface or interface == "":
-            interface = "Floating"
-        entity = OPNsenseFirewallRuleSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"firewall.rule.{rule.get('uuid', 'unknown')}",
-                name=f"Firewall: {interface}: {rule.get('description', 'unknown')}",
-                icon="mdi:play-network-outline",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
+        entities.append(
+            _create_switch(
+                OPNsenseFirewallRuleSwitch,
+                config_entry,
+                coordinator,
+                _build_firewall_rule_switch_description(rule),
+            )
         )
-        entities.append(entity)
+    return entities
+
+
+async def _compile_nat_rule_switches(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+    nat_rule_type: str,
+    name_prefix: str,
+) -> list:
+    """Compile NAT rule switches from OPNsense state."""
+    rules = dict_get(state, f"firewall.nat.{nat_rule_type}")
+    if not isinstance(rules, MutableMapping):
+        return []
+
+    entities: list = []
+    for rule in rules.values():
+        if not isinstance(rule, MutableMapping):
+            continue
+        entities.append(
+            _create_switch(
+                OPNsenseNATRuleSwitch,
+                config_entry,
+                coordinator,
+                _build_nat_rule_switch_description(nat_rule_type, name_prefix, rule),
+            )
+        )
     return entities
 
 
@@ -266,30 +371,9 @@ async def _compile_nat_source_rules_switches(
     Returns:
         list: A list of OPNsenseNATRuleSwitch entities for source NAT rules.
     """
-    rules = dict_get(state, "firewall.nat.source_nat")
-    if not isinstance(rules, MutableMapping):
-        return []
-
-    entities: list = []
-    for rule in rules.values():
-        if not isinstance(rule, MutableMapping):
-            continue
-        entity = OPNsenseNATRuleSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"firewall.nat.source_nat.{rule.get('uuid', 'unknown')}",
-                name=(
-                    f"NAT Source: {rule.get('%interface', '')}: "
-                    f"{rule.get('description', 'unknown')}"
-                ),
-                icon="mdi:network-outline",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
-        )
-        entities.append(entity)
-    return entities
+    return await _compile_nat_rule_switches(
+        config_entry, coordinator, state, "source_nat", "NAT Source"
+    )
 
 
 async def _compile_nat_destination_rules_switches(
@@ -307,30 +391,9 @@ async def _compile_nat_destination_rules_switches(
     Returns:
         list: A list of OPNsenseNATRuleSwitch entities for destination NAT rules.
     """
-    rules = dict_get(state, "firewall.nat.d_nat")
-    if not isinstance(rules, MutableMapping):
-        return []
-
-    entities: list = []
-    for rule in rules.values():
-        if not isinstance(rule, MutableMapping):
-            continue
-        entity = OPNsenseNATRuleSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"firewall.nat.d_nat.{rule.get('uuid', 'unknown')}",
-                name=(
-                    f"NAT Destination: {rule.get('%interface', '')}: "
-                    f"{rule.get('description', 'unknown')}"
-                ),
-                icon="mdi:network-outline",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
-        )
-        entities.append(entity)
-    return entities
+    return await _compile_nat_rule_switches(
+        config_entry, coordinator, state, "d_nat", "NAT Destination"
+    )
 
 
 async def _compile_nat_one_to_one_rules_switches(
@@ -348,30 +411,9 @@ async def _compile_nat_one_to_one_rules_switches(
     Returns:
         list: A list of OPNsenseNATRuleSwitch entities for one-to-one NAT rules.
     """
-    rules = dict_get(state, "firewall.nat.one_to_one")
-    if not isinstance(rules, MutableMapping):
-        return []
-
-    entities: list = []
-    for rule in rules.values():
-        if not isinstance(rule, MutableMapping):
-            continue
-        entity = OPNsenseNATRuleSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"firewall.nat.one_to_one.{rule.get('uuid', 'unknown')}",
-                name=(
-                    f"NAT One to One: {rule.get('%interface', '')}: "
-                    f"{rule.get('description', 'unknown')}"
-                ),
-                icon="mdi:network-outline",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
-        )
-        entities.append(entity)
-    return entities
+    return await _compile_nat_rule_switches(
+        config_entry, coordinator, state, "one_to_one", "NAT One to One"
+    )
 
 
 async def _compile_nat_npt_rules_switches(
@@ -389,29 +431,7 @@ async def _compile_nat_npt_rules_switches(
     Returns:
         list: A list of OPNsenseNATRuleSwitch entities for NPTv6 NAT rules.
     """
-    rules = dict_get(state, "firewall.nat.npt")
-    if not isinstance(rules, MutableMapping):
-        return []
-
-    entities: list = []
-    for rule in rules.values():
-        if not isinstance(rule, MutableMapping):
-            continue
-        entity = OPNsenseNATRuleSwitch(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=SwitchEntityDescription(
-                key=f"firewall.nat.npt.{rule.get('uuid', 'unknown')}",
-                name=(
-                    f"NAT NPTv6: {rule.get('%interface', '')}: {rule.get('description', 'unknown')}"
-                ),
-                icon="mdi:network-outline",
-                device_class=SwitchDeviceClass.SWITCH,
-                entity_registry_enabled_default=False,
-            ),
-        )
-        entities.append(entity)
-    return entities
+    return await _compile_nat_rule_switches(config_entry, coordinator, state, "npt", "NAT NPTv6")
 
 
 async def async_setup_entry(
@@ -686,9 +706,6 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             entity_description=entity_description,
         )
         self._rule_id: str = self._opnsense_get_rule_id()
-        # _LOGGER.debug(
-        #     "[OPNsenseFirewallRuleSwitch init] Name: %s, rule_id: %s", self.name, self._rule_id
-        # )
 
     def _opnsense_get_rule_id(self) -> str:
         """Get the rule ID from the entity description.
@@ -748,14 +765,6 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
         for name, attr in properties.items():
             self._attr_extra_state_attributes[name] = rule.get(attr, None)
         self.async_write_ha_state()
-        # _LOGGER.debug(
-        #     "[OPNsenseFirewallRuleSwitch handle_coordinator_update] "
-        #     "Name: %s, available: %s, is_on: %s, extra_state_attributes: %s",
-        #     self.name,
-        #     self.available,
-        #     self.is_on,
-        #     self.extra_state_attributes,
-        # )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -814,13 +823,6 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
         )
         self._rule_id: str = self._opnsense_get_rule_id()
         self._nat_rule_type: str = self._get_nat_rule_type()
-        # _LOGGER.debug(
-        #     "[OPNsenseNATRuleSwitch init] Name: %s, key: %s, rule_id: %s, rule_type: %s",
-        #     self.name,
-        #     self.entity_description.key,
-        #     self._rule_id,
-        #     self._nat_rule_type,
-        # )
 
     def _get_nat_rule_type(self) -> str:
         """Get the NAT rule type from the entity description.
@@ -861,7 +863,6 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             _LOGGER.debug("Skipping coordinator update for NAT switch %s due to delay", self.name)
             return
         rule = self._opnsense_get_rule()
-        # _LOGGER.debug("[OPNsenseNATRuleSwitch handle_coordinator_update] fetched rule: %s", rule)
         if not rule:
             self._available = False
             self.async_write_ha_state()
@@ -927,15 +928,6 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             self._attr_extra_state_attributes[name] = rule.get(attr, None)
 
         self.async_write_ha_state()
-        # _LOGGER.debug(
-        #     "[OPNsenseNATRuleSwitch handle_coordinator_update] "
-        #     "Name: %s, available: %s, is_on: %s, "
-        #     "extra_state_attributes: %s",
-        #     self.name,
-        #     self.available,
-        #     self.is_on,
-        #     self.extra_state_attributes,
-        # )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -994,8 +986,6 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         )
         self._service: MutableMapping[str, Any] | None = None
         self._prop_name: str = self._opnsense_get_property_name()
-        # _LOGGER.debug(f"[OPNsenseServiceSwitch init] Name: {self.name}, prop_name:
-        # {self._prop_name}")
 
     def _opnsense_get_property_name(self) -> str:
         """Get the property name from the entity description.
@@ -1050,9 +1040,6 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         for attr in ("id", "name"):
             self._attr_extra_state_attributes[f"service_{attr}"] = self._service.get(attr, None)
         self.async_write_ha_state()
-        # _LOGGER.debug(f"[OPNsenseServiceSwitch handle_coordinator_update] Name:
-        # {self.name}, available: {self.available}, is_on: {self.is_on},
-        # extra_state_attributes: {self.extra_state_attributes}")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -1124,9 +1111,6 @@ class OPNsenseUnboundBlocklistSwitchLegacy(OPNsenseSwitch):
             "Return NXDOMAIN": bool(dnsbl.get("nxdomain", "0") == "1"),
         }
         self.async_write_ha_state()
-        # _LOGGER.debug(f"[OPNsenseUnboundBlocklistSwitch handle_coordinator_update] Name:
-        # {self.name}, available: {self.available}, is_on: {self.is_on},
-        # extra_state_attributes: {self.extra_state_attributes}")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -1212,9 +1196,6 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
             "Return NXDOMAIN": bool(dnsbl.get("nxdomain", "0") == "1"),
         }
         self.async_write_ha_state()
-        # _LOGGER.debug(f"[OPNsenseUnboundBlocklistSwitch handle_coordinator_update] Name:
-        # {self.name}, available: {self.available}, is_on: {self.is_on},
-        # extra_state_attributes: {self.extra_state_attributes}")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -1267,7 +1248,6 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         self._vpn_type = self.entity_description.key.split(".")[0]
         self._clients_servers = self.entity_description.key.split(".")[1]
         self._uuid = self.entity_description.key.split(".")[2]
-        # _LOGGER.debug(f"[OPNsenseVPNSwitch init] Name: {self.name}")
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -1329,9 +1309,6 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             if instance.get(attr):
                 self._attr_extra_state_attributes[attr] = instance.get(attr)
         self.async_write_ha_state()
-        # _LOGGER.debug(f"[OPNsenseVPNSwitch handle_coordinator_update] Name: {self.name},
-        # available: {self.available}, is_on: {self.is_on}, extra_state_attributes:
-        # {self.extra_state_attributes}")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the VPN switch.

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -21,6 +21,31 @@ from .helpers import dict_get
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _build_firmware_update_entity_description() -> UpdateEntityDescription:
+    """Build the firmware update entity description."""
+    return UpdateEntityDescription(
+        key="firmware.update_available",
+        name="Firmware Updates Available",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=UpdateDeviceClass.FIRMWARE,
+        entity_registry_enabled_default=True,
+    )
+
+
+def _compile_firmware_update_entities(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+) -> list[OPNsenseFirmwareUpdatesAvailableUpdate]:
+    """Compile firmware update entities for the update platform."""
+    return [
+        OPNsenseFirmwareUpdatesAvailableUpdate(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=_build_firmware_update_entity_description(),
+        )
+    ]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -28,22 +53,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the OPNsense update entities."""
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
-    entities: list = []
+    entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
     config: Mapping[str, Any] = config_entry.data
 
     if config.get(CONF_SYNC_FIRMWARE_UPDATES, DEFAULT_SYNC_OPTION_VALUE):
-        entity = OPNsenseFirmwareUpdatesAvailableUpdate(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=UpdateEntityDescription(
-                key="firmware.update_available",
-                name="Firmware Updates Available",
-                entity_category=EntityCategory.DIAGNOSTIC,
-                device_class=UpdateDeviceClass.FIRMWARE,
-                entity_registry_enabled_default=True,
-            ),
-        )
-        entities.append(entity)
+        entities.extend(_compile_firmware_update_entities(config_entry, coordinator))
 
     async_add_entities(entities)
 
@@ -73,9 +87,6 @@ class OPNsenseUpdate(OPNsenseEntity, UpdateEntity):
         self.entity_description: UpdateEntityDescription = entity_description
         self._attr_supported_features |= (
             UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
-            # | UpdateEntityFeature.BACKUP
-            # | UpdateEntityFeature.PROGRESS
-            # | UpdateEntityFeature.SPECIFIC_VERSION
         )
         self._attr_title: str = "OPNsense"
         self._attr_in_progress: bool = False
@@ -104,14 +115,6 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         self._attr_latest_version = product_latest.replace("_", ".") if product_latest else None
 
         product_class = self._get_product_class(product_series)
-        # _LOGGER.debug(
-        #     "[Update handle_coordinator_update] product_version: %s, product_latest: %s, "
-        #     "product_series: %s, product_class: %s",
-        #     product_version,
-        #     product_latest,
-        #     product_series,
-        #     product_class,
-        # )
 
         if product_series and product_latest and product_class:
             self._attr_release_url = f"https://github.com/opnsense/changelog/blob/master/{product_class}/{product_series}/{product_latest.split('+')[0].split('_')[0]}"
@@ -120,10 +123,6 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
                 self.config_entry.data.get("url", None) + "/ui/core/firmware#changelog"
             )
 
-        # _LOGGER.debug(
-        #     "[Update handle_coordinator_update] release_url: %s",
-        #     self._attr_release_url
-        # )
         self._release_notes = self._get_release_notes(state, product_latest, product_version)
         self._attr_release_summary = dict_get(state, "firmware_update_info.status_msg")
 

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -33,6 +33,25 @@ def _build_firmware_update_entity_description() -> UpdateEntityDescription:
     )
 
 
+def _mapping_or_empty(value: Any) -> Mapping[str, Any]:
+    """Return a mapping value or an empty mapping."""
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list_or_empty(value: Any) -> list[Any]:
+    """Return a list value or an empty list."""
+    return value if isinstance(value, list) else []
+
+
+def _affected_package_count(value: Any) -> int:
+    """Return the count of affected firmware packages."""
+    if isinstance(value, Mapping):
+        return len(value)
+    if isinstance(value, list):
+        return len(value)
+    return 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -144,64 +163,67 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         Returns:
             bool: True if update available; otherwise, False.
         """
-        try:
-            return state["firmware_update_info"]["status"] != "error"
-        except TypeError, KeyError, AttributeError:
+        if not isinstance(state, Mapping):
             return False
+        firmware_update_info = state.get("firmware_update_info")
+        if not isinstance(firmware_update_info, Mapping):
+            return False
+        return firmware_update_info.get("status") != "error"
 
     def _get_installed_version(self, state: MutableMapping[str, Any]) -> str | None:
         """Return installed version."""
-        try:
-            return dict_get(state, "firmware_update_info.product.product_version")
-        except TypeError, KeyError, AttributeError:
-            return None
+        product_version = dict_get(state, "firmware_update_info.product.product_version")
+        return product_version if isinstance(product_version, str) else None
 
     def _get_versions(
         self, state: MutableMapping[str, Any]
     ) -> tuple[str | None, str | None, str | None]:
         """Return versions."""
-        try:
-            product_version = dict_get(state, "firmware_update_info.product.product_version")
-            product_latest = dict_get(state, "firmware_update_info.product.product_latest")
-            product_series = dict_get(state, "firmware_update_info.product.product_series")
-            if product_version is None or product_latest is None:
-                return product_version, None, product_series
+        product_version = dict_get(state, "firmware_update_info.product.product_version")
+        product_latest = dict_get(state, "firmware_update_info.product.product_latest")
+        product_series = dict_get(state, "firmware_update_info.product.product_series")
+        product_version = product_version if isinstance(product_version, str) else None
+        product_latest = product_latest if isinstance(product_latest, str) else None
+        product_series = product_series if isinstance(product_series, str) else None
+        if product_version is None or product_latest is None:
+            return product_version, None, product_series
 
-            status = dict_get(state, "firmware_update_info.status")
-            if status == "update":
-                packages = dict_get(
-                    state, "firmware_update_info.product.product_check.upgrade_packages"
+        status = dict_get(state, "firmware_update_info.status")
+        if status == "update":
+            packages = _list_or_empty(
+                dict_get(state, "firmware_update_info.product.product_check.upgrade_packages")
+            )
+            if product_version == product_latest:
+                package_found: bool = False
+                for package in packages:
+                    if not isinstance(package, Mapping):
+                        continue
+                    new_version = package.get("new_version")
+                    if package.get("name") == "opnsense" and isinstance(new_version, str):
+                        package_found = True
+                        product_latest = new_version
+                        break
+                if not package_found:
+                    product_latest = f"{product_latest}+"
+            else:
+                for package in packages:
+                    if not isinstance(package, Mapping):
+                        continue
+                    new_version = package.get("new_version")
+                    if package.get("name") == "opnsense" and isinstance(new_version, str):
+                        product_latest = new_version
+                        break
+
+        if status == "upgrade":
+            upgrade_major_version = dict_get(state, "firmware_update_info.upgrade_major_version")
+            if isinstance(upgrade_major_version, str) and upgrade_major_version:
+                product_latest = upgrade_major_version
+                product_series = (
+                    ".".join(product_latest.split(".")[:2])
+                    if "." in product_latest
+                    else product_latest
                 )
-                if product_version == product_latest:
-                    if isinstance(packages, list):
-                        package_found: bool = False
-                        for package in packages:
-                            if package.get("name") == "opnsense" and package.get("new_version"):
-                                package_found = True
-                                product_latest = package.get("new_version")
-                                break
-                        if not package_found:
-                            product_latest = f"{product_latest}+"
-                    else:
-                        product_latest = f"{product_latest}+"
-                elif isinstance(packages, list):
-                    for package in packages:
-                        if package.get("name") == "opnsense" and package.get("new_version"):
-                            product_latest = package.get("new_version")
-                            break
-
-            if status == "upgrade":
-                product_latest = dict_get(state, "firmware_update_info.upgrade_major_version")
-                if product_latest:
-                    product_series = (
-                        ".".join(product_latest.split(".")[:2])
-                        if "." in product_latest
-                        else product_latest
-                    )
-        except TypeError, KeyError, AttributeError:
-            return None, None, None
-        else:
-            return product_version, product_latest, product_series
+        return product_version, product_latest, product_series
 
     def _get_product_class(self, product_series: str | None) -> str | None:
         """Return product class."""
@@ -223,36 +245,29 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         product_version: str | None,
     ) -> str | None:
         """Return release notes."""
-        try:
-            status = dict_get(state, "firmware_update_info.status")
-            if status == "update":
-                product_name = dict_get(state, "firmware_update_info.product.product_name")
-                product_nickname = dict_get(state, "firmware_update_info.product.product_nickname")
-                status_msg = dict_get(state, "firmware_update_info.status_msg")
+        firmware_update_info = state.get("firmware_update_info")
+        if not isinstance(firmware_update_info, Mapping):
+            return None
 
-                needs_reboot: bool = (
-                    dict_get(state, "firmware_update_info.needs_reboot") == "1"
-                    if dict_get(state, "firmware_update_info.needs_reboot")
-                    else False
-                )
+        status = firmware_update_info.get("status")
+        status_msg = firmware_update_info.get("status_msg")
+        if status == "update":
+            product = _mapping_or_empty(firmware_update_info.get("product"))
+            product_name = product.get("product_name")
+            product_nickname = product.get("product_nickname")
+            needs_reboot = firmware_update_info.get("needs_reboot") == "1"
 
-                total_package_count: int = len(
-                    (dict_get(state, "firmware_update_info.all_packages", {}) or {}).keys()
-                )
-                new_package_count: int = len(
-                    dict_get(state, "firmware_update_info.new_packages", []) or []
-                )
-                reinstall_package_count: int = len(
-                    dict_get(state, "firmware_update_info.reinstall_packages", []) or []
-                )
-                remove_package_count: int = len(
-                    dict_get(state, "firmware_update_info.remove_packages", []) or []
-                )
-                upgrade_package_count: int = len(
-                    dict_get(state, "firmware_update_info.upgrade_packages", []) or []
-                )
+            total_package_count = _affected_package_count(firmware_update_info.get("all_packages"))
+            new_package_count = len(_list_or_empty(firmware_update_info.get("new_packages")))
+            reinstall_package_count = len(
+                _list_or_empty(firmware_update_info.get("reinstall_packages"))
+            )
+            remove_package_count = len(_list_or_empty(firmware_update_info.get("remove_packages")))
+            upgrade_package_count = len(
+                _list_or_empty(firmware_update_info.get("upgrade_packages"))
+            )
 
-                return f"""
+            return f"""
 ## {product_name} version {product_latest} ({product_nickname})
 
 {status_msg}
@@ -264,36 +279,19 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
 - removed packages: {remove_package_count}
 - upgraded packages: {upgrade_package_count}
 """
-            if status == "upgrade":
-                product_name = dict_get(state, "firmware_update_info.product.product_name")
-                status_msg = dict_get(state, "firmware_update_info.status_msg")
+        if status == "upgrade":
+            product = _mapping_or_empty(firmware_update_info.get("product"))
+            product_name = product.get("product_name")
+            upgrade_needs_reboot = firmware_update_info.get("upgrade_needs_reboot") == "1"
 
-                upgrade_needs_reboot: bool = (
-                    dict_get(state, "firmware_update_info.upgrade_needs_reboot") == "1"
-                    if dict_get(state, "firmware_update_info.upgrade_needs_reboot")
-                    else False
-                )
-
-                return f"""
+            return f"""
 ## {product_name} version {product_version}
 
 {status_msg}
 
 - reboot needed: {upgrade_needs_reboot}
 """
-            return dict_get(state, "firmware_update_info.status_msg")
-        except (TypeError, KeyError, AttributeError) as e:
-            _LOGGER.error(
-                "Error getting release notes. %s: %s",
-                type(e).__name__,
-                e,
-            )
-            return (
-                "Release notes unavailable due to an error. "
-                "Check the Read release announcement link above or see the OPNsense web interface "
-                "for details. "
-                f"{type(e).__name__}: {e}"
-            )
+        return status_msg if isinstance(status_msg, str) else None
 
     async def async_release_notes(self) -> str | None:
         """Return the release notes of the latest version."""

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -23,7 +23,11 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 def _build_firmware_update_entity_description() -> UpdateEntityDescription:
-    """Build the firmware update entity description."""
+    """Build the firmware update entity description.
+
+    Returns:
+        An update entity description for firmware availability.
+    """
     return UpdateEntityDescription(
         key="firmware.update_available",
         name="Firmware Updates Available",
@@ -34,17 +38,38 @@ def _build_firmware_update_entity_description() -> UpdateEntityDescription:
 
 
 def _mapping_or_empty(value: Any) -> Mapping[str, Any]:
-    """Return a mapping value or an empty mapping."""
+    """Return a mapping value or an empty mapping.
+
+    Args:
+        value: Candidate mapping value.
+
+    Returns:
+        The mapping when provided, otherwise an empty dict.
+    """
     return value if isinstance(value, Mapping) else {}
 
 
 def _list_or_empty(value: Any) -> list[Any]:
-    """Return a list value or an empty list."""
+    """Return a list value or an empty list.
+
+    Args:
+        value: Candidate list value.
+
+    Returns:
+        The list when provided, otherwise an empty list.
+    """
     return value if isinstance(value, list) else []
 
 
 def _affected_package_count(value: Any) -> int:
-    """Return the count of affected firmware packages."""
+    """Return the count of affected firmware packages.
+
+    Args:
+        value: Candidate package collection from firmware status data.
+
+    Returns:
+        The number of packages represented by ``value``.
+    """
     if isinstance(value, Mapping):
         return len(value)
     if isinstance(value, list):
@@ -57,7 +82,13 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the OPNsense update entities."""
+    """Set up the OPNsense update entities.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Config entry being set up.
+        async_add_entities: Callback used to register new entities.
+    """
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
     config: Mapping[str, Any] = config_entry.data
@@ -83,7 +114,13 @@ class OPNsenseUpdate(OPNsenseEntity, UpdateEntity):
         coordinator: OPNsenseDataUpdateCoordinator,
         entity_description: UpdateEntityDescription,
     ) -> None:
-        """Initialize update entity."""
+        """Initialize update entity.
+
+        Args:
+            config_entry: Config entry owning the entity.
+            coordinator: Shared OPNsense data coordinator.
+            entity_description: Description that defines the entity identity.
+        """
         name_suffix: str | None = (
             entity_description.name if isinstance(entity_description.name, str) else None
         )
@@ -158,10 +195,13 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         self.async_write_ha_state()
 
     def _is_update_available(self, state: MutableMapping[str, Any]) -> bool:
-        """Return whether update available.
+        """Return whether an update is available.
+
+        Args:
+            state: Current OPNsense state payload.
 
         Returns:
-            bool: True if update available; otherwise, False.
+            ``True`` when firmware update data reports an actionable status.
         """
         if not isinstance(state, Mapping):
             return False
@@ -172,14 +212,28 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         return isinstance(status, str) and status not in {"", "error"}
 
     def _get_installed_version(self, state: MutableMapping[str, Any]) -> str | None:
-        """Return installed version."""
+        """Return the installed firmware version.
+
+        Args:
+            state: Current OPNsense state payload.
+
+        Returns:
+            The installed firmware version, or ``None`` when unavailable.
+        """
         product_version = dict_get(state, "firmware_update_info.product.product_version")
         return product_version if isinstance(product_version, str) else None
 
     def _get_versions(
         self, state: MutableMapping[str, Any]
     ) -> tuple[str | None, str | None, str | None]:
-        """Return versions."""
+        """Return installed, latest, and series versions.
+
+        Args:
+            state: Current OPNsense state payload.
+
+        Returns:
+            A tuple of installed version, latest version, and series version.
+        """
         product_version = dict_get(state, "firmware_update_info.product.product_version")
         product_latest = dict_get(state, "firmware_update_info.product.product_latest")
         product_series = dict_get(state, "firmware_update_info.product.product_series")
@@ -227,7 +281,14 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         return product_version, product_latest, product_series
 
     def _get_product_class(self, product_series: str | None) -> str | None:
-        """Return product class."""
+        """Return product class.
+
+        Args:
+            product_series: Firmware product series string.
+
+        Returns:
+            The OPNsense product class, or ``None`` when the series is unknown.
+        """
         if product_series:
             try:
                 series_minor: str | None = str(product_series).split(".")[1]
@@ -245,7 +306,16 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         product_latest: str | None,
         product_version: str | None,
     ) -> str | None:
-        """Return release notes."""
+        """Return firmware release notes.
+
+        Args:
+            state: Current OPNsense state payload.
+            product_latest: Latest available firmware version.
+            product_version: Installed firmware version.
+
+        Returns:
+            A formatted release-notes summary, status message, or ``None``.
+        """
         firmware_update_info = state.get("firmware_update_info")
         if not isinstance(firmware_update_info, Mapping):
             return None
@@ -295,13 +365,23 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         return status_msg if isinstance(status_msg, str) else None
 
     async def async_release_notes(self) -> str | None:
-        """Return the release notes of the latest version."""
+        """Return the release notes of the latest version.
+
+        Returns:
+            Cached release notes for the currently available update.
+        """
         return self._release_notes
 
     async def async_install(
         self, version: str | None = None, backup: bool = False, **kwargs: Any
     ) -> None:
-        """Install an update."""
+        """Install the available firmware update.
+
+        Args:
+            version: Requested firmware version, if provided by Home Assistant.
+            backup: Whether Home Assistant requested a backup before install.
+            **kwargs: Additional keyword arguments from Home Assistant.
+        """
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             _LOGGER.error("Cannot update firmware, state data is missing")

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -168,7 +168,8 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         firmware_update_info = state.get("firmware_update_info")
         if not isinstance(firmware_update_info, Mapping):
             return False
-        return firmware_update_info.get("status") != "error"
+        status = firmware_update_info.get("status")
+        return isinstance(status, str) and status not in {"", "error"}
 
     def _get_installed_version(self, state: MutableMapping[str, Any]) -> str | None:
         """Return installed version."""

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -32,20 +32,6 @@ def _build_firmware_update_entity_description() -> UpdateEntityDescription:
     )
 
 
-def _compile_firmware_update_entities(
-    config_entry: ConfigEntry,
-    coordinator: OPNsenseDataUpdateCoordinator,
-) -> list[OPNsenseFirmwareUpdatesAvailableUpdate]:
-    """Compile firmware update entities for the update platform."""
-    return [
-        OPNsenseFirmwareUpdatesAvailableUpdate(
-            config_entry=config_entry,
-            coordinator=coordinator,
-            entity_description=_build_firmware_update_entity_description(),
-        )
-    ]
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -57,7 +43,13 @@ async def async_setup_entry(
     config: Mapping[str, Any] = config_entry.data
 
     if config.get(CONF_SYNC_FIRMWARE_UPDATES, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(_compile_firmware_update_entities(config_entry, coordinator))
+        entities.append(
+            OPNsenseFirmwareUpdatesAvailableUpdate(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=_build_firmware_update_entity_description(),
+            )
+        )
 
     async_add_entities(entities)
 

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -5,8 +5,6 @@ from collections.abc import Mapping, MutableMapping
 import logging
 from typing import Any
 
-from aiohttp import ClientError
-from aiopnsense.exceptions import OPNsenseError
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity, UpdateEntityDescription
 from homeassistant.components.update.const import UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -407,14 +405,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
                 _LOGGER.debug("[async_install] upgrade_status: %s", response)
                 # after finished status is "done"
                 running = response["status"] == "running"
-            except (
-                OPNsenseError,
-                TimeoutError,
-                KeyError,
-                TypeError,
-                ClientError,
-                OSError,
-            ) as e:
+            except (KeyError, TypeError) as e:
                 exceptions += 1
                 _LOGGER.warning(
                     "Error #%s while getting upgrade_status. %s: %s",

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -76,6 +76,24 @@ def _affected_package_count(value: Any) -> int:
     return 0
 
 
+def _opnsense_package_version(packages: list[Any]) -> str | None:
+    """Return the OPNsense package version from firmware package rows.
+
+    Args:
+        packages: Firmware package rows from OPNsense.
+
+    Returns:
+        The OPNsense package version, or ``None`` when unavailable.
+    """
+    for package in packages:
+        if not isinstance(package, Mapping):
+            continue
+        new_version = package.get("new_version")
+        if package.get("name") == "opnsense" and isinstance(new_version, str):
+            return new_version
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -247,26 +265,11 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
             packages = _list_or_empty(
                 dict_get(state, "firmware_update_info.product.product_check.upgrade_packages")
             )
-            if product_version == product_latest:
-                package_found: bool = False
-                for package in packages:
-                    if not isinstance(package, Mapping):
-                        continue
-                    new_version = package.get("new_version")
-                    if package.get("name") == "opnsense" and isinstance(new_version, str):
-                        package_found = True
-                        product_latest = new_version
-                        break
-                if not package_found:
-                    product_latest = f"{product_latest}+"
-            else:
-                for package in packages:
-                    if not isinstance(package, Mapping):
-                        continue
-                    new_version = package.get("new_version")
-                    if package.get("name") == "opnsense" and isinstance(new_version, str):
-                        product_latest = new_version
-                        break
+            package_version = _opnsense_package_version(packages)
+            if package_version is not None:
+                product_latest = package_version
+            elif product_version == product_latest:
+                product_latest = f"{product_latest}+"
 
         if status == "upgrade":
             upgrade_major_version = dict_get(state, "firmware_update_info.upgrade_major_version")

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, MutableMapping
 import logging
 from typing import Any
 
+from aiohttp import ClientError
 from aiopnsense.exceptions import OPNsenseError
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity, UpdateEntityDescription
 from homeassistant.components.update.const import UpdateEntityFeature
@@ -356,7 +357,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
             upgrade_needs_reboot = firmware_update_info.get("upgrade_needs_reboot") == "1"
 
             return f"""
-## {product_name} version {product_version}
+## {product_name} version {product_latest or product_version}
 
 {status_msg}
 
@@ -406,7 +407,14 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
                 _LOGGER.debug("[async_install] upgrade_status: %s", response)
                 # after finished status is "done"
                 running = response["status"] == "running"
-            except (OPNsenseError, TimeoutError, KeyError, TypeError) as e:
+            except (
+                OPNsenseError,
+                TimeoutError,
+                KeyError,
+                TypeError,
+                ClientError,
+                OSError,
+            ) as e:
                 exceptions += 1
                 _LOGGER.warning(
                     "Error #%s while getting upgrade_status. %s: %s",

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -89,7 +89,7 @@ def _opnsense_package_version(packages: list[Any]) -> str | None:
         if not isinstance(package, Mapping):
             continue
         new_version = package.get("new_version")
-        if package.get("name") == "opnsense" and isinstance(new_version, str):
+        if package.get("name") == "opnsense" and isinstance(new_version, str) and new_version != "":
             return new_version
     return None
 

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, MutableMapping
 import logging
 from typing import Any
 
+from aiopnsense.exceptions import OPNsenseError
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntity, UpdateEntityDescription
 from homeassistant.components.update.const import UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -326,7 +327,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
                 _LOGGER.debug("[async_install] upgrade_status: %s", response)
                 # after finished status is "done"
                 running = response["status"] == "running"
-            except Exception as e:  # noqa: BLE001
+            except (OPNsenseError, TimeoutError, KeyError, TypeError) as e:
                 exceptions += 1
                 _LOGGER.warning(
                     "Error #%s while getting upgrade_status. %s: %s",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,16 +8,12 @@ background tasks, and simplify Home Assistant testing.
 import asyncio
 from collections.abc import AsyncIterator
 import contextlib
-import inspect
-import logging
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
-import homeassistant.core as ha_core
 from homeassistant.core import HomeAssistant
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from pytest_homeassistant_custom_component.plugins import get_scheduled_timer_handles
 
 import custom_components.opnsense as _init_mod
 from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID
@@ -191,41 +187,6 @@ def fake_stream_response_factory() -> Any:
         return _Resp()
 
     return _make
-
-
-# Module logger for test diagnostics
-logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(autouse=True)
-def _patch_homeassistant_stop(monkeypatch: pytest.MonkeyPatch) -> Any:
-    """Wrap HomeAssistant.stop to ignore 'Event loop is closed' runtime errors. Some tests or integrations can close the event loop unexpectedly. During test teardown the pytest-homeassistant-custom-component plugin attempts to stop HomeAssistant instances which may call into a closed loop; this wrapper silently swallows that specific RuntimeError to allow teardown to continue in a best-effort manner."""
-    original_stop = getattr(ha_core.HomeAssistant, "stop", None)
-
-    if original_stop is None:
-        return
-
-    def _safe_stop(self: Any, *args, **kwargs) -> Any:
-        """Safe stop.
-
-        Args:
-            self: Home Assistant instance being stopped.
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        try:
-            return original_stop(self, *args, **kwargs)
-        except RuntimeError as err:
-            if "Event loop is closed" in str(err):
-                # Log for diagnostics then swallow this specific error during tests.
-                logger.exception(
-                    "HomeAssistant.stop suppressed during test teardown: Event loop is closed",
-                    exc_info=err,
-                )
-                return None
-            raise
-
-    monkeypatch.setattr(ha_core.HomeAssistant, "stop", _safe_stop, raising=False)
 
 
 @pytest.fixture
@@ -580,8 +541,8 @@ def make_config_entry() -> Any:
 
 
 @pytest.fixture
-def ph_hass(request: Any, hass: HomeAssistant | None = None) -> Any:
-    """Safe hass-like fixture: prefer real PHCC `hass` when available. Prefer the pytest-injected `hass` fixture when the pytest-homeassistant- custom-component plugin is present. To support environments where the plugin is absent (or where fixture injection order yields an async generator), fall back to using `request.getfixturevalue("hass")` only as a last resort; if that still isn't available, return a MagicMock that provides the minimal attributes tests expect."""
+def ph_hass(hass: HomeAssistant) -> HomeAssistant:
+    """Return the PHCC Home Assistant fixture with task creation observable by tests."""
 
     # Helper used to schedule coroutines on the running loop when possible.
     def _schedule_or_return(coro: Any) -> Any:
@@ -598,141 +559,11 @@ def ph_hass(request: Any, hass: HomeAssistant | None = None) -> Any:
             # back to returning the coroutine so callers can decide.
             return coro
 
-    # helper _ensure_async_create_task_mock moved to module top-level
-
-    # If pytest injected a `hass` fixture, prefer it (but avoid advancing
-    # async-generator fixtures here). This lets pytest supply the real
-    # PHCC hass instance when available without calling getfixturevalue.
-    real = hass
-    if real is not None:
-        # If the injected fixture is an async-generator object, we must not
-        # advance it here because its lifecycle is managed by the plugin
-        # (treat as unavailable and fall back below).
-        if inspect.isasyncgen(real):
-            real = None
-        else:
-            # Reuse helper to ensure async_create_task is a MagicMock so tests
-            # can assert `.called` etc.
-            _ensure_async_create_task_mock(real, _schedule_or_return)
-            return real
-
-    # No injected hass or injected hass unusable; try the legacy fallback
-    # of requesting the fixture by name. Only call getfixturevalue as a
-    # safety net when injection did not occur.
-    try:
-        real = request.getfixturevalue("hass")
-        if inspect.isasyncgen(real):
-            real = None
-        if real is not None:
-            # Mirror the same robust assignment logic for the plugin-provided
-            # hass fixture path using the helper.
-            _ensure_async_create_task_mock(real, _schedule_or_return)
-            return real
-    except pytest.FixtureLookupError:
-        # No PHCC hass available; will return MagicMock fallback below.
-        pass
-
-    # No real hass fixture available; return a MagicMock fallback.
-    m = MagicMock()
-    m.config_entries = MagicMock()
-    m.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    m.config_entries.async_reload = AsyncMock(return_value=None)
-    m.data = {}
-    # Mirror HomeAssistant API used by the integration/tests.
-    m.async_create_task = MagicMock(side_effect=_schedule_or_return)
-    # provide a loop wrapper that cancels scheduled timer handles immediately
-    # so the pytest-homeassistant-custom-component plugin does not report
-    # lingering timers during test teardown.
-    try:
-        real_loop = asyncio.get_running_loop()
-    except RuntimeError:
-        real_loop = asyncio.new_event_loop()
-
-    class FakeLoop:
-        def __init__(self, loop: Any) -> None:
-            """Initialize FakeLoop.
-
-            Args:
-                loop: Loop provided by pytest or the test case.
-            """
-            self._loop = loop
-
-        def call_later(self, delay: Any, callback: Any, *args) -> Any:
-            """Call later.
-
-            Args:
-                delay: Delay provided by pytest or the test case.
-                callback: Callback provided by pytest or the test case.
-                *args: Additional positional arguments forwarded by the function.
-            """
-            handle = self._loop.call_later(delay, callback, *args)
-            with contextlib.suppress(Exception):
-                handle.cancel()
-            return handle
-
-        def __getattr__(self, name: str) -> Any:
-            """Getattr.
-
-            Args:
-                name: Name provided by pytest or the test case.
-            """
-            return getattr(self._loop, name)
-
-    m.loop = FakeLoop(real_loop)
-    return m
+    _ensure_async_create_task_mock(hass, _schedule_or_return)
+    return hass
 
 
 @pytest.fixture
 def expected_lingering_timers() -> bool:
-    """Tell the PHCC verify_cleanup fixture to allow lingering timers. Tests in this suite intentionally create short-lived timers; during the incremental migration we accept plugin warnings instead of hard failures."""
+    """Allow switch delay timers that tests intentionally leave scheduled."""
     return True
-
-
-def pytest_runtest_teardown(item: Any, nextitem: Any) -> None:
-    """Pytest hook: cancel any scheduled timer handles after each test. Prevent the pytest-homeassistant-custom-component plugin from failing tests due to lingering timer handles created by the integration (for example via hass.loop.call_later / async_call_later)."""
-    try:
-        # Prefer the running loop when called from a running async context.
-        event_loop = asyncio.get_running_loop()
-    except RuntimeError:
-        # No running loop; create a new event loop as a safe fallback.
-        # This avoids using the deprecated `get_event_loop` path and mirrors
-        # the recommended pattern for synchronous code needing a loop.
-        event_loop = asyncio.new_event_loop()
-    # If some integration code created and closed the global loop, we may
-    # need to replace it with a fresh loop to allow the PHCC plugin to
-    # perform teardown. However, this repository opts in to that behavior
-    # via the `expected_lingering_timers` fixture. Only perform loop
-    # replacement when the current test requested it; otherwise skip the
-    # surgery but still attempt to cancel any scheduled timer handles in a
-    # best-effort manner.
-    if getattr(event_loop, "is_closed", lambda: False)():
-        replace_loop = False
-        try:
-            # Prefer the fixture value for the current test if present.
-            replace_loop = bool(item.funcargs.get("expected_lingering_timers", False))
-        except AttributeError, KeyError:
-            replace_loop = False
-
-        if replace_loop:
-            try:
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                event_loop = new_loop
-            except OSError, RuntimeError:
-                # Best-effort: if we cannot recreate the loop, continue and
-                # let teardown attempt to proceed (it may still error).
-                pass
-
-    # Collect scheduled timer handles from the (possibly replaced) loop;
-    # if the loop is closed and handle collection fails, skip cancellation
-    # gracefully.
-    try:
-        handles = get_scheduled_timer_handles(event_loop)
-    except RuntimeError, OSError:
-        handles = []
-
-    for handle in handles:
-        # Best-effort cancellation; don't raise from teardown hook.
-        with contextlib.suppress(Exception):
-            if not handle.cancelled():
-                handle.cancel()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -20,6 +20,9 @@ from custom_components.opnsense.binary_sensor import (
     OPNsenseInterfaceEnabledBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
     OPNsenseSmartStatusBinarySensor,
+    _build_interface_enabled_binary_sensor_description,
+    _build_pending_notices_present_binary_sensor_description,
+    _build_smart_status_binary_sensor_description,
     _compile_interface_enabled_binary_sensors,
     _compile_smart_status_binary_sensors,
     async_setup_entry,
@@ -33,6 +36,33 @@ from custom_components.opnsense.const import (
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from tests.utilities import stub_async_write_ha_state
+
+
+def test_binary_sensor_description_builders_preserve_entity_contract() -> None:
+    """Binary sensor description builders should preserve generated entity metadata."""
+    interface_description = _build_interface_enabled_binary_sensor_description(
+        "wan", {"name": "WAN"}
+    )
+    smart_description = _build_smart_status_binary_sensor_description("nvme0")
+    notices_description = _build_pending_notices_present_binary_sensor_description()
+
+    assert interface_description.key == "interface.wan.enabled"
+    assert interface_description.name == "Interface WAN Enabled"
+    assert interface_description.icon == "mdi:network"
+    assert interface_description.device_class is None
+    assert interface_description.entity_registry_enabled_default is False
+
+    assert smart_description.key == "smart.nvme0.status"
+    assert smart_description.name == "SMART nvme0 Status"
+    assert smart_description.icon == "mdi:harddisk"
+    assert smart_description.device_class is BinarySensorDeviceClass.PROBLEM
+    assert smart_description.entity_registry_enabled_default is False
+
+    assert notices_description.key == "notices.pending_notices_present"
+    assert notices_description.name == "Pending Notices Present"
+    assert notices_description.icon == "mdi:alert"
+    assert notices_description.device_class is BinarySensorDeviceClass.PROBLEM
+    assert notices_description.entity_registry_enabled_default is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1089,9 +1089,8 @@ async def test_build_categories_keeps_firewall_polling_for_legacy_firmware(
 
     assert "firewall" in keys
     assert "get_firewall" in functions
-    removed_backend = "plug" + "in"
-    assert f"is_{removed_backend}_installed" not in functions
-    assert f"is_{removed_backend}_deprecated" not in functions
+    assert "is_plugin_installed" not in functions
+    assert "is_plugin_deprecated" not in functions
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.opnsense.device_tracker import OPNsenseScannerEntity
+
 # import the module under test and package constants
 dt_mod = importlib.import_module("custom_components.opnsense.device_tracker")
 pkg = importlib.import_module("custom_components.opnsense")
@@ -23,8 +25,8 @@ def _make_scanner_entity(
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
     *,
-    coordinator_data: Any | None = None,
-) -> Any:
+    coordinator_data: object | None = None,
+) -> OPNsenseScannerEntity:
     """Create a scanner entity with coordinator runtime data wired in.
 
     Args:
@@ -279,6 +281,30 @@ def test_handle_coordinator_update_entry_present(
     assert ent.extra_state_attributes.get("interface") == "lan0"
     assert ent.extra_state_attributes.get("type") == "arp"
     assert ent.icon == "mdi:lan-connect"
+    assert ent.source_type == dt_mod.SourceType.ROUTER
+
+
+def test_device_data_from_arp_entry_normalizes_hostname_and_filters_manufacturer() -> None:
+    """ARP setup data should normalize hostnames and ignore non-string manufacturer."""
+    device = dt_mod._device_data_from_arp_entry(
+        "aa:bb:cc", {"hostname": "host?", "manufacturer": ""}
+    )
+    assert device == {"mac": "aa:bb:cc", "hostname": "host"}
+
+    device = dt_mod._device_data_from_arp_entry(
+        "dd:ee:ff", {"hostname": "host", "manufacturer": None}
+    )
+    assert device == {"mac": "dd:ee:ff", "hostname": "host"}
+
+
+def test_device_from_arp_entry_matches_mac_case_insensitively_and_rejects_non_string_macs() -> None:
+    """Device lookup should match MAC addresses case-insensitively and skip bad MAC types."""
+    device = dt_mod._device_from_arp_entry(
+        "aa:bb:cc",
+        [{"mac": 12345}, {"mac": "AA:BB:CC", "hostname": "TrackedHost", "manufacturer": "m"}],
+    )
+
+    assert device == {"mac": "aa:bb:cc", "hostname": "TrackedHost", "manufacturer": "m"}
 
 
 def test_handle_coordinator_update_skips_malformed_arp_entries(
@@ -296,6 +322,47 @@ def test_handle_coordinator_update_skips_malformed_arp_entries(
 
     assert ent.is_connected is False
     assert ent.available is True
+
+
+def test_handle_coordinator_update_matches_mac_case_insensitively(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Coordinator matching should include uppercase/lowercase MAC variations."""
+    coordinator.data = {
+        "arp_table": [{"mac": "AA:BB:CC", "ip": "1.2.3.4", "intf_description": "lan"}],
+        "update_time": 0,
+    }
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data=coordinator.data,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.ip_address == "1.2.3.4"
+    attrs = ent.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("interface") == "lan"
+    assert ent.available is True
+
+
+def test_update_arp_extra_state_attributes_clears_stale_values() -> None:
+    """Stale ARP extra state attributes are removed when absent in current entry."""
+    attributes: dict[str, Any] = {
+        "interface": "old",
+        "expires": "Never",
+        "type": "old",
+        "last_known_ip": "9.9.9.9",
+    }
+
+    dt_mod._update_arp_extra_state_attributes(attributes, {})
+
+    assert "interface" not in attributes
+    assert "expires" not in attributes
+    assert "type" not in attributes
+    assert attributes == {"last_known_ip": "9.9.9.9"}
 
 
 def test_handle_coordinator_update_missing_entry_consider_home(
@@ -324,6 +391,20 @@ def test_handle_coordinator_update_missing_entry_consider_home(
     ent._handle_coordinator_update()
     # elapsed < consider_home so device considered connected
     assert ent.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_returns_when_no_snapshot(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Restoring state should return when Home Assistant has no saved snapshot."""
+    ent = _make_scanner_entity(coordinator, make_config_entry)
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=None))
+
+    await ent._restore_last_state()
+
+    assert ent.extra_state_attributes == {}
 
 
 @pytest.mark.asyncio
@@ -360,7 +441,7 @@ async def test_restore_last_state_and_device_info(
             "last_known_connected_time": last_known_connected_time.isoformat(),
         },
     )
-    ent.async_get_last_state = AsyncMock(return_value=last_state)
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()
     # restored attributes should be present
@@ -403,7 +484,7 @@ async def test_restore_last_state_uses_datetime_and_skips_empty_attributes(
         "type": "",
         "last_known_connected_time": last_known_connected_time,
     }
-    ent.async_get_last_state = AsyncMock(return_value=last_state)
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()
 
@@ -420,12 +501,14 @@ async def test_restore_last_state_ignores_unparseable_connected_time(
     ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = {"last_known_connected_time": "not-a-date"}
-    ent.async_get_last_state = AsyncMock(return_value=last_state)
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()
 
     assert ent._last_known_connected_time is None
-    assert "last_known_connected_time" not in ent.extra_state_attributes
+    attrs = ent.extra_state_attributes
+    assert attrs is not None
+    assert "last_known_connected_time" not in attrs
 
 
 @pytest.mark.asyncio
@@ -437,7 +520,7 @@ async def test_restore_last_state_ignores_non_mapping_attributes(
     ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = ["not", "a", "mapping"]
-    ent.async_get_last_state = AsyncMock(return_value=last_state)
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -19,6 +19,35 @@ dt_mod = importlib.import_module("custom_components.opnsense.device_tracker")
 pkg = importlib.import_module("custom_components.opnsense")
 
 
+def _make_scanner_entity(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    *,
+    coordinator_data: Any | None = None,
+) -> Any:
+    """Create a scanner entity with coordinator runtime data wired in.
+
+    Args:
+        coordinator: Device tracker coordinator used by the entity.
+        make_config_entry: Fixture that creates a mock config entry.
+        coordinator_data: Optional coordinator data to install before creating the entity.
+
+    Returns:
+        A scanner entity for the standard tracked MAC used in these tests.
+    """
+    coordinator.data = {"arp_table": []} if coordinator_data is None else coordinator_data
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    return dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+
+
 def test_device_from_arp_entry_skips_malformed_and_nonmatching_entries() -> None:
     """Device lookup should ignore malformed and nonmatching ARP entries."""
     device = dt_mod._device_from_arp_entry(
@@ -256,17 +285,10 @@ def test_handle_coordinator_update_skips_malformed_arp_entries(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
     """Malformed ARP entries should be skipped while searching for the tracked MAC."""
-    coordinator.data = {"arp_table": [object()]}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=entry,
+    ent = _make_scanner_entity(
         coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
-        mac_vendor=None,
-        hostname=None,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": [object()]},
     )
     object.__setattr__(ent, "async_write_ha_state", MagicMock())
 
@@ -370,19 +392,8 @@ async def test_restore_last_state_uses_datetime_and_skips_empty_attributes(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Restoring state should preserve datetime values and ignore empty saved attributes."""
-    coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
     last_known_connected_time = datetime.now(UTC)
-
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=entry,
-        coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
-        mac_vendor=None,
-        hostname=None,
-    )
+    ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = {
         "last_known_hostname": None,
@@ -406,18 +417,7 @@ async def test_restore_last_state_ignores_unparseable_connected_time(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Restoring state should ignore invalid saved connection timestamps."""
-    coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=entry,
-        coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
-        mac_vendor=None,
-        hostname=None,
-    )
+    ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = {"last_known_connected_time": "not-a-date"}
     ent.async_get_last_state = AsyncMock(return_value=last_state)
@@ -434,18 +434,7 @@ async def test_restore_last_state_ignores_non_mapping_attributes(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Restoring state should ignore snapshots with malformed attributes."""
-    coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=entry,
-        coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
-        mac_vendor=None,
-        hostname=None,
-    )
+    ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = ["not", "a", "mapping"]
     ent.async_get_last_state = AsyncMock(return_value=last_state)

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -7,6 +7,7 @@ and device info formatting for the integration's device tracker entities.
 from collections.abc import Callable, Iterable, MutableMapping
 from datetime import UTC, datetime
 import importlib
+from types import MappingProxyType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -264,23 +265,27 @@ async def test_restore_last_state_and_device_info(
         hostname="dev",
     )
     ent._attr_extra_state_attributes = {}
+    last_known_connected_time = datetime.now(UTC)
 
     # fake last state with attributes including isoformat time
     last_state = MagicMock()
-    last_state.attributes = {
-        "last_known_hostname": "oldhost",
-        "last_known_ip": "9.9.9.9",
-        "interface": "lan0",
-        "expires": 10,
-        "type": "arp",
-        "last_known_connected_time": datetime.now(UTC).isoformat(),
-    }
+    last_state.attributes = MappingProxyType(
+        {
+            "last_known_hostname": "oldhost",
+            "last_known_ip": "9.9.9.9",
+            "interface": "lan0",
+            "expires": 10,
+            "type": "arp",
+            "last_known_connected_time": last_known_connected_time.isoformat(),
+        },
+    )
     ent.async_get_last_state = AsyncMock(return_value=last_state)
 
     await ent._restore_last_state()
     # restored attributes should be present
     assert ent._last_known_hostname == "oldhost"
     assert ent._last_known_ip == "9.9.9.9"
+    assert ent._last_known_connected_time == last_known_connected_time
     assert ent.extra_state_attributes.get("interface") == "lan0"
     assert "last_known_connected_time" in ent.extra_state_attributes
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -16,7 +16,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense.device_tracker import OPNsenseScannerEntity
 
-# import the module under test and package constants
 dt_mod = importlib.import_module("custom_components.opnsense.device_tracker")
 pkg = importlib.import_module("custom_components.opnsense")
 
@@ -103,7 +102,6 @@ async def test_async_setup_entry_configured_devices(
         options={dt_mod.CONF_DEVICES: ["aa:bb:cc"], dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="eid",
     )
-    # attach coordinator into runtime_data under the expected attribute name
     setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
     entry.add_update_listener = lambda f: lambda: None
     entry.async_on_unload = lambda x: None
@@ -113,7 +111,6 @@ async def test_async_setup_entry_configured_devices(
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
 
-    # use shared fake registry fixture: device does not exist
     fake = fake_reg_factory(device_exists=False)
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
 
@@ -130,22 +127,15 @@ async def test_async_setup_entry_configured_devices(
     await dt_mod.async_setup_entry(hass, entry, async_add_entities)
 
     assert len(added) == 1
-    # the created entity should be the integration's device tracker entity and have a unique_id
     created = added[0]
     assert isinstance(created, dt_mod.OPNsenseScannerEntity)
-    # make_config_entry sets the device unique id to a suffix like "mac_<normalized_mac>".
-    # slugify should normalize ':' to '_' -> unique_id should end with 'mac_aa_bb_cc'
     uid = getattr(created, "unique_id", None)
     assert uid is not None
     assert uid.startswith("dev1_")
     assert uid.endswith("mac_aa_bb_cc")
-    # ensure the normalized MAC components are present in the unique_id
     assert "aa_bb_cc" in uid
-    # ensure the MAC is available on the entity (or included in unique_id) and was normalized
     assert created.mac_address == "aa:bb:cc"
-    # tracked macs should have been updated on the config entry
     assert hass.config_entries.async_update_entry.called
-    # Inspect the update payload to ensure tracked MACs were persisted
     call = hass.config_entries.async_update_entry.call_args
     args = call.args
     kwargs = call.kwargs
@@ -166,12 +156,10 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     fake_reg_factory: Any,
 ) -> None:
     """Ensure previously-tracked MACs not present in current devices are removed."""
-    # coordinator reports only one arp entry
     coordinator.data = {
         "arp_table": [{"mac": "aa:bb:cc", "ip": "1.2.3.4", "hostname": "dev", "manufacturer": "m"}]
     }
 
-    # entry previously tracked an extra MAC that is no longer present
     entry = make_config_entry(
         data={dt_mod.TRACKED_MACS: ["aa:bb:cc", "ff:ee:dd"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
         options={dt_mod.CONF_DEVICES: ["aa:bb:cc"], dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
@@ -202,7 +190,6 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
 
     await dt_mod.async_setup_entry(hass, entry, async_add_entities)
 
-    # ensure an update was persisted and the stale MAC was removed
     assert hass.config_entries.async_update_entry.called
     call = hass.config_entries.async_update_entry.call_args
     args = call.args
@@ -210,9 +197,7 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     updated_data = kwargs.get("data", args[1] if len(args) > 1 else None)
 
     assert updated_data is not None
-    # The stale MAC should no longer be present
     assert "ff:ee:dd" not in updated_data.get(dt_mod.TRACKED_MACS, [])
-    # The expected remaining MAC should still be present
     assert "aa:bb:cc" in updated_data.get(dt_mod.TRACKED_MACS, [])
 
 
@@ -274,7 +259,6 @@ def test_handle_coordinator_update_entry_present(
     ent._handle_coordinator_update()
 
     assert ent.ip_address == "1.2.3.4"
-    # hostname should have stripped the trailing '?'
     assert ent.hostname == "host"
     assert ent.is_connected is True
     assert ent.extra_state_attributes.get("expires") == "Never"
@@ -401,12 +385,10 @@ def test_handle_coordinator_update_missing_entry_consider_home(
         mac_vendor=None,
         hostname=None,
     )
-    # set a recent last known connected time
     ent._last_known_connected_time = datetime.now(UTC).astimezone()
     object.__setattr__(ent, "async_write_ha_state", MagicMock())
 
     ent._handle_coordinator_update()
-    # elapsed < consider_home so device considered connected
     assert ent.is_connected is True
 
 
@@ -472,7 +454,6 @@ async def test_restore_last_state_and_device_info(
     ent._attr_extra_state_attributes = {}
     last_known_connected_time = datetime.now(UTC)
 
-    # fake last state with attributes including isoformat time
     last_state = MagicMock()
     last_state.attributes = MappingProxyType(
         {
@@ -487,14 +468,12 @@ async def test_restore_last_state_and_device_info(
     object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()
-    # restored attributes should be present
     assert ent._last_known_hostname == "oldhost"
     assert ent._last_known_ip == "9.9.9.9"
     assert ent._last_known_connected_time == last_known_connected_time
     assert ent.extra_state_attributes.get("interface") == "lan0"
     assert "last_known_connected_time" in ent.extra_state_attributes
 
-    # device_info should include the mac connection and via_device tuple
     devinfo = ent.device_info
     # support both DeviceInfo object and dict-shaped DeviceInfo used in tests
     if isinstance(devinfo, MutableMapping):
@@ -609,9 +588,7 @@ async def test_async_added_to_hass_calls_restore(
         hostname=None,
     )
 
-    # patch the restore method and the parent async_added_to_hass to avoid side effects
     ent._restore_last_state = AsyncMock()
-    # patch the base class async_added_to_hass (no-op)
     base_mod = importlib.import_module("custom_components.opnsense.entity")
     monkeypatch.setattr(base_mod.OPNsenseBaseEntity, "async_added_to_hass", AsyncMock())
 
@@ -628,7 +605,6 @@ async def test_async_setup_entry_state_not_mapping(
     fake_reg_factory: Any,
 ) -> None:
     """Setup exits early when coordinator state is not a mapping."""
-    # coordinator.data is not a mapping -> async_setup_entry should return early and not add entities
     coordinator.data = "not-a-mapping"
     entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
     setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
@@ -654,7 +630,6 @@ async def test_async_setup_entry_removes_previous_mac(
     fake_reg_factory: Any,
 ) -> None:
     """Setup removes previously tracked MAC addresses when reconfiguring."""
-    # previous tracked macs include an old mac that should be removed via device registry
     coordinator.data = {"arp_table": []}
     entry = make_config_entry(
         data={dt_mod.TRACKED_MACS: ["old:mac:1"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
@@ -664,7 +639,6 @@ async def test_async_setup_entry_removes_previous_mac(
     hass = ph_hass
     hass.data = {}
 
-    # use shared fake registry fixture: simulate device present and removal
     fake = fake_reg_factory(device_exists=True, device_id="dev_to_remove")
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
 
@@ -766,7 +740,6 @@ def test_handle_coordinator_update_ip_typeerror(
     object.__setattr__(ent, "async_write_ha_state", MagicMock())
 
     ent._handle_coordinator_update()
-    # no exception and ip_address is None
     assert ent.ip_address is None
 
 
@@ -774,8 +747,6 @@ def test_handle_coordinator_update_expired_preserve_last_known_ip(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
     """Expired entries preserve last_known_ip when no IP present."""
-    # expired entry should set is_connected False and preserve last_known_ip
-    # no ip in entry triggers branch where last_known_ip is preserved
     coordinator.data = {"arp_table": [{"mac": "aa:bb:cc", "expired": True}]}
 
     entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
@@ -807,7 +778,6 @@ async def test_async_setup_entry_from_arp_entries(
     fake_reg_factory: Any,
 ) -> None:
     """Setup from ARP entries creates device trackers for present ARP rows."""
-    # when CONF_DEVICES not set but device tracker enabled, create entity per arp entry
     coordinator.data = {"arp_table": [{"mac": "m1"}, {"mac": "m2", "hostname": "h2"}]}
     entry = make_config_entry(
         data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -420,6 +420,43 @@ def test_handle_coordinator_update_expires_positive(
     assert isinstance(ent.extra_state_attributes.get("expires"), datetime)
 
 
+def test_handle_coordinator_update_skips_malformed_expires(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed ARP expiry data should not hide other valid ARP attributes."""
+    coordinator.data = {
+        "arp_table": [
+            {
+                "mac": "aa:bb:cc",
+                "ip": "1.2.3.4",
+                "intf_description": "lan",
+                "expires": "soon",
+                "type": "arp",
+            }
+        ],
+        "update_time": float(int(datetime.now(UTC).timestamp())),
+    }
+
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.extra_state_attributes.get("interface") == "lan"
+    assert "expires" not in ent.extra_state_attributes
+    assert ent.extra_state_attributes.get("type") == "arp"
+
+
 def test_handle_coordinator_update_ip_typeerror(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -5,7 +5,7 @@ and device info formatting for the integration's device tracker entities.
 """
 
 from collections.abc import Callable, Iterable, MutableMapping
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import importlib
 from types import MappingProxyType
 from typing import Any
@@ -324,6 +324,23 @@ def test_handle_coordinator_update_skips_malformed_arp_entries(
     assert ent.available is True
 
 
+def test_handle_coordinator_update_skips_nonmatching_mapping_arp_entries(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Nonmatching ARP mapping entries should be skipped while searching."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": [{"mac": "dd:ee:ff"}]},
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.is_connected is False
+    assert ent.available is True
+
+
 def test_handle_coordinator_update_matches_mac_case_insensitively(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -391,6 +408,32 @@ def test_handle_coordinator_update_missing_entry_consider_home(
     ent._handle_coordinator_update()
     # elapsed < consider_home so device considered connected
     assert ent.is_connected is True
+
+
+def test_handle_coordinator_update_expired_entry_outside_consider_home(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Expired ARP entries outside consider_home should stay disconnected."""
+    entry = make_config_entry(
+        data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={dt_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: 1},
+    )
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    coordinator.data = {"arp_table": [{"mac": "aa:bb:cc", "expired": True}]}
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    ent._last_known_connected_time = datetime.now(UTC).astimezone() - timedelta(seconds=5)
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.is_connected is False
 
 
 @pytest.mark.asyncio
@@ -501,6 +544,25 @@ async def test_restore_last_state_ignores_unparseable_connected_time(
     ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
     last_state.attributes = {"last_known_connected_time": "not-a-date"}
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
+
+    await ent._restore_last_state()
+
+    assert ent._last_known_connected_time is None
+    attrs = ent.extra_state_attributes
+    assert attrs is not None
+    assert "last_known_connected_time" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_ignores_non_datetime_connected_time(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Restoring state should ignore non-string and non-datetime timestamps."""
+    ent = _make_scanner_entity(coordinator, make_config_entry)
+    last_state = MagicMock()
+    last_state.attributes = {"last_known_connected_time": 1}
     object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -515,6 +515,52 @@ async def test_restore_last_state_uses_datetime_and_skips_empty_attributes(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "connected_time",
+    [
+        datetime(2026, 6, 22, 12, 30, 5, tzinfo=UTC),
+        datetime(2026, 6, 22, 12, 30, 5, tzinfo=UTC).isoformat(),
+    ],
+)
+async def test_restore_last_state_restores_tz_aware_connected_time(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    connected_time: datetime | str,
+) -> None:
+    """Aware datetime values should restore into tracker state."""
+    ent = _make_scanner_entity(coordinator, make_config_entry)
+    last_state = MagicMock()
+    last_state.attributes = {"last_known_connected_time": connected_time}
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
+
+    await ent._restore_last_state()
+
+    assert ent._last_known_connected_time == datetime(2026, 6, 22, 12, 30, 5, tzinfo=UTC)
+    attrs = ent.extra_state_attributes
+    assert attrs is not None
+    assert "last_known_connected_time" in attrs
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_ignores_naive_iso_connected_time(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Naive ISO timestamps should be ignored during state restore."""
+    ent = _make_scanner_entity(coordinator, make_config_entry)
+    last_state = MagicMock()
+    last_state.attributes = {"last_known_connected_time": "2026-06-22T12:30:05"}
+    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
+
+    await ent._restore_last_state()
+
+    assert ent._last_known_connected_time is None
+    attrs = ent.extra_state_attributes
+    assert attrs is not None
+    assert "last_known_connected_time" not in attrs
+
+
+@pytest.mark.asyncio
 async def test_restore_last_state_ignores_unparseable_connected_time(
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -19,6 +19,41 @@ dt_mod = importlib.import_module("custom_components.opnsense.device_tracker")
 pkg = importlib.import_module("custom_components.opnsense")
 
 
+def test_device_from_arp_entry_skips_malformed_and_nonmatching_entries() -> None:
+    """Device lookup should ignore malformed and nonmatching ARP entries."""
+    device = dt_mod._device_from_arp_entry(
+        "aa:bb:cc",
+        [
+            object(),
+            {"mac": "dd:ee:ff", "hostname": "other"},
+            {"mac": "aa:bb:cc", "hostname": "tracked", "manufacturer": "maker"},
+        ],
+    )
+
+    assert device == {"mac": "aa:bb:cc", "hostname": "tracked", "manufacturer": "maker"}
+
+
+def test_device_from_arp_entry_returns_mac_fallback_without_entries() -> None:
+    """Device lookup should return a MAC-only fallback when no ARP entries exist."""
+    assert dt_mod._device_from_arp_entry("aa:bb:cc", []) == {"mac": "aa:bb:cc"}
+
+
+def test_devices_from_arp_entries_skips_malformed_invalid_and_duplicate_macs() -> None:
+    """ARP conversion should only return devices for unique valid MAC strings."""
+    devices, mac_addresses = dt_mod._devices_from_arp_entries(
+        [
+            object(),
+            {"mac": None},
+            {"mac": ""},
+            {"mac": "aa:bb:cc", "hostname": "tracked"},
+            {"mac": "aa:bb:cc", "hostname": "duplicate"},
+        ],
+    )
+
+    assert mac_addresses == ["aa:bb:cc"]
+    assert devices == [{"mac": "aa:bb:cc", "hostname": "tracked"}]
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_configured_devices(
     monkeypatch: pytest.MonkeyPatch,
@@ -217,6 +252,30 @@ def test_handle_coordinator_update_entry_present(
     assert ent.icon == "mdi:lan-connect"
 
 
+def test_handle_coordinator_update_skips_malformed_arp_entries(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed ARP entries should be skipped while searching for the tracked MAC."""
+    coordinator.data = {"arp_table": [object()]}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.is_connected is False
+    assert ent.available is True
+
+
 def test_handle_coordinator_update_missing_entry_consider_home(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -303,6 +362,97 @@ async def test_restore_last_state_and_device_info(
     assert via is not None
     assert via[0] == dt_mod.DOMAIN
     assert via[1] == entry.data[pkg.CONF_DEVICE_UNIQUE_ID]
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_uses_datetime_and_skips_empty_attributes(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Restoring state should preserve datetime values and ignore empty saved attributes."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    last_known_connected_time = datetime.now(UTC)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    last_state = MagicMock()
+    last_state.attributes = {
+        "last_known_hostname": None,
+        "last_known_ip": None,
+        "interface": "",
+        "expires": None,
+        "type": "",
+        "last_known_connected_time": last_known_connected_time,
+    }
+    ent.async_get_last_state = AsyncMock(return_value=last_state)
+
+    await ent._restore_last_state()
+
+    assert ent._last_known_connected_time == last_known_connected_time
+    assert ent.extra_state_attributes == {"last_known_connected_time": last_known_connected_time}
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_ignores_unparseable_connected_time(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Restoring state should ignore invalid saved connection timestamps."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    last_state = MagicMock()
+    last_state.attributes = {"last_known_connected_time": "not-a-date"}
+    ent.async_get_last_state = AsyncMock(return_value=last_state)
+
+    await ent._restore_last_state()
+
+    assert ent._last_known_connected_time is None
+    assert "last_known_connected_time" not in ent.extra_state_attributes
+
+
+@pytest.mark.asyncio
+async def test_restore_last_state_ignores_non_mapping_attributes(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Restoring state should ignore snapshots with malformed attributes."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    last_state = MagicMock()
+    last_state.attributes = ["not", "a", "mapping"]
+    ent.async_get_last_state = AsyncMock(return_value=last_state)
+
+    await ent._restore_last_state()
+
+    assert ent.extra_state_attributes == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -794,11 +794,6 @@ async def test_async_update_listener_reload_and_remove(
 
     # config option already provided via factory; no mutation needed
 
-    # Ensure hass.async_create_task exists (ph_hass MagicMock fallback may not
-    # provide it). Tests expect this to exist so they can assert it was called.
-    if not hasattr(hass, "async_create_task"):
-        hass.async_create_task = MagicMock()
-
     await init_mod._async_update_listener(hass, entry)
 
     # async_create_task should have been used to schedule reload
@@ -857,9 +852,6 @@ async def test_async_update_listener_removes_native_firewall_entities(
         lambda registry, config_entry_id: [],
     )
 
-    if not hasattr(hass, "async_create_task"):
-        hass.async_create_task = MagicMock()
-
     await init_mod._async_update_listener(hass, entry)
 
     entity_registry.async_remove.assert_called_once_with(ent.entity_id)
@@ -906,9 +898,6 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
         lambda registry, config_entry_id: [],
     )
 
-    if not hasattr(hass, "async_create_task"):
-        hass.async_create_task = MagicMock()
-
     await init_mod._async_update_listener(hass, entry)
 
     entity_registry.async_remove.assert_not_called()
@@ -942,10 +931,6 @@ async def test_async_update_listener_device_removal_param(
     hass = ph_hass
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
-
-    # ensure hass.async_create_task exists for scheduling reload
-    if not hasattr(hass, "async_create_task"):
-        hass.async_create_task = MagicMock()
 
     # prepare a single device entry returned by the device registry
     device = MagicMock()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1938,7 +1938,7 @@ def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None
 
 
 @pytest.mark.parametrize(
-    ("state", "select_suffix", "expect_name", "toggle_return", "expect_on"),
+    ("state", "entity_key", "expect_name", "toggle_return", "expect_on"),
     [
         (
             {
@@ -1989,7 +1989,7 @@ def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None
                 },
                 "wireguard": {"clients": {}, "servers": {}},
             },
-            "cfail",
+            "openvpn.clients.cfail",
             "Cfail",
             False,
             False,
@@ -2001,7 +2001,7 @@ async def test_vpn_toggle_parametrized(
     coordinator: MagicMock,
     ph_hass: Any,
     state: MutableMapping[str, Any],
-    select_suffix: Any,
+    entity_key: str,
     expect_name: Any,
     toggle_return: Any,
     expect_on: Any,
@@ -2013,16 +2013,7 @@ async def test_vpn_toggle_parametrized(
     coordinator.data = state
     ents = await _compile_vpn_switches(config_entry, coordinator, state)
 
-    # pick matching entity: prefer exact key match, then full dotted-suffix,
-    # then fallback to last-segment match
-    ent = next((e for e in ents if e.entity_description.key == select_suffix), None)
-    if ent is None:
-        ent = next((e for e in ents if e.entity_description.key.endswith(select_suffix)), None)
-    if ent is None:
-        ent = next(
-            (e for e in ents if e.entity_description.key.endswith(select_suffix.split(".")[-1])),
-            None,
-        )
+    ent = next((e for e in ents if e.entity_description.key == entity_key), None)
     assert ent is not None
     hass = ph_hass
     ent.hass = hass

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2094,11 +2094,12 @@ def test_reset_delay_calls_existing_remover(
 async def test_compile_service_skips_locked(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
-    """Service compilation skips locked services."""
+    """Service compilation skips locked and malformed services."""
     config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1", "url": "http://example"})
     setattr(config_entry.runtime_data, COORDINATOR, coordinator)
     state = {
         "services": [
+            object(),
             {"id": "s1", "name": "one", "locked": 1, "status": True},
             {"id": "s2", "name": "two", "locked": 0, "status": False},
         ]
@@ -2109,6 +2110,15 @@ async def test_compile_service_skips_locked(
     assert "service.s2.status" in keys
     assert "service.s1.status" not in keys
     assert len(ents) == 1
+
+
+def test_firewall_rule_description_normalizes_non_string_interface() -> None:
+    """Firewall rule descriptions should normalize non-string interfaces to Floating."""
+    description = switch_mod._build_firewall_rule_switch_description(
+        {"uuid": "r1", "description": "Test", "%interface": ["lan", "wan"]}
+    )
+
+    assert description.name == "Firewall: Floating: Test"
 
 
 @pytest.mark.asyncio

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -367,7 +367,6 @@ def test_get_versions_scenarios(
     dummy_coordinator: MagicMock,
 ) -> None:
     """Parameterize _get_versions behaviors across upgrade package presence and missing fields."""
-    # Use the shared fixture for a config entry
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -423,7 +422,6 @@ def test_handle_coordinator_update_sets_attributes(
             key="firmware.update_available", name="Firmware"
         ),
     )
-    # prepare state with many firmware fields
     state = {
         "firmware_update_info": {
             "status": "update",
@@ -452,7 +450,6 @@ def test_handle_coordinator_update_sets_attributes(
     assert ent.installed_version == "1_0_0"
     assert ent.latest_version == "1.0.2"
     assert ent.release_summary == "ok"
-    # extra state attributes are created from firmware_update_info keys (top-level ones)
     attrs = ent.extra_state_attributes
     assert attrs is not None
     assert "opnsense_download_size" in attrs
@@ -554,17 +551,11 @@ async def test_handle_coordinator_update_update_normalizes_product_latest(
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
     ent._handle_coordinator_update()
 
-    # product_latest should be normalized into latest_version
     assert ent.latest_version == expected_latest_normalized
 
-    # release notes are currently generated from the raw product_latest value
-    # (the entity stores a normalized latest_version separately), so verify
-    # the original input appears in the notes and the normalized value is
-    # available on the entity
     notes = await ent.async_release_notes()
     assert notes is not None
     assert product_latest_input in notes
-    # series '2.1' -> community mapping reflected in path
     assert ent.release_url is not None
     assert "community/2.1" in ent.release_url
 
@@ -575,7 +566,6 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
     dummy_coordinator: MagicMock,
 ) -> None:
     """When _get_product_class returns None, release_url should fall back to the OPNsense UI changelog."""
-    # ensure config entry has a base url for the fallback and a device id
     entry = make_config_entry(
         {
             CONF_DEVICE_UNIQUE_ID: "test-device-123",
@@ -591,7 +581,6 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
         ),
     )
 
-    # arrange state where product_series and product_latest exist but product class will be None
     state = {
         "firmware_update_info": {
             "status": "upgrade",
@@ -606,7 +595,6 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
     ent.coordinator.data = state
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
-    # Patch the instance method to return None to force the fallback branch
     monkeypatch.setattr(ent, "_get_product_class", lambda series: None)
 
     ent._handle_coordinator_update()
@@ -963,8 +951,6 @@ async def test_async_release_notes_returns_value(
             key="firmware.update_available", name="Firmware"
         ),
     )
-    # Provide coordinator state that would generate release notes via the
-    # entity's normal update handling instead of setting the private attr.
     state = {
         "firmware_update_info": {
             "status": "update",
@@ -987,7 +973,6 @@ async def test_async_release_notes_returns_value(
     }
     ent.coordinator.data = state
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
-    # Populate internal fields as Home Assistant would via coordinator update
     ent._handle_coordinator_update()
 
     val = await ent.async_release_notes()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -833,12 +833,20 @@ def test_get_release_notes_malformed_state_returns_none(
 
 
 @pytest.mark.asyncio
-async def test_async_install_exceptions_loop(
+@pytest.mark.parametrize(
+    "upgrade_status_response",
+    [
+        pytest.param(None, id="none-response"),
+        pytest.param({}, id="missing-status"),
+    ],
+)
+async def test_async_install_handles_masked_polling_response(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
+    upgrade_status_response: Any,
 ) -> None:
-    """async_install should handle exceptions and exit the install loop gracefully."""
+    """async_install should handle masked aiopnsense polling failures."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -849,10 +857,10 @@ async def test_async_install_exceptions_loop(
     )
 
     class BadClient:
-        """Fake firmware client that raises retryable polling errors."""
+        """Fake firmware client that returns unusable polling payloads."""
 
         def __init__(self) -> None:
-            """Initialize a fake client that fails during upgrade polling."""
+            """Initialize a fake client that returns masked polling failures."""
             self.rebooted = False
 
         async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
@@ -866,17 +874,13 @@ async def test_async_install_exceptions_loop(
             """
             return {"started": True}
 
-        async def upgrade_status(self) -> dict[str, Any]:
-            """Raise a timeout error while the entity polls upgrade status.
-
-            Raises:
-                TimeoutError: Always raised to exercise the entity's exception
-                    handling path.
+        async def upgrade_status(self) -> dict[str, Any] | None:
+            """Return an unusable polling response from aiopnsense.
 
             Returns:
-                dict[str, Any]: This method never returns normally.
+                dict[str, Any] | None: Masked polling failure payload.
             """
-            raise TimeoutError("fail")
+            return upgrade_status_response
 
         async def get_firmware_update_info(self) -> dict[str, Any]:
             """Return update metadata showing that no reboot is required.
@@ -897,6 +901,57 @@ async def test_async_install_exceptions_loop(
 
     await ent.async_install()
     assert bad.rebooted is False
+
+
+@pytest.mark.asyncio
+async def test_async_install_transport_polling_error_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
+) -> None:
+    """async_install should not hide transport errors raised by aiopnsense."""
+    entry = make_config_entry()
+    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
+        config_entry=entry,
+        coordinator=dummy_coordinator,
+        entity_description=UpdateEntityDescription(
+            key="firmware.update_available", name="Firmware"
+        ),
+    )
+
+    class BadClient:
+        """Fake firmware client that raises a transport polling error."""
+
+        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
+            """Simulate accepting an upgrade request before polling fails.
+
+            Args:
+                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
+
+            Returns:
+                dict[str, Any]: Payload indicating that the upgrade request started.
+            """
+            return {"started": True}
+
+        async def upgrade_status(self) -> dict[str, Any]:
+            """Raise a transport polling error.
+
+            Raises:
+                TimeoutError: Always raised to verify transport errors are not
+                    handled after aiopnsense masking.
+
+            Returns:
+                dict[str, Any]: This method never returns normally.
+            """
+            raise TimeoutError("fail")
+
+    bad: Any = BadClient()
+    object.__setattr__(ent, "_client", bad)
+    ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
+
+    with pytest.raises(TimeoutError, match="fail"):
+        await ent.async_install()
 
 
 @pytest.mark.asyncio

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -550,7 +550,6 @@ async def test_async_install_reboots_when_needed(
             return {"started": True}
 
         async def upgrade_status(self) -> dict[str, str]:
-            # placeholder; will be replaced by AsyncMock in test below
             """Return the next queued upgrade status payload."""
             return self._status_calls.pop(0)
 
@@ -757,7 +756,7 @@ async def test_async_install_unexpected_polling_error_raises(
 
             Raises:
                 RuntimeError: Always raised to verify unexpected errors are not
-                    swallowed by retry handling.
+                    handled as retryable polling errors.
             """
             raise RuntimeError("unexpected")
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -58,10 +58,41 @@ async def test_async_setup_entry_adds_firmware_update_entity_contract(
     )
 
 
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_disabled_firmware_update_sync(
+    hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
+) -> None:
+    """async_setup_entry should not add firmware entities when sync is disabled."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "test-device-123",
+            CONF_SYNC_FIRMWARE_UPDATES: False,
+        }
+    )
+    setattr(entry.runtime_data, update_module.COORDINATOR, dummy_coordinator)
+    added_entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
+
+    def async_add_entities(
+        entities: list[OPNsenseFirmwareUpdatesAvailableUpdate],
+        _update_before_add: bool = False,
+    ) -> None:
+        """Capture entities added by the platform setup callback."""
+        added_entities.extend(entities)
+
+    await update_module.async_setup_entry(
+        hass, entry, cast("AddEntitiesCallback", async_add_entities)
+    )
+
+    assert added_entities == []
+
+
 @pytest.mark.parametrize(
     "coordinator_data",
     [
         pytest.param(None, id="missing"),
+        pytest.param({"firmware_update_info": []}, id="non-mapping-info"),
         pytest.param({"firmware_update_info": {"status": "error"}}, id="error-status"),
         pytest.param({"firmware_update_info": {}}, id="missing-status"),
         pytest.param({"firmware_update_info": {"status": 1}}, id="non-string-status"),
@@ -126,6 +157,11 @@ def test_is_update_available_true_for_valid_status(
     assert ent.available is True
 
 
+def test_affected_package_count_counts_lists() -> None:
+    """Affected package count should count list-shaped package collections."""
+    assert update_module._affected_package_count(["base", "kernel"]) == 2
+
+
 @pytest.mark.parametrize(
     ("state_builder", "expect_latest", "expect_series", "expect_latest_condition"),
     [
@@ -165,6 +201,49 @@ def test_is_update_available_true_for_valid_status(
             "1_0_1",
             "1.0",
             lambda latest: latest == "1_0_1",
+        ),
+        (
+            lambda: {
+                "firmware_update_info": {
+                    "product": {
+                        "product_version": "1.0.0",
+                        "product_latest": "1.0.0",
+                        "product_series": "1.0",
+                        "product_check": {
+                            "upgrade_packages": [
+                                object(),
+                                {"name": "opnsense", "new_version": "1.0.1"},
+                            ]
+                        },
+                    },
+                    "status": "update",
+                }
+            },
+            "1.0.1",
+            "1.0",
+            lambda latest: latest == "1.0.1",
+        ),
+        (
+            lambda: {
+                "firmware_update_info": {
+                    "product": {
+                        "product_version": "1.0.0",
+                        "product_latest": "1.0.1",
+                        "product_series": "1.0",
+                        "product_check": {
+                            "upgrade_packages": [
+                                object(),
+                                {"name": "kernel", "new_version": "1.0.2"},
+                                {"name": "opnsense", "new_version": "1.0.2"},
+                            ]
+                        },
+                    },
+                    "status": "update",
+                }
+            },
+            "1.0.2",
+            "1.0",
+            lambda latest: latest == "1.0.2",
         ),
         (
             lambda: {
@@ -213,6 +292,22 @@ def test_is_update_available_true_for_valid_status(
             "2.1.3",
             "2.1",
             lambda latest: latest == "2.1.3",
+        ),
+        (
+            lambda: {
+                "firmware_update_info": {
+                    "status": "upgrade",
+                    "product": {
+                        "product_version": "2.0.0",
+                        "product_latest": "2.0.0",
+                        "product_series": "2.0",
+                    },
+                    "upgrade_major_version": "",
+                }
+            },
+            "2.0.0",
+            "2.0",
+            lambda latest: latest == "2.0.0",
         ),
     ],
 )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -571,6 +571,8 @@ async def test_async_install_reboots_when_needed(
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
     class FakeClient:
+        """Fake firmware client for a successful install flow."""
+
         def __init__(self) -> None:
             # planned sequence: first 'running', then 'done'
             """Initialize a fake client that simulates a successful update flow."""
@@ -585,15 +587,26 @@ async def test_async_install_reboots_when_needed(
 
             Args:
                 _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
+
+            Returns:
+                dict[str, Any]: Payload indicating that the upgrade request started.
             """
             return {"started": True}
 
         async def upgrade_status(self) -> dict[str, str]:
-            """Return the next queued upgrade status payload."""
+            """Return the next queued upgrade status payload.
+
+            Returns:
+                dict[str, str]: The next queued upgrade status response.
+            """
             return self._status_calls.pop(0)
 
         async def get_firmware_update_info(self) -> dict[str, Any]:
-            """Return update metadata indicating that a reboot is required."""
+            """Return update metadata indicating that a reboot is required.
+
+            Returns:
+                dict[str, Any]: Firmware update metadata that requires a reboot.
+            """
             return {"needs_reboot": "1", "upgrade_needs_reboot": None}
 
         async def system_reboot(self) -> None:
@@ -731,6 +744,8 @@ async def test_async_install_exceptions_loop(
     )
 
     class BadClient:
+        """Fake firmware client that raises retryable polling errors."""
+
         def __init__(self) -> None:
             """Initialize a fake client that fails during upgrade polling."""
             self.rebooted = False
@@ -740,6 +755,9 @@ async def test_async_install_exceptions_loop(
 
             Args:
                 _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
+
+            Returns:
+                dict[str, Any]: Payload indicating that the upgrade request started.
             """
             return {"started": True}
 
@@ -749,11 +767,18 @@ async def test_async_install_exceptions_loop(
             Raises:
                 TimeoutError: Always raised to exercise the entity's exception
                     handling path.
+
+            Returns:
+                dict[str, Any]: This method never returns normally.
             """
             raise TimeoutError("fail")
 
         async def get_firmware_update_info(self) -> dict[str, Any]:
-            """Return update metadata showing that no reboot is required."""
+            """Return update metadata showing that no reboot is required.
+
+            Returns:
+                dict[str, Any]: Firmware update metadata that does not require a reboot.
+            """
             return {"needs_reboot": None, "upgrade_needs_reboot": None}
 
         async def system_reboot(self) -> None:
@@ -786,8 +811,17 @@ async def test_async_install_unexpected_polling_error_raises(
     )
 
     class BadClient:
+        """Fake firmware client that raises an unexpected polling error."""
+
         async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
-            """Simulate accepting an upgrade request before polling fails."""
+            """Simulate accepting an upgrade request before polling fails.
+
+            Args:
+                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
+
+            Returns:
+                dict[str, Any]: Payload indicating that the upgrade request started.
+            """
             return {"started": True}
 
         async def upgrade_status(self) -> dict[str, Any]:
@@ -796,6 +830,9 @@ async def test_async_install_unexpected_polling_error_raises(
             Raises:
                 RuntimeError: Always raised to verify unexpected errors are not
                     handled as retryable polling errors.
+
+            Returns:
+                dict[str, Any]: This method never returns normally.
             """
             raise RuntimeError("unexpected")
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -581,7 +581,7 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
             "1_2_0",
             "1.2.0",
             False,
-            "1.2.0",
+            "1_2_0",
         ),
         (
             {"firmware_update_info": {"status": "none", "status_msg": "nothing"}},
@@ -621,6 +621,38 @@ def test_get_release_notes_variants(
     else:
         assert notes is not None
         assert expected in notes
+
+
+def test_get_release_notes_upgrade_uses_target_version_in_header(
+    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
+) -> None:
+    """Upgrade release notes should use product_latest as the target version."""
+    entry = make_config_entry()
+    coord = dummy_coordinator
+    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=UpdateEntityDescription(
+            key="firmware.update_available", name="Firmware"
+        ),
+    )
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    notes = ent._get_release_notes(
+        state={
+            "firmware_update_info": {
+                "status": "upgrade",
+                "product": {"product_name": "OPN"},
+                "status_msg": "up",
+                "upgrade_needs_reboot": "1",
+            }
+        },
+        product_latest="2_1_0",
+        product_version="2.0.0",
+    )
+    assert notes is not None
+    assert "## OPN version 2_1_0" in notes
+    assert "2.0.0" not in notes
 
 
 @pytest.mark.asyncio
@@ -778,7 +810,9 @@ def test_get_versions_malformed_state_returns_empty_versions(
     )
 
     pv, pl, ps = ent._get_versions({"firmware_update_info": []})
-    assert pv is None and pl is None and ps is None
+    assert pv is None
+    assert pl is None
+    assert ps is None
 
 
 def test_get_release_notes_malformed_state_returns_none(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -18,6 +18,43 @@ from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, CONF_SYNC_FI
 from custom_components.opnsense.update import OPNsenseFirmwareUpdatesAvailableUpdate
 
 
+def _firmware_update_state(
+    *,
+    product_version: Any,
+    product_latest: Any,
+    product_series: Any,
+    status: str = "update",
+    upgrade_packages: Any = None,
+    upgrade_major_version: Any = None,
+) -> dict[str, Any]:
+    """Build firmware update state for version parsing tests.
+
+    Args:
+        product_version: Installed product version value.
+        product_latest: Latest product version value.
+        product_series: Product series value.
+        status: Firmware status value.
+        upgrade_packages: Optional package check payload.
+        upgrade_major_version: Optional major upgrade version.
+
+    Returns:
+        Firmware update state with the requested product and status payload.
+    """
+    firmware_update_info: dict[str, Any] = {
+        "product": {
+            "product_version": product_version,
+            "product_latest": product_latest,
+            "product_series": product_series,
+        },
+        "status": status,
+    }
+    if upgrade_packages is not None:
+        firmware_update_info["product"]["product_check"] = {"upgrade_packages": upgrade_packages}
+    if upgrade_major_version is not None:
+        firmware_update_info["upgrade_major_version"] = upgrade_major_version
+    return {"firmware_update_info": firmware_update_info}
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_adds_firmware_update_entity_contract(
     hass: HomeAssistant,
@@ -163,159 +200,101 @@ def test_affected_package_count_counts_lists() -> None:
 
 
 @pytest.mark.parametrize(
-    ("state_builder", "expect_latest", "expect_series", "expect_latest_condition"),
+    ("state", "expected_latest", "expected_series"),
     [
-        # product_version == product_latest and packages is list without opnsense -> append '+'
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "1_0_0",
-                        "product_latest": "1_0_0",
-                        "product_series": "1.0",
-                        "product_check": {"upgrade_packages": [{"name": "not-opnsense"}]},
-                    },
-                    "status": "update",
-                }
-            },
-            None,
+            _firmware_update_state(
+                product_version="1_0_0",
+                product_latest="1_0_0",
+                product_series="1.0",
+                upgrade_packages=[{"name": "not-opnsense"}],
+            ),
+            "1_0_0+",
             "1.0",
-            lambda latest: latest == "1_0_0+",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "1.0.0",
-                        "product_latest": "1_0_0",
-                        "product_series": "1.0",
-                        "product_check": {
-                            "upgrade_packages": [
-                                {"name": "opnsense", "new_version": "1_0_1"},
-                            ]
-                        },
-                    },
-                    "status": "update",
-                }
-            },
+            _firmware_update_state(
+                product_version="1.0.0",
+                product_latest="1_0_0",
+                product_series="1.0",
+                upgrade_packages=[{"name": "opnsense", "new_version": "1_0_1"}],
+            ),
             "1_0_1",
             "1.0",
-            lambda latest: latest == "1_0_1",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "1.0.0",
-                        "product_latest": "1.0.0",
-                        "product_series": "1.0",
-                        "product_check": {
-                            "upgrade_packages": [
-                                object(),
-                                {"name": "opnsense", "new_version": "1.0.1"},
-                            ]
-                        },
-                    },
-                    "status": "update",
-                }
-            },
+            _firmware_update_state(
+                product_version="1.0.0",
+                product_latest="1.0.0",
+                product_series="1.0",
+                upgrade_packages=[
+                    object(),
+                    {"name": "opnsense", "new_version": "1.0.1"},
+                ],
+            ),
             "1.0.1",
             "1.0",
-            lambda latest: latest == "1.0.1",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "1.0.0",
-                        "product_latest": "1.0.1",
-                        "product_series": "1.0",
-                        "product_check": {
-                            "upgrade_packages": [
-                                object(),
-                                {"name": "kernel", "new_version": "1.0.2"},
-                                {"name": "opnsense", "new_version": "1.0.2"},
-                            ]
-                        },
-                    },
-                    "status": "update",
-                }
-            },
+            _firmware_update_state(
+                product_version="1.0.0",
+                product_latest="1.0.1",
+                product_series="1.0",
+                upgrade_packages=[
+                    object(),
+                    {"name": "kernel", "new_version": "1.0.2"},
+                    {"name": "opnsense", "new_version": "1.0.2"},
+                ],
+            ),
             "1.0.2",
             "1.0",
-            lambda latest: latest == "1.0.2",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "1_0_0",
-                        "product_latest": "1_0_0",
-                        "product_series": "1.0",
-                        "product_check": {"upgrade_packages": None},
-                    },
-                    "status": "update",
-                }
-            },
-            None,  # expect_latest unknown until post-processing; condition will check exact string
+            _firmware_update_state(
+                product_version="1_0_0",
+                product_latest="1_0_0",
+                product_series="1.0",
+            ),
+            "1_0_0+",
             "1.0",
-            lambda latest, pv="1_0_0": latest == pv + "+",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "product": {
-                        "product_version": "v1",
-                        "product_latest": None,
-                        "product_series": "s1",
-                    },
-                    "status": "update",
-                }
-            },
+            _firmware_update_state(
+                product_version="v1",
+                product_latest=None,
+                product_series="s1",
+            ),
             None,
             "s1",
-            lambda latest: latest is None,
         ),
-        # exercise the 'upgrade' branch: upgrade_major_version should become product_latest
         (
-            lambda: {
-                "firmware_update_info": {
-                    "status": "upgrade",
-                    "product": {
-                        "product_version": "2_0_0",
-                        "product_latest": "2_0_0",
-                        "product_series": "2.0",
-                    },
-                    "upgrade_major_version": "2.1.3",
-                }
-            },
+            _firmware_update_state(
+                product_version="2_0_0",
+                product_latest="2_0_0",
+                product_series="2.0",
+                status="upgrade",
+                upgrade_major_version="2.1.3",
+            ),
             "2.1.3",
             "2.1",
-            lambda latest: latest == "2.1.3",
         ),
         (
-            lambda: {
-                "firmware_update_info": {
-                    "status": "upgrade",
-                    "product": {
-                        "product_version": "2.0.0",
-                        "product_latest": "2.0.0",
-                        "product_series": "2.0",
-                    },
-                    "upgrade_major_version": "",
-                }
-            },
+            _firmware_update_state(
+                product_version="2.0.0",
+                product_latest="2.0.0",
+                product_series="2.0",
+                status="upgrade",
+                upgrade_major_version="",
+            ),
             "2.0.0",
             "2.0",
-            lambda latest: latest == "2.0.0",
         ),
     ],
 )
 def test_get_versions_scenarios(
-    state_builder: Any,
-    expect_latest: Any,
-    expect_series: Any,
-    expect_latest_condition: Any,
+    state: dict[str, Any],
+    expected_latest: str | None,
+    expected_series: str | None,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
@@ -329,12 +308,9 @@ def test_get_versions_scenarios(
             key="firmware.update_available", name="Firmware"
         ),
     )
-    state = state_builder()
     _pv, pl, ps = ent._get_versions(state)
-    assert ps == expect_series
-    if expect_latest is not None:
-        assert pl == expect_latest
-    assert expect_latest_condition(pl)
+    assert ps == expected_series
+    assert pl == expected_latest
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -55,6 +55,74 @@ def _firmware_update_state(
     return {"firmware_update_info": firmware_update_info}
 
 
+class _FirmwareInstallClient:
+    """Fake firmware client for update install flow tests."""
+
+    def __init__(
+        self,
+        *,
+        status_responses: list[Any] | None = None,
+        status_response: Any = None,
+        status_error: BaseException | None = None,
+        firmware_info: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a fake firmware install client.
+
+        Args:
+            status_responses: Queued responses returned by ``upgrade_status``.
+            status_response: Repeated response returned by ``upgrade_status``.
+            status_error: Error raised by ``upgrade_status``.
+            firmware_info: Payload returned by ``get_firmware_update_info``.
+        """
+        self.status_responses = list(status_responses or [])
+        self.status_response = status_response
+        self.status_error = status_error
+        self.firmware_info = firmware_info or {
+            "needs_reboot": None,
+            "upgrade_needs_reboot": None,
+        }
+        self.rebooted = False
+
+    async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
+        """Simulate accepting an upgrade request before polling.
+
+        Args:
+            _upgrade_type: Upgrade mode requested by the entity and ignored by
+                this fake client.
+
+        Returns:
+            Payload indicating that the upgrade request started.
+        """
+        return {"started": True}
+
+    async def upgrade_status(self) -> Any:
+        """Return or raise the configured polling result.
+
+        Raises:
+            BaseException: The configured ``status_error``, when provided.
+
+        Returns:
+            The next queued status response, or the configured repeated response.
+        """
+        if self.status_error is not None:
+            raise self.status_error
+        if self.status_responses:
+            return self.status_responses.pop(0)
+        return self.status_response
+
+    async def get_firmware_update_info(self) -> dict[str, Any]:
+        """Return configured firmware metadata.
+
+        Returns:
+            Firmware update metadata.
+        """
+        return self.firmware_info
+
+    async def system_reboot(self) -> None:
+        """Record that the update entity requested a system reboot."""
+        self.rebooted = True
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_adds_firmware_update_entity_contract(
     hass: HomeAssistant,
@@ -673,66 +741,22 @@ async def test_async_install_reboots_when_needed(
     )
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
-    class FakeClient:
-        """Fake firmware client for a successful install flow."""
-
-        def __init__(self) -> None:
-            # planned sequence: first 'running', then 'done'
-            """Initialize a fake client that simulates a successful update flow."""
-            self._status_calls = [
-                {"status": "running"},
-                {"status": "done"},
-            ]
-            self.rebooted = False
-
-        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
-            """Simulate starting a firmware upgrade request.
-
-            Args:
-                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
-
-            Returns:
-                dict[str, Any]: Payload indicating that the upgrade request started.
-            """
-            return {"started": True}
-
-        async def upgrade_status(self) -> dict[str, str]:
-            """Return the next queued upgrade status payload.
-
-            Returns:
-                dict[str, str]: The next queued upgrade status response.
-            """
-            return self._status_calls.pop(0)
-
-        async def get_firmware_update_info(self) -> dict[str, Any]:
-            """Return update metadata indicating that a reboot is required.
-
-            Returns:
-                dict[str, Any]: Firmware update metadata that requires a reboot.
-            """
-            return {"needs_reboot": "1", "upgrade_needs_reboot": None}
-
-        async def system_reboot(self) -> None:
-            """Record that the update entity requested a system reboot."""
-            self.rebooted = True
-
-    fake: Any = FakeClient()
-    # replace upgrade_status with an AsyncMock to track await calls and sequence
-    object.__setattr__(fake, "upgrade_status", AsyncMock(side_effect=fake._status_calls.copy()))
-    # wrap upgrade_firmware to assert it was awaited exactly once
+    status_responses = [{"status": "running"}, {"status": "done"}]
+    fake: Any = _FirmwareInstallClient(
+        status_responses=status_responses,
+        firmware_info={"needs_reboot": "1", "upgrade_needs_reboot": None},
+    )
+    object.__setattr__(fake, "upgrade_status", AsyncMock(side_effect=status_responses))
     object.__setattr__(fake, "upgrade_firmware", AsyncMock(wraps=fake.upgrade_firmware))
     object.__setattr__(ent, "_client", fake)
 
-    # provide coordinator state with firmware info and upgrade in progress
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
 
-    # speed up sleep and capture await count
     sleep_spy = AsyncMock(return_value=None)
     monkeypatch.setattr(asyncio, "sleep", sleep_spy)
 
     await ent.async_install()
     assert fake.rebooted is True
-    # ensure polling occurred: upgrade_status should have been awaited twice (running -> done)
     assert fake.upgrade_status.await_count == 2
     fake.upgrade_firmware.assert_awaited_once_with("update")
     assert 1 <= sleep_spy.await_count <= 5
@@ -754,10 +778,8 @@ async def test_async_install_does_nothing_on_non_update_status(
     )
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
-    # non-update status
     ent.coordinator.data = {"firmware_update_info": {"status": "none"}}
 
-    # attach a mock client and ensure upgrade_firmware is not called
     client = MagicMock()
     object.__setattr__(client, "upgrade_firmware", AsyncMock())
     ent._client = client
@@ -785,11 +807,9 @@ async def test_async_install_early_returns_and_no_client(
     )
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
 
-    # state not mapping
     ent.coordinator.data = cast("dict[str, Any]", None)
     await ent.async_install()
 
-    # state present but no client
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
     object.__setattr__(ent, "_client", None)
     await ent.async_install()
@@ -856,45 +876,7 @@ async def test_async_install_handles_masked_polling_response(
         ),
     )
 
-    class BadClient:
-        """Fake firmware client that returns unusable polling payloads."""
-
-        def __init__(self) -> None:
-            """Initialize a fake client that returns masked polling failures."""
-            self.rebooted = False
-
-        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
-            """Simulate accepting an upgrade request before polling fails.
-
-            Args:
-                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
-
-            Returns:
-                dict[str, Any]: Payload indicating that the upgrade request started.
-            """
-            return {"started": True}
-
-        async def upgrade_status(self) -> dict[str, Any] | None:
-            """Return an unusable polling response from aiopnsense.
-
-            Returns:
-                dict[str, Any] | None: Masked polling failure payload.
-            """
-            return upgrade_status_response
-
-        async def get_firmware_update_info(self) -> dict[str, Any]:
-            """Return update metadata showing that no reboot is required.
-
-            Returns:
-                dict[str, Any]: Firmware update metadata that does not require a reboot.
-            """
-            return {"needs_reboot": None, "upgrade_needs_reboot": None}
-
-        async def system_reboot(self) -> None:
-            """Record whether a reboot was incorrectly requested after failure."""
-            self.rebooted = True
-
-    bad: Any = BadClient()
+    bad: Any = _FirmwareInstallClient(status_response=upgrade_status_response)
     object.__setattr__(ent, "_client", bad)
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
     monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
@@ -919,33 +901,7 @@ async def test_async_install_transport_polling_error_raises(
         ),
     )
 
-    class BadClient:
-        """Fake firmware client that raises a transport polling error."""
-
-        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
-            """Simulate accepting an upgrade request before polling fails.
-
-            Args:
-                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
-
-            Returns:
-                dict[str, Any]: Payload indicating that the upgrade request started.
-            """
-            return {"started": True}
-
-        async def upgrade_status(self) -> dict[str, Any]:
-            """Raise a transport polling error.
-
-            Raises:
-                TimeoutError: Always raised to verify transport errors are not
-                    handled after aiopnsense masking.
-
-            Returns:
-                dict[str, Any]: This method never returns normally.
-            """
-            raise TimeoutError("fail")
-
-    bad: Any = BadClient()
+    bad: Any = _FirmwareInstallClient(status_error=TimeoutError("fail"))
     object.__setattr__(ent, "_client", bad)
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
     monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
@@ -970,33 +926,7 @@ async def test_async_install_unexpected_polling_error_raises(
         ),
     )
 
-    class BadClient:
-        """Fake firmware client that raises an unexpected polling error."""
-
-        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
-            """Simulate accepting an upgrade request before polling fails.
-
-            Args:
-                _upgrade_type: Upgrade mode requested by the entity and ignored by this fake client.
-
-            Returns:
-                dict[str, Any]: Payload indicating that the upgrade request started.
-            """
-            return {"started": True}
-
-        async def upgrade_status(self) -> dict[str, Any]:
-            """Raise an unexpected polling error.
-
-            Raises:
-                RuntimeError: Always raised to verify unexpected errors are not
-                    handled as retryable polling errors.
-
-            Returns:
-                dict[str, Any]: This method never returns normally.
-            """
-            raise RuntimeError("unexpected")
-
-    bad: Any = BadClient()
+    bad: Any = _FirmwareInstallClient(status_error=RuntimeError("unexpected"))
     object.__setattr__(ent, "_client", bad)
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
     monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -5,13 +5,57 @@ from collections.abc import Callable, MutableMapping
 from typing import Any, Never, cast
 from unittest.mock import AsyncMock, MagicMock
 
-from homeassistant.components.update import UpdateEntityDescription
+from homeassistant.components.update import UpdateDeviceClass, UpdateEntityDescription
+from homeassistant.components.update.const import UpdateEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import update as update_module
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, CONF_SYNC_FIRMWARE_UPDATES
 from custom_components.opnsense.update import OPNsenseFirmwareUpdatesAvailableUpdate
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_firmware_update_entity_contract(
+    hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
+) -> None:
+    """async_setup_entry creates the firmware update entity with its public contract."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "test-device-123",
+            CONF_SYNC_FIRMWARE_UPDATES: True,
+        }
+    )
+    setattr(entry.runtime_data, update_module.COORDINATOR, dummy_coordinator)
+    added_entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
+
+    def async_add_entities(
+        entities: list[OPNsenseFirmwareUpdatesAvailableUpdate],
+        _update_before_add: bool = False,
+    ) -> None:
+        """Capture entities added by the platform setup callback."""
+        added_entities.extend(entities)
+
+    await update_module.async_setup_entry(
+        hass, entry, cast("AddEntitiesCallback", async_add_entities)
+    )
+
+    assert len(added_entities) == 1
+    entity = added_entities[0]
+    assert isinstance(entity, OPNsenseFirmwareUpdatesAvailableUpdate)
+    assert entity.entity_description.key == "firmware.update_available"
+    assert entity.entity_description.name == "Firmware Updates Available"
+    assert entity.entity_description.entity_category is EntityCategory.DIAGNOSTIC
+    assert entity.entity_description.device_class is UpdateDeviceClass.FIRMWARE
+    assert entity.entity_description.entity_registry_enabled_default is True
+    assert entity.supported_features == (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -292,6 +292,16 @@ def test_affected_package_count_counts_lists() -> None:
         ),
         (
             _firmware_update_state(
+                product_version="1_0_0",
+                product_latest="1_0_0",
+                product_series="1.0",
+                upgrade_packages=[{"name": "opnsense", "new_version": ""}],
+            ),
+            "1_0_0+",
+            "1.0",
+        ),
+        (
+            _firmware_update_state(
                 product_version="1.0.0",
                 product_latest="1.0.0",
                 product_series="1.0",

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -63,6 +63,9 @@ async def test_async_setup_entry_adds_firmware_update_entity_contract(
     [
         pytest.param(None, id="missing"),
         pytest.param({"firmware_update_info": {"status": "error"}}, id="error-status"),
+        pytest.param({"firmware_update_info": {}}, id="missing-status"),
+        pytest.param({"firmware_update_info": {"status": 1}}, id="non-string-status"),
+        pytest.param({"firmware_update_info": {"status": ""}}, id="empty-status"),
     ],
 )
 def test_is_update_available_false_for_missing_or_error_state(
@@ -71,7 +74,12 @@ def test_is_update_available_false_for_missing_or_error_state(
     dummy_coordinator: MagicMock,
 ) -> None:
     """Update entity should be unavailable when firmware update state is unusable."""
-    entry = make_config_entry()
+    entry = make_config_entry(
+        {
+            "url": "https://opnsense.example",
+            CONF_DEVICE_UNIQUE_ID: "test-device-123",
+        }
+    )
     coord = dummy_coordinator
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -85,6 +93,37 @@ def test_is_update_available_false_for_missing_or_error_state(
     coord.data = coordinator_data
     ent._handle_coordinator_update()
     assert ent.available is False
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["none", "update", "upgrade"],
+)
+def test_is_update_available_true_for_valid_status(
+    status: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
+) -> None:
+    """Valid firmware statuses should keep the update entity available."""
+    entry = make_config_entry(
+        {
+            "url": "https://opnsense.example",
+            CONF_DEVICE_UNIQUE_ID: "test-device-123",
+        }
+    )
+    coord = dummy_coordinator
+    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=UpdateEntityDescription(
+            key="firmware.update_available", name="Firmware"
+        ),
+    )
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    coord.data = {"firmware_update_info": {"status": status}}
+    ent._handle_coordinator_update()
+    assert ent.available is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -738,13 +738,13 @@ async def test_async_install_exceptions_loop(
             return {"started": True}
 
         async def upgrade_status(self) -> dict[str, Any]:
-            """Raise a runtime error while the entity polls upgrade status.
+            """Raise a timeout error while the entity polls upgrade status.
 
             Raises:
-                RuntimeError: Always raised to exercise the entity's exception
+                TimeoutError: Always raised to exercise the entity's exception
                     handling path.
             """
-            raise RuntimeError("fail")
+            raise TimeoutError("fail")
 
         async def get_firmware_update_info(self) -> dict[str, Any]:
             """Return update metadata showing that no reboot is required."""
@@ -761,6 +761,45 @@ async def test_async_install_exceptions_loop(
 
     await ent.async_install()
     assert bad.rebooted is False
+
+
+@pytest.mark.asyncio
+async def test_async_install_unexpected_polling_error_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    dummy_coordinator: MagicMock,
+) -> None:
+    """async_install should not hide unexpected polling errors."""
+    entry = make_config_entry()
+    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
+        config_entry=entry,
+        coordinator=dummy_coordinator,
+        entity_description=UpdateEntityDescription(
+            key="firmware.update_available", name="Firmware"
+        ),
+    )
+
+    class BadClient:
+        async def upgrade_firmware(self, _upgrade_type: Any) -> dict[str, Any]:
+            """Simulate accepting an upgrade request before polling fails."""
+            return {"started": True}
+
+        async def upgrade_status(self) -> dict[str, Any]:
+            """Raise an unexpected polling error.
+
+            Raises:
+                RuntimeError: Always raised to verify unexpected errors are not
+                    swallowed by retry handling.
+            """
+            raise RuntimeError("unexpected")
+
+    bad: Any = BadClient()
+    object.__setattr__(ent, "_client", bad)
+    ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        await ent.async_install()
 
 
 def test_get_installed_version_none_on_error(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Callable, MutableMapping
-from typing import Any, Never, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntityDescription
@@ -641,14 +641,11 @@ async def test_async_install_early_returns_and_no_client(
     await ent.async_install()
 
 
-def test_get_versions_exception_path(
-    monkeypatch: pytest.MonkeyPatch,
+def test_get_versions_malformed_state_returns_empty_versions(
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """_get_versions returns None tuple when underlying dict_get raises."""
-    # force dict_get to raise so we hit the exception return
-
+    """_get_versions returns empty version data for malformed firmware state."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -658,29 +655,15 @@ def test_get_versions_exception_path(
         ),
     )
 
-    def raise_type(*args, **kwargs) -> Never:
-        """Raise ``TypeError`` so version parsing error handling can be exercised.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-
-        Raises:
-            TypeError: If a supplied argument has an unsupported type.
-        """
-        raise TypeError("boom")
-
-    monkeypatch.setattr(update_module, "dict_get", raise_type)
-    pv, pl, ps = ent._get_versions({})
+    pv, pl, ps = ent._get_versions({"firmware_update_info": []})
     assert pv is None and pl is None and ps is None
 
 
-def test_get_release_notes_exception_path(
-    monkeypatch: pytest.MonkeyPatch,
+def test_get_release_notes_malformed_state_returns_none(
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """_get_release_notes returns an unavailable message when dict_get raises."""
+    """_get_release_notes returns None for malformed firmware state."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -690,22 +673,7 @@ def test_get_release_notes_exception_path(
         ),
     )
 
-    def raise_key(*args, **kwargs) -> Never:
-        """Raise ``KeyError`` so release-note fallback handling can be exercised.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-
-        Raises:
-            KeyError: Always raised to test the release-note exception path.
-        """
-        raise KeyError("nope")
-
-    monkeypatch.setattr(update_module, "dict_get", raise_key)
-    res = ent._get_release_notes({}, None, None)
-    assert res is not None
-    assert "Release notes unavailable" in res
+    assert ent._get_release_notes({"firmware_update_info": []}, None, None) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Refactors platform entity compilation for binary sensors, switches, device trackers, and firmware updates while preserving the generated entity contracts. The PR standardizes how each platform builds descriptions and source entity data so future sensor-style compilation changes are easier to review and maintain.

## What Changed
- Extracted binary sensor description builders for interface enabled sensors, SMART status sensors, and pending notices.
- Refactored switch compilation to use shared entity-description builders across services, VPN, CARP maintenance, Unbound blocklist, firewall rules, and NAT rules.
- Consolidated device tracker ARP entry parsing and tracked-device compilation into focused helpers.
- Tightened firmware update parsing around explicit mapping/list shape checks instead of broad parsing fallbacks.
- Removed stale commented debug and placeholder code from the touched platform paths.
- Added regression coverage for generated entity metadata, malformed ARP expiry handling, firmware setup metadata, and malformed firmware payloads.

## Why
The platform files had several different inline patterns for compiling entities from coordinator data. That made the code harder to compare across entity types and made small contract-preserving changes look larger than they were.

This keeps the same sensors, switches, device trackers, and update entity behavior, but moves repeated description-building and source-data assembly into narrow helpers. The result matches the existing sensor compilation style more closely while keeping malformed coordinator payload handling explicit and tested.

## Screenshots
N/A - no UI changes.

## Related Issues
N/A