### PR TITLE
Refine OPNsense services

### DIFF
--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -34,7 +34,6 @@ from .const import (
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
-_SERVICE_IDENTIFIER_ERROR = "Must use service_id or service_name"
 _SERVICE_IDENTIFIER_CONFLICT_ERROR = "Must use service_id or service_name but not both"
 _TRANSLATION_KEY_GENERATE_VOUCHERS_FAILED = "generate_vouchers_failed"
 _TRANSLATION_KEY_GET_VNSTAT_METRICS_FAILED = "get_vnstat_metrics_failed"
@@ -73,23 +72,6 @@ def _service_validation_error(
             key: str(value) for key, value in (translation_placeholders or {}).items()
         },
     )
-
-
-def _validate_service_identifier(data: dict[str, Any]) -> dict[str, Any]:
-    """Validate that a service control call includes a service identifier.
-
-    Args:
-        data: Validated service call payload.
-
-    Returns:
-        dict[str, Any]: Original service call payload.
-
-    Raises:
-        vol.Invalid: If neither ``service_id`` nor ``service_name`` was supplied.
-    """
-    if data.get("service_id") or data.get("service_name"):
-        return data
-    raise vol.Invalid(_SERVICE_IDENTIFIER_ERROR)
 
 
 def _target_fields() -> dict[Any, Any]:
@@ -134,7 +116,7 @@ def _service_control_schema(extra_fields: dict[Any, Any] | None = None) -> vol.S
         vol.Schema: Service control schema with identifier validation.
     """
     fields = _service_identifier_fields() | (extra_fields or {}) | _target_fields()
-    return vol.Schema(vol.All(fields, _validate_service_identifier))
+    return vol.Schema(fields)
 
 
 def _targeted_schema(fields: dict[Any, Any] | None = None) -> vol.Schema:
@@ -317,6 +299,8 @@ async def _get_clients(
         or not isinstance(hass.data[DOMAIN], MutableMapping)
         or not hass.data[DOMAIN]
     ):
+        if opndevice_id or opnentity_id:
+            raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
         return []
     first_entry_id = next(iter(hass.data[DOMAIN]))
     if len(hass.data[DOMAIN]) == 1 and not opndevice_id and not opnentity_id:
@@ -359,7 +343,7 @@ def _resolve_target_entry_ids(
         except TypeError, AttributeError, HomeAssistantError:
             pass
         else:
-            _append_entry_id(entry_ids, device_entry.primary_config_entry if device_entry else None)
+            _append_device_entry_ids(entry_ids, device_entry)
     if opnentity_id:
         try:
             entity_entry = er.async_get(hass).async_get(opnentity_id)
@@ -379,6 +363,20 @@ def _append_entry_id(entry_ids: list[str], entry_id: str | None) -> None:
     """
     if entry_id and entry_id not in entry_ids:
         entry_ids.append(entry_id)
+
+
+def _append_device_entry_ids(entry_ids: list[str], device_entry: Any | None) -> None:
+    """Append config entry IDs resolved from a device registry entry.
+
+    Args:
+        entry_ids: Existing config entry IDs.
+        device_entry: Device registry entry resolved from an explicit device target.
+    """
+    if device_entry is None:
+        return
+    _append_entry_id(entry_ids, getattr(device_entry, "primary_config_entry", None))
+    for entry_id in getattr(device_entry, "config_entries", ()):
+        _append_entry_id(entry_ids, entry_id)
 
 
 async def _get_target_clients(

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -34,6 +34,24 @@ from .const import (
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
+_SERVICE_IDENTIFIER_ERROR = "Must use service_id or service_name"
+
+
+def _validate_service_identifier(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate that a service control call includes a service identifier.
+
+    Args:
+        data: Validated service call payload.
+
+    Returns:
+        dict[str, Any]: Original service call payload.
+
+    Raises:
+        vol.Invalid: If neither ``service_id`` nor ``service_name`` was supplied.
+    """
+    if data.get("service_id") or data.get("service_name"):
+        return data
+    raise vol.Invalid(_SERVICE_IDENTIFIER_ERROR)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -55,20 +73,23 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         service=SERVICE_START_SERVICE,
         schema=vol.Schema(
-            {
-                vol.Exclusive(
-                    "service_id",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Exclusive(
-                    "service_name",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
+            vol.All(
+                {
+                    vol.Exclusive(
+                        "service_id",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Exclusive(
+                        "service_name",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Optional("device_id"): vol.Any(cv.string),
+                    vol.Optional("entity_id"): vol.Any(cv.string),
+                },
+                _validate_service_identifier,
+            )
         ),
         service_func=functools.partial(_service_start_service, hass),
     )
@@ -77,20 +98,23 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         service=SERVICE_STOP_SERVICE,
         schema=vol.Schema(
-            {
-                vol.Exclusive(
-                    "service_id",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Exclusive(
-                    "service_name",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
+            vol.All(
+                {
+                    vol.Exclusive(
+                        "service_id",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Exclusive(
+                        "service_name",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Optional("device_id"): vol.Any(cv.string),
+                    vol.Optional("entity_id"): vol.Any(cv.string),
+                },
+                _validate_service_identifier,
+            )
         ),
         service_func=functools.partial(_service_stop_service, hass),
     )
@@ -99,21 +123,24 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         service=SERVICE_RESTART_SERVICE,
         schema=vol.Schema(
-            {
-                vol.Exclusive(
-                    "service_id",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Exclusive(
-                    "service_name",
-                    "service_type",
-                    msg="Must use service_id or service_name but not both",
-                ): cv.string,
-                vol.Optional("only_if_running"): cv.boolean,
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
+            vol.All(
+                {
+                    vol.Exclusive(
+                        "service_id",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Exclusive(
+                        "service_name",
+                        "service_type",
+                        msg="Must use service_id or service_name but not both",
+                    ): cv.string,
+                    vol.Optional("only_if_running"): cv.boolean,
+                    vol.Optional("device_id"): vol.Any(cv.string),
+                    vol.Optional("entity_id"): vol.Any(cv.string),
+                },
+                _validate_service_identifier,
+            )
         ),
         service_func=functools.partial(_service_restart_service, hass),
     )
@@ -261,6 +288,9 @@ async def _get_clients(
         services.
         opndevice_id: Device identifier used to target the correct OPNsense device or config entry.
         opnentity_id: Entity identifier used to resolve the matching OPNsense entity.
+
+    Raises:
+        ServiceValidationError: If explicit target selectors do not resolve to configured clients.
     """
     if (
         DOMAIN not in hass.data
@@ -269,7 +299,7 @@ async def _get_clients(
     ):
         return []
     first_entry_id = next(iter(hass.data[DOMAIN]))
-    if len(hass.data[DOMAIN]) == 1:
+    if len(hass.data[DOMAIN]) == 1 and not opndevice_id and not opnentity_id:
         # _LOGGER.debug(f"[get_clients] Only 1 entry. entry_id: {first_entry_id}")
         return [hass.data[DOMAIN][first_entry_id]]
 
@@ -294,13 +324,37 @@ async def _get_clients(
             # {entity_entry}")
             if entity_entry and entity_entry.config_entry_id not in entry_ids:
                 entry_ids.append(entity_entry.config_entry_id)
+
+    if (opndevice_id or opnentity_id) and not entry_ids:
+        raise ServiceValidationError("No OPNsense clients match the selected target")
+
     clients: list = []
     # _LOGGER.debug(f"[get_clients] entry_ids: {entry_ids}")
     for entry_id, opnsense_client in hass.data[DOMAIN].items():
         if len(entry_ids) == 0 or entry_id in entry_ids:
             clients.append(opnsense_client)
+    if (opndevice_id or opnentity_id) and not clients:
+        raise ServiceValidationError("No OPNsense clients match the selected target")
     _LOGGER.debug("[get_clients] clients: %s", clients)
     return clients
+
+
+def _get_service_identifier(call: ServiceCall) -> str:
+    """Return the OPNsense service identifier from a service call.
+
+    Args:
+        call: Service call payload received from Home Assistant.
+
+    Returns:
+        str: OPNsense service identifier.
+
+    Raises:
+        ServiceValidationError: If no service identifier is present.
+    """
+    service_identifier = call.data.get("service_id", call.data.get("service_name"))
+    if not service_identifier:
+        raise ServiceValidationError(_SERVICE_IDENTIFIER_ERROR)
+    return service_identifier
 
 
 async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -337,6 +391,7 @@ async def _service_start_service(hass: HomeAssistant, call: ServiceCall) -> None
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
+    service_identifier = _get_service_identifier(call)
     clients: list = await _get_clients(
         hass=hass,
         opndevice_id=call.data.get("device_id", []),
@@ -344,20 +399,17 @@ async def _service_start_service(hass: HomeAssistant, call: ServiceCall) -> None
     )
     success: bool | None = None
     for client in clients:
-        response = await client.start_service(
-            call.data.get("service_id", call.data.get("service_name"))
-        )
+        response = await client.start_service(service_identifier)
         _LOGGER.debug(
             "[service_start_service] client: %s, service: %s, response: %s",
             client.name,
-            call.data.get("service_id", call.data.get("service_name")),
+            service_identifier,
             response,
         )
         if success is None or success:
             success = response
     if success is None or not success:
-        service_name = call.data.get("service_id", call.data.get("service_name"))
-        raise ServiceValidationError(f"Start Service Failed. service: {service_name}")
+        raise ServiceValidationError(f"Start Service Failed. service: {service_identifier}")
 
 
 async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -372,6 +424,7 @@ async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
+    service_identifier = _get_service_identifier(call)
     clients: list = await _get_clients(
         hass=hass,
         opndevice_id=call.data.get("device_id", []),
@@ -379,20 +432,17 @@ async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
     )
     success: bool | None = None
     for client in clients:
-        response = await client.stop_service(
-            call.data.get("service_id", call.data.get("service_name"))
-        )
+        response = await client.stop_service(service_identifier)
         _LOGGER.debug(
             "[service_stop_service] client: %s, service: %s, response: %s",
             client.name,
-            call.data.get("service_id", call.data.get("service_name")),
+            service_identifier,
             response,
         )
         if success is None or success:
             success = response
     if success is None or not success:
-        service_name = call.data.get("service_id", call.data.get("service_name"))
-        raise ServiceValidationError(f"Stop Service Failed. service: {service_name}")
+        raise ServiceValidationError(f"Stop Service Failed. service: {service_identifier}")
 
 
 async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -407,6 +457,7 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
+    service_identifier = _get_service_identifier(call)
     clients: list = await _get_clients(
         hass=hass,
         opndevice_id=call.data.get("device_id", []),
@@ -415,40 +466,29 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
     success: bool | None = None
     if call.data.get("only_if_running"):
         for client in clients:
-            response = await client.restart_service_if_running(
-                call.data.get(
-                    "service_id",
-                    call.data.get("service_name"),
-                )
-            )
+            response = await client.restart_service_if_running(service_identifier)
             _LOGGER.debug(
                 "[service_restart_service] restart_service_if_running, client: %s, service: %s, "
                 "response: %s",
                 client.name,
-                call.data.get("service_id", call.data.get("service_name")),
+                service_identifier,
                 response,
             )
             if success is None or success:
                 success = response
     else:
         for client in clients:
-            response = await client.restart_service(
-                call.data.get(
-                    "service_id",
-                    call.data.get("service_name"),
-                )
-            )
+            response = await client.restart_service(service_identifier)
             _LOGGER.debug(
                 "[service_restart_service] restart_service, client: %s, service: %s, response: %s",
                 client.name,
-                call.data.get("service_id", call.data.get("service_name")),
+                service_identifier,
                 response,
             )
             if success is None or success:
                 success = response
     if success is None or not success:
-        service = call.data.get("service_id", call.data.get("service_name"))
-        raise ServiceValidationError(f"Restart Service Failed. service: {service}")
+        raise ServiceValidationError(f"Restart Service Failed. service: {service_identifier}")
 
 
 async def _service_system_halt(hass: HomeAssistant, call: ServiceCall) -> None:

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -272,7 +272,7 @@ async def _get_clients(
     hass: HomeAssistant,
     opndevice_id: str | None = None,
     opnentity_id: str | None = None,
-) -> list:
+) -> list[OPNsenseServiceClient]:
     """Resolve the OPNsense clients targeted by the current request.
 
     Args:
@@ -292,36 +292,32 @@ async def _get_clients(
         return []
     first_entry_id = next(iter(hass.data[DOMAIN]))
     if len(hass.data[DOMAIN]) == 1 and not opndevice_id and not opnentity_id:
-        # _LOGGER.debug(f"[get_clients] Only 1 entry. entry_id: {first_entry_id}")
         return [hass.data[DOMAIN][first_entry_id]]
 
-    entry_ids: list = []
+    entry_ids: list[str] = []
     if opndevice_id:
         try:
             device_entry = dr.async_get(hass).async_get(opndevice_id)
         except TypeError, AttributeError, HomeAssistantError:
             pass
         else:
-            # _LOGGER.debug(f"[get_clients] device_id: {opndevice_id}, device_entry:
-            # {device_entry}")
-            if device_entry and device_entry.primary_config_entry not in entry_ids:
-                entry_ids.append(device_entry.primary_config_entry)
+            primary_config_entry = device_entry.primary_config_entry if device_entry else None
+            if primary_config_entry and primary_config_entry not in entry_ids:
+                entry_ids.append(primary_config_entry)
     if opnentity_id:
         try:
             entity_entry = er.async_get(hass).async_get(opnentity_id)
         except TypeError, AttributeError, HomeAssistantError:
             pass
         else:
-            # _LOGGER.debug(f"[get_clients] entity_id: {opnentity_id}, entity_entry:
-            # {entity_entry}")
-            if entity_entry and entity_entry.config_entry_id not in entry_ids:
-                entry_ids.append(entity_entry.config_entry_id)
+            config_entry_id = entity_entry.config_entry_id if entity_entry else None
+            if config_entry_id and config_entry_id not in entry_ids:
+                entry_ids.append(config_entry_id)
 
     if (opndevice_id or opnentity_id) and not entry_ids:
         raise ServiceValidationError("No OPNsense clients match the selected target")
 
-    clients: list = []
-    # _LOGGER.debug(f"[get_clients] entry_ids: {entry_ids}")
+    clients: list[OPNsenseServiceClient] = []
     for entry_id, opnsense_client in hass.data[DOMAIN].items():
         if len(entry_ids) == 0 or entry_id in entry_ids:
             clients.append(opnsense_client)

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -1,6 +1,6 @@
 """The OPNsense HA Services/Actions."""
 
-from collections.abc import MutableMapping
+from collections.abc import Awaitable, Callable, MutableMapping
 import functools
 import logging
 from typing import Any
@@ -35,6 +35,10 @@ from .const import (
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
 _SERVICE_IDENTIFIER_ERROR = "Must use service_id or service_name"
+_SERVICE_IDENTIFIER_CONFLICT_ERROR = "Must use service_id or service_name but not both"
+type OPNsenseServiceClient = Any
+type ServiceHandler = Callable[[HomeAssistant, ServiceCall], Awaitable[Any]]
+type BooleanClientAction = Callable[[OPNsenseServiceClient], Awaitable[bool]]
 
 
 def _validate_service_identifier(data: dict[str, Any]) -> dict[str, Any]:
@@ -54,211 +58,202 @@ def _validate_service_identifier(data: dict[str, Any]) -> dict[str, Any]:
     raise vol.Invalid(_SERVICE_IDENTIFIER_ERROR)
 
 
+def _target_fields() -> dict[Any, Any]:
+    """Return the common optional OPNsense target selector fields.
+
+    Returns:
+        dict[Any, Any]: Voluptuous field definitions for OPNsense device/entity selectors.
+    """
+    return {
+        vol.Optional("device_id"): vol.Any(cv.string),
+        vol.Optional("entity_id"): vol.Any(cv.string),
+    }
+
+
+def _service_identifier_fields() -> dict[Any, Any]:
+    """Return fields that identify an OPNsense service.
+
+    Returns:
+        dict[Any, Any]: Voluptuous field definitions for service identifiers.
+    """
+    return {
+        vol.Exclusive(
+            "service_id",
+            "service_type",
+            msg=_SERVICE_IDENTIFIER_CONFLICT_ERROR,
+        ): cv.string,
+        vol.Exclusive(
+            "service_name",
+            "service_type",
+            msg=_SERVICE_IDENTIFIER_CONFLICT_ERROR,
+        ): cv.string,
+    }
+
+
+def _service_control_schema(extra_fields: dict[Any, Any] | None = None) -> vol.Schema:
+    """Build a schema for service start, stop, and restart actions.
+
+    Args:
+        extra_fields: Additional fields to include in the schema.
+
+    Returns:
+        vol.Schema: Service control schema with identifier validation.
+    """
+    fields = _service_identifier_fields() | (extra_fields or {}) | _target_fields()
+    return vol.Schema(vol.All(fields, _validate_service_identifier))
+
+
+def _targeted_schema(fields: dict[Any, Any] | None = None) -> vol.Schema:
+    """Build a schema that includes optional OPNsense target selectors.
+
+    Args:
+        fields: Service-specific fields to include before target selectors.
+
+    Returns:
+        vol.Schema: Service schema with common target selector fields.
+    """
+    return vol.Schema((fields or {}) | _target_fields())
+
+
+def _register_service(
+    hass: HomeAssistant,
+    service: str,
+    service_func: ServiceHandler,
+    schema: vol.Schema,
+    supports_response: SupportsResponse | None = None,
+) -> None:
+    """Register an OPNsense service with Home Assistant.
+
+    Args:
+        hass: Home Assistant instance.
+        service: OPNsense service/action name.
+        service_func: Handler for the service call.
+        schema: Voluptuous schema for validating service data.
+        supports_response: Response support declaration for action response data.
+    """
+    kwargs: dict[str, Any] = {
+        "domain": DOMAIN,
+        "service": service,
+        "schema": schema,
+        "service_func": functools.partial(service_func, hass),
+    }
+    if supports_response is not None:
+        kwargs["supports_response"] = supports_response
+    hass.services.async_register(**kwargs)
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Create the OPNsense HA Services/Actions."""
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_CLOSE_NOTICE,
-        schema=vol.Schema(
-            {
-                vol.Required("id", default="all"): vol.Any(cv.positive_int, cv.string),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_close_notice, hass),
+    _register_service(
+        hass,
+        SERVICE_CLOSE_NOTICE,
+        _service_close_notice,
+        _targeted_schema({vol.Required("id", default="all"): vol.Any(cv.positive_int, cv.string)}),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_START_SERVICE,
-        schema=vol.Schema(
-            vol.All(
-                {
-                    vol.Exclusive(
-                        "service_id",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Exclusive(
-                        "service_name",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Optional("device_id"): vol.Any(cv.string),
-                    vol.Optional("entity_id"): vol.Any(cv.string),
-                },
-                _validate_service_identifier,
-            )
-        ),
-        service_func=functools.partial(_service_start_service, hass),
+    _register_service(
+        hass,
+        SERVICE_START_SERVICE,
+        _service_start_service,
+        _service_control_schema(),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_STOP_SERVICE,
-        schema=vol.Schema(
-            vol.All(
-                {
-                    vol.Exclusive(
-                        "service_id",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Exclusive(
-                        "service_name",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Optional("device_id"): vol.Any(cv.string),
-                    vol.Optional("entity_id"): vol.Any(cv.string),
-                },
-                _validate_service_identifier,
-            )
-        ),
-        service_func=functools.partial(_service_stop_service, hass),
+    _register_service(
+        hass,
+        SERVICE_STOP_SERVICE,
+        _service_stop_service,
+        _service_control_schema(),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_RESTART_SERVICE,
-        schema=vol.Schema(
-            vol.All(
-                {
-                    vol.Exclusive(
-                        "service_id",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Exclusive(
-                        "service_name",
-                        "service_type",
-                        msg="Must use service_id or service_name but not both",
-                    ): cv.string,
-                    vol.Optional("only_if_running"): cv.boolean,
-                    vol.Optional("device_id"): vol.Any(cv.string),
-                    vol.Optional("entity_id"): vol.Any(cv.string),
-                },
-                _validate_service_identifier,
-            )
-        ),
-        service_func=functools.partial(_service_restart_service, hass),
+    _register_service(
+        hass,
+        SERVICE_RESTART_SERVICE,
+        _service_restart_service,
+        _service_control_schema({vol.Optional("only_if_running"): cv.boolean}),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_SYSTEM_HALT,
-        schema=vol.Schema(
-            {
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_system_halt, hass),
+    _register_service(
+        hass,
+        SERVICE_SYSTEM_HALT,
+        _service_system_halt,
+        _targeted_schema(),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_SYSTEM_REBOOT,
-        schema=vol.Schema(
-            {
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_system_reboot, hass),
+    _register_service(
+        hass,
+        SERVICE_SYSTEM_REBOOT,
+        _service_system_reboot,
+        _targeted_schema(),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_SEND_WOL,
-        schema=vol.Schema(
+    _register_service(
+        hass,
+        SERVICE_SEND_WOL,
+        _service_send_wol,
+        _targeted_schema(
             {
                 vol.Required("interface"): vol.Any(cv.string),
                 vol.Required("mac"): vol.Any(cv.string),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
             }
         ),
-        service_func=functools.partial(_service_send_wol, hass),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_RELOAD_INTERFACE,
-        schema=vol.Schema(
-            {
-                vol.Required("interface"): vol.Any(cv.string),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_reload_interface, hass),
+    _register_service(
+        hass,
+        SERVICE_RELOAD_INTERFACE,
+        _service_reload_interface,
+        _targeted_schema({vol.Required("interface"): vol.Any(cv.string)}),
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_GENERATE_VOUCHERS,
-        schema=vol.Schema(
+    _register_service(
+        hass,
+        SERVICE_GENERATE_VOUCHERS,
+        _service_generate_vouchers,
+        _targeted_schema(
             {
                 vol.Required("validity"): vol.Any(cv.string),
                 vol.Required("expirytime"): vol.Any(cv.string),
                 vol.Required("count"): vol.Any(cv.string),
                 vol.Required("vouchergroup"): vol.Any(cv.string),
                 vol.Optional("voucher_server"): vol.Any(cv.string),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
             }
         ),
-        service_func=functools.partial(_service_generate_vouchers, hass),
-        supports_response=SupportsResponse.ONLY,
+        SupportsResponse.ONLY,
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_KILL_STATES,
-        schema=vol.Schema(
-            {
-                vol.Required("ip_addr"): vol.Any(cv.string),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_kill_states, hass),
-        supports_response=SupportsResponse.OPTIONAL,
+    _register_service(
+        hass,
+        SERVICE_KILL_STATES,
+        _service_kill_states,
+        _targeted_schema({vol.Required("ip_addr"): vol.Any(cv.string)}),
+        SupportsResponse.OPTIONAL,
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_RUN_SPEEDTEST,
-        schema=vol.Schema(
-            {
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
-            }
-        ),
-        service_func=functools.partial(_service_run_speedtest, hass),
-        supports_response=SupportsResponse.ONLY,
+    _register_service(
+        hass,
+        SERVICE_RUN_SPEEDTEST,
+        _service_run_speedtest,
+        _targeted_schema(),
+        SupportsResponse.ONLY,
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_GET_VNSTAT_METRICS,
-        schema=vol.Schema(
+    _register_service(
+        hass,
+        SERVICE_GET_VNSTAT_METRICS,
+        _service_get_vnstat_metrics,
+        _targeted_schema(
             {
                 vol.Required("period"): vol.All(cv.string, vol.Lower, vol.In(_VNSTAT_PERIODS)),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
             }
         ),
-        service_func=functools.partial(_service_get_vnstat_metrics, hass),
-        supports_response=SupportsResponse.ONLY,
+        SupportsResponse.ONLY,
     )
 
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=SERVICE_TOGGLE_ALIAS,
-        schema=vol.Schema(
+    _register_service(
+        hass,
+        SERVICE_TOGGLE_ALIAS,
+        _service_toggle_alias,
+        _targeted_schema(
             {
                 vol.Required("alias"): vol.Any(cv.string),
                 vol.Required("toggle_on_off", default="toggle"): vol.In(
@@ -268,11 +263,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         "off": "Off",
                     }
                 ),
-                vol.Optional("device_id"): vol.Any(cv.string),
-                vol.Optional("entity_id"): vol.Any(cv.string),
             }
         ),
-        service_func=functools.partial(_service_toggle_alias, hass),
     )
 
 
@@ -357,6 +349,44 @@ def _get_service_identifier(call: ServiceCall) -> str:
     return service_identifier
 
 
+async def _run_boolean_client_action(
+    clients: list[OPNsenseServiceClient],
+    log_prefix: str,
+    target_name: str,
+    target_value: Any,
+    failure_message: str,
+    action: BooleanClientAction,
+) -> None:
+    """Run a boolean-returning action across all selected clients.
+
+    Args:
+        clients: OPNsense clients selected for the service call.
+        log_prefix: Prefix used in the debug log message.
+        target_name: Human-readable target field name for logs.
+        target_value: Target value passed to the client action.
+        failure_message: Error message to raise if no clients or any client action fails.
+        action: Awaitable client action returning success state.
+
+    Raises:
+        ServiceValidationError: If no selected clients report success or any selected client fails.
+    """
+    success: bool | None = None
+    for client in clients:
+        response = await action(client)
+        _LOGGER.debug(
+            "[%s] client: %s, %s: %s, response: %s",
+            log_prefix,
+            client.name,
+            target_name,
+            target_value,
+            response,
+        )
+        if success is None or success:
+            success = response
+    if success is None or not success:
+        raise ServiceValidationError(failure_message)
+
+
 async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle the close notice service call.
 
@@ -397,19 +427,14 @@ async def _service_start_service(hass: HomeAssistant, call: ServiceCall) -> None
         opndevice_id=call.data.get("device_id", []),
         opnentity_id=call.data.get("entity_id", []),
     )
-    success: bool | None = None
-    for client in clients:
-        response = await client.start_service(service_identifier)
-        _LOGGER.debug(
-            "[service_start_service] client: %s, service: %s, response: %s",
-            client.name,
-            service_identifier,
-            response,
-        )
-        if success is None or success:
-            success = response
-    if success is None or not success:
-        raise ServiceValidationError(f"Start Service Failed. service: {service_identifier}")
+    await _run_boolean_client_action(
+        clients=clients,
+        log_prefix="service_start_service",
+        target_name="service",
+        target_value=service_identifier,
+        failure_message=f"Start Service Failed. service: {service_identifier}",
+        action=lambda client: client.start_service(service_identifier),
+    )
 
 
 async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -430,19 +455,14 @@ async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
         opndevice_id=call.data.get("device_id", []),
         opnentity_id=call.data.get("entity_id", []),
     )
-    success: bool | None = None
-    for client in clients:
-        response = await client.stop_service(service_identifier)
-        _LOGGER.debug(
-            "[service_stop_service] client: %s, service: %s, response: %s",
-            client.name,
-            service_identifier,
-            response,
-        )
-        if success is None or success:
-            success = response
-    if success is None or not success:
-        raise ServiceValidationError(f"Stop Service Failed. service: {service_identifier}")
+    await _run_boolean_client_action(
+        clients=clients,
+        log_prefix="service_stop_service",
+        target_name="service",
+        target_value=service_identifier,
+        failure_message=f"Stop Service Failed. service: {service_identifier}",
+        action=lambda client: client.stop_service(service_identifier),
+    )
 
 
 async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -463,32 +483,24 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
         opndevice_id=call.data.get("device_id", []),
         opnentity_id=call.data.get("entity_id", []),
     )
-    success: bool | None = None
     if call.data.get("only_if_running"):
-        for client in clients:
-            response = await client.restart_service_if_running(service_identifier)
-            _LOGGER.debug(
-                "[service_restart_service] restart_service_if_running, client: %s, service: %s, "
-                "response: %s",
-                client.name,
-                service_identifier,
-                response,
-            )
-            if success is None or success:
-                success = response
+        await _run_boolean_client_action(
+            clients=clients,
+            log_prefix="service_restart_service] restart_service_if_running",
+            target_name="service",
+            target_value=service_identifier,
+            failure_message=f"Restart Service Failed. service: {service_identifier}",
+            action=lambda client: client.restart_service_if_running(service_identifier),
+        )
     else:
-        for client in clients:
-            response = await client.restart_service(service_identifier)
-            _LOGGER.debug(
-                "[service_restart_service] restart_service, client: %s, service: %s, response: %s",
-                client.name,
-                service_identifier,
-                response,
-            )
-            if success is None or success:
-                success = response
-    if success is None or not success:
-        raise ServiceValidationError(f"Restart Service Failed. service: {service_identifier}")
+        await _run_boolean_client_action(
+            clients=clients,
+            log_prefix="service_restart_service] restart_service",
+            target_name="service",
+            target_value=service_identifier,
+            failure_message=f"Restart Service Failed. service: {service_identifier}",
+            action=lambda client: client.restart_service(service_identifier),
+        )
 
 
 async def _service_system_halt(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -567,19 +579,15 @@ async def _service_reload_interface(hass: HomeAssistant, call: ServiceCall) -> N
         opndevice_id=call.data.get("device_id", []),
         opnentity_id=call.data.get("entity_id", []),
     )
-    success: bool | None = None
-    for client in clients:
-        response = await client.reload_interface(call.data.get("interface"))
-        _LOGGER.debug(
-            "[service_reload_interface] client: %s, interface: %s, response: %s",
-            client.name,
-            call.data.get("interface"),
-            response,
-        )
-        if success is None or success:
-            success = response
-    if success is None or not success:
-        raise ServiceValidationError(f"Reload Interface Failed: {call.data.get('interface')}")
+    interface = call.data.get("interface")
+    await _run_boolean_client_action(
+        clients=clients,
+        log_prefix="service_reload_interface",
+        target_name="interface",
+        target_value=interface,
+        failure_message=f"Reload Interface Failed: {interface}",
+        action=lambda client: client.reload_interface(interface),
+    )
 
 
 async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> ServiceResponse:
@@ -615,11 +623,9 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
         if isinstance(vouchers, list):
             for voucher in vouchers:
                 if isinstance(voucher, MutableMapping):
-                    new_voucher = {"client": client.name}
-                    new_voucher.update(voucher)
-                    voucher.clear()
-                    voucher.update(new_voucher)
-            voucher_list.extend(vouchers)
+                    voucher_list.append({"client": client.name, **voucher})
+                else:
+                    voucher_list.append(voucher)
     final_vouchers: dict[str, Any] = {"vouchers": voucher_list}
     _LOGGER.debug("[service_generate_vouchers] vouchers: %s", final_vouchers)
     return final_vouchers
@@ -762,19 +768,13 @@ async def _service_toggle_alias(hass: HomeAssistant, call: ServiceCall) -> None:
         opndevice_id=call.data.get("device_id", []),
         opnentity_id=call.data.get("entity_id", []),
     )
-    success: bool | None = None
-    for client in clients:
-        response = await client.toggle_alias(call.data.get("alias"), call.data.get("toggle_on_off"))
-        _LOGGER.debug(
-            "[service_toggle_alias] client: %s, alias: %s, response: %s",
-            client.name,
-            call.data.get("alias"),
-            response,
-        )
-        if success is None or success:
-            success = response
-    if success is None or not success:
-        raise ServiceValidationError(
-            f"Toggle Alias Failed. alias: {call.data.get('alias')}, action: "
-            f"{call.data.get('toggle_on_off')}"
-        )
+    alias = call.data.get("alias")
+    toggle_on_off = call.data.get("toggle_on_off")
+    await _run_boolean_client_action(
+        clients=clients,
+        log_prefix="service_toggle_alias",
+        target_name="alias",
+        target_value=alias,
+        failure_message=f"Toggle Alias Failed. alias: {alias}, action: {toggle_on_off}",
+        action=lambda client: client.toggle_alias(alias, toggle_on_off),
+    )

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -287,13 +287,43 @@ async def _get_clients(
     if (
         DOMAIN not in hass.data
         or not isinstance(hass.data[DOMAIN], MutableMapping)
-        or len(hass.data[DOMAIN]) == 0
+        or not hass.data[DOMAIN]
     ):
         return []
     first_entry_id = next(iter(hass.data[DOMAIN]))
     if len(hass.data[DOMAIN]) == 1 and not opndevice_id and not opnentity_id:
         return [hass.data[DOMAIN][first_entry_id]]
 
+    entry_ids = _resolve_target_entry_ids(hass, opndevice_id, opnentity_id)
+
+    if (opndevice_id or opnentity_id) and not entry_ids:
+        raise ServiceValidationError("No OPNsense clients match the selected target")
+
+    clients: list[OPNsenseServiceClient] = []
+    for entry_id, opnsense_client in hass.data[DOMAIN].items():
+        if not entry_ids or entry_id in entry_ids:
+            clients.append(opnsense_client)
+    if (opndevice_id or opnentity_id) and not clients:
+        raise ServiceValidationError("No OPNsense clients match the selected target")
+    _LOGGER.debug("[get_clients] clients: %s", clients)
+    return clients
+
+
+def _resolve_target_entry_ids(
+    hass: HomeAssistant,
+    opndevice_id: str | None,
+    opnentity_id: str | None,
+) -> list[str]:
+    """Resolve selected device/entity registry targets to config entry IDs.
+
+    Args:
+        hass: Home Assistant instance that owns the registries.
+        opndevice_id: Optional device registry target.
+        opnentity_id: Optional entity registry target.
+
+    Returns:
+        list[str]: Unique config entry IDs resolved from selected targets.
+    """
     entry_ids: list[str] = []
     if opndevice_id:
         try:
@@ -301,30 +331,26 @@ async def _get_clients(
         except TypeError, AttributeError, HomeAssistantError:
             pass
         else:
-            primary_config_entry = device_entry.primary_config_entry if device_entry else None
-            if primary_config_entry and primary_config_entry not in entry_ids:
-                entry_ids.append(primary_config_entry)
+            _append_entry_id(entry_ids, device_entry.primary_config_entry if device_entry else None)
     if opnentity_id:
         try:
             entity_entry = er.async_get(hass).async_get(opnentity_id)
         except TypeError, AttributeError, HomeAssistantError:
             pass
         else:
-            config_entry_id = entity_entry.config_entry_id if entity_entry else None
-            if config_entry_id and config_entry_id not in entry_ids:
-                entry_ids.append(config_entry_id)
+            _append_entry_id(entry_ids, entity_entry.config_entry_id if entity_entry else None)
+    return entry_ids
 
-    if (opndevice_id or opnentity_id) and not entry_ids:
-        raise ServiceValidationError("No OPNsense clients match the selected target")
 
-    clients: list[OPNsenseServiceClient] = []
-    for entry_id, opnsense_client in hass.data[DOMAIN].items():
-        if len(entry_ids) == 0 or entry_id in entry_ids:
-            clients.append(opnsense_client)
-    if (opndevice_id or opnentity_id) and not clients:
-        raise ServiceValidationError("No OPNsense clients match the selected target")
-    _LOGGER.debug("[get_clients] clients: %s", clients)
-    return clients
+def _append_entry_id(entry_ids: list[str], entry_id: str | None) -> None:
+    """Append a resolved config entry ID once.
+
+    Args:
+        entry_ids: Existing config entry IDs.
+        entry_id: Config entry ID resolved from a registry target.
+    """
+    if entry_id and entry_id not in entry_ids:
+        entry_ids.append(entry_id)
 
 
 async def _get_target_clients(
@@ -439,13 +465,13 @@ async def _collect_mapping_results(
             action_context or {},
             response,
         )
-        if not isinstance(response, MutableMapping) or len(response) == 0:
+        if not isinstance(response, MutableMapping) or not response:
             continue
         result: dict[str, Any] = {"client_name": client.name}
         result.update(dict(response))
         response_list.append(result)
 
-    if len(response_list) == 0:
+    if not response_list:
         raise ServiceValidationError(failure_message)
     return response_list
 

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -494,6 +494,48 @@ async def _collect_kill_state_results(
     return response_list
 
 
+async def _collect_voucher_results(
+    clients: list[OPNsenseServiceClient],
+    call_data: dict[str, Any],
+) -> list[Any]:
+    """Collect generated vouchers from selected clients.
+
+    Args:
+        clients: OPNsense clients selected for the service call.
+        call_data: Validated Home Assistant voucher-generation service payload.
+
+    Returns:
+        list[Any]: Voucher response items with client names added to mapping entries.
+
+    Raises:
+        ServiceValidationError: If no OPNsense clients are selected or the voucher server fails.
+    """
+    if not clients:
+        raise ServiceValidationError("Generate Vouchers Failed. No selected OPNsense clients")
+
+    voucher_list: list[Any] = []
+    for client in clients:
+        try:
+            vouchers: list[Any] = await client.generate_vouchers(call_data)
+        except OPNsenseVoucherServerError as e:
+            _LOGGER.error("Error getting vouchers from %s. %s", client.name, e)
+            raise ServiceValidationError(f"Error getting vouchers from {client.name}. {e}") from e
+        _LOGGER.debug(
+            "[service_generate_vouchers] client: %s, data: %s, vouchers: %s",
+            client.name,
+            call_data,
+            vouchers,
+        )
+        if not isinstance(vouchers, list):
+            continue
+        for voucher in vouchers:
+            if isinstance(voucher, MutableMapping):
+                voucher_list.append({"client": client.name, **voucher})
+            else:
+                voucher_list.append(voucher)
+    return voucher_list
+
+
 async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle the close notice service call.
 
@@ -683,25 +725,7 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
         required value.
     """
     clients = await _get_target_clients(hass, call)
-    voucher_list: list = []
-    for client in clients:
-        try:
-            vouchers: list = await client.generate_vouchers(call.data)
-        except OPNsenseVoucherServerError as e:
-            _LOGGER.error("Error getting vouchers from %s. %s", client.name, e)
-            raise ServiceValidationError(f"Error getting vouchers from {client.name}. {e}") from e
-        _LOGGER.debug(
-            "[service_generate_vouchers] client: %s, data: %s, vouchers: %s",
-            client.name,
-            call.data,
-            vouchers,
-        )
-        if isinstance(vouchers, list):
-            for voucher in vouchers:
-                if isinstance(voucher, MutableMapping):
-                    voucher_list.append({"client": client.name, **voucher})
-                else:
-                    voucher_list.append(voucher)
+    voucher_list = await _collect_voucher_results(clients, dict(call.data))
     final_vouchers: dict[str, Any] = {"vouchers": voucher_list}
     _LOGGER.debug("[service_generate_vouchers] vouchers: %s", final_vouchers)
     return final_vouchers

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -454,6 +454,46 @@ async def _collect_mapping_results(
     return response_list
 
 
+async def _collect_kill_state_results(
+    clients: list[OPNsenseServiceClient],
+    ip_addr: str,
+) -> list[dict[str, Any]]:
+    """Collect dropped state counts from selected clients.
+
+    Args:
+        clients: OPNsense clients selected for the service call.
+        ip_addr: IP address whose firewall states should be killed.
+
+    Returns:
+        list[dict[str, Any]]: Successful per-client dropped state counts.
+
+    Raises:
+        ServiceValidationError: If no selected clients report success or any selected client fails.
+    """
+    success: bool | None = None
+    response_list: list[dict[str, Any]] = []
+    for client in clients:
+        response: dict[str, Any] = await client.kill_states(ip_addr)
+        _LOGGER.debug(
+            "[service_kill_states] client: %s, ip_addr: %s, response: %s",
+            client.name,
+            ip_addr,
+            response,
+        )
+        if response.get("success", False):
+            response_list.append(
+                {
+                    "client_name": client.name,
+                    "dropped_states": response.get("dropped_states", 0),
+                }
+            )
+        if success is None or success:
+            success = response.get("success", False)
+    if success is None or not success:
+        raise ServiceValidationError(f"Kill States Failed: {ip_addr}")
+    return response_list
+
+
 async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle the close notice service call.
 
@@ -680,27 +720,7 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
         required value.
     """
     clients = await _get_target_clients(hass, call)
-    success: bool | None = None
-    response_list: list = []
-    for client in clients:
-        response: dict[str, Any] = await client.kill_states(call.data.get("ip_addr"))
-        _LOGGER.debug(
-            "[service_kill_states] client: %s, ip_addr: %s, response: %s",
-            client.name,
-            call.data.get("ip_addr"),
-            response,
-        )
-        if response.get("success", False):
-            response_list.append(
-                {
-                    "client_name": client.name,
-                    "dropped_states": response.get("dropped_states", 0),
-                }
-            )
-        if success is None or success:
-            success = response.get("success", False)
-    if success is None or not success:
-        raise ServiceValidationError(f"Kill States Failed: {call.data.get('ip_addr')}")
+    response_list = await _collect_kill_state_results(clients, call.data["ip_addr"])
     return_response: dict[str, Any] = {"dropped_states": response_list}
     _LOGGER.debug("[service_kill_states] return_response: %s", return_response)
     if return_response:

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -747,9 +747,7 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
     response_list = await _collect_kill_state_results(clients, call.data["ip_addr"])
     return_response: dict[str, Any] = {"dropped_states": response_list}
     _LOGGER.debug("[service_kill_states] return_response: %s", return_response)
-    if return_response:
-        return return_response
-    return None
+    return return_response
 
 
 async def _service_run_speedtest(hass: HomeAssistant, call: ServiceCall) -> ServiceResponse:

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -36,9 +36,43 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
 _SERVICE_IDENTIFIER_ERROR = "Must use service_id or service_name"
 _SERVICE_IDENTIFIER_CONFLICT_ERROR = "Must use service_id or service_name but not both"
+_TRANSLATION_KEY_GENERATE_VOUCHERS_FAILED = "generate_vouchers_failed"
+_TRANSLATION_KEY_GET_VNSTAT_METRICS_FAILED = "get_vnstat_metrics_failed"
+_TRANSLATION_KEY_KILL_STATES_FAILED = "kill_states_failed"
+_TRANSLATION_KEY_NO_TARGET_CLIENTS = "no_target_clients"
+_TRANSLATION_KEY_RELOAD_INTERFACE_FAILED = "reload_interface_failed"
+_TRANSLATION_KEY_RESTART_SERVICE_FAILED = "restart_service_failed"
+_TRANSLATION_KEY_RUN_SPEEDTEST_FAILED = "run_speedtest_failed"
+_TRANSLATION_KEY_SERVICE_IDENTIFIER_REQUIRED = "service_identifier_required"
+_TRANSLATION_KEY_START_SERVICE_FAILED = "start_service_failed"
+_TRANSLATION_KEY_STOP_SERVICE_FAILED = "stop_service_failed"
+_TRANSLATION_KEY_TOGGLE_ALIAS_FAILED = "toggle_alias_failed"
+_TRANSLATION_KEY_VOUCHER_SERVER_ERROR = "voucher_server_error"
 type OPNsenseServiceClient = Any
 type ServiceHandler = Callable[[HomeAssistant, ServiceCall], Awaitable[Any]]
 type BooleanClientAction = Callable[[OPNsenseServiceClient], Awaitable[bool]]
+
+
+def _service_validation_error(
+    translation_key: str,
+    translation_placeholders: dict[str, Any] | None = None,
+) -> ServiceValidationError:
+    """Return a localized service validation error.
+
+    Args:
+        translation_key: Translation key from the integration ``exceptions`` section.
+        translation_placeholders: Values to interpolate into the translated message.
+
+    Returns:
+        ServiceValidationError: Home Assistant service validation error with translation metadata.
+    """
+    return ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key=translation_key,
+        translation_placeholders={
+            key: str(value) for key, value in (translation_placeholders or {}).items()
+        },
+    )
 
 
 def _validate_service_identifier(data: dict[str, Any]) -> dict[str, Any]:
@@ -256,13 +290,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         _targeted_schema(
             {
                 vol.Required("alias"): vol.Any(cv.string),
-                vol.Required("toggle_on_off", default="toggle"): vol.In(
-                    {
-                        "toggle": "Toggle",
-                        "on": "On",
-                        "off": "Off",
-                    }
-                ),
+                vol.Required("toggle_on_off", default="toggle"): vol.In(("toggle", "on", "off")),
             }
         ),
     )
@@ -297,14 +325,14 @@ async def _get_clients(
     entry_ids = _resolve_target_entry_ids(hass, opndevice_id, opnentity_id)
 
     if (opndevice_id or opnentity_id) and not entry_ids:
-        raise ServiceValidationError("No OPNsense clients match the selected target")
+        raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
 
     clients: list[OPNsenseServiceClient] = []
     for entry_id, opnsense_client in hass.data[DOMAIN].items():
         if not entry_ids or entry_id in entry_ids:
             clients.append(opnsense_client)
     if (opndevice_id or opnentity_id) and not clients:
-        raise ServiceValidationError("No OPNsense clients match the selected target")
+        raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
     _LOGGER.debug("[get_clients] clients: %s", clients)
     return clients
 
@@ -387,7 +415,7 @@ def _get_service_identifier(call: ServiceCall) -> str:
     """
     service_identifier = call.data.get("service_id", call.data.get("service_name"))
     if not service_identifier:
-        raise ServiceValidationError(_SERVICE_IDENTIFIER_ERROR)
+        raise _service_validation_error(_TRANSLATION_KEY_SERVICE_IDENTIFIER_REQUIRED)
     return service_identifier
 
 
@@ -397,7 +425,8 @@ async def _run_boolean_client_action(
     action_name: str | None,
     target_name: str,
     target_value: Any,
-    failure_message: str,
+    failure_translation_key: str,
+    failure_translation_placeholders: dict[str, Any],
     action: BooleanClientAction,
 ) -> None:
     """Run a boolean-returning action across all selected clients.
@@ -408,7 +437,8 @@ async def _run_boolean_client_action(
         action_name: Optional action variant to include after the log prefix.
         target_name: Human-readable target field name for logs.
         target_value: Target value passed to the client action.
-        failure_message: Error message to raise if no clients or any client action fails.
+        failure_translation_key: Translation key to raise if no clients or any action fails.
+        failure_translation_placeholders: Values to interpolate into the translated error.
         action: Awaitable client action returning success state.
 
     Raises:
@@ -430,13 +460,14 @@ async def _run_boolean_client_action(
         if success is None or success:
             success = response
     if success is None or not success:
-        raise ServiceValidationError(failure_message)
+        raise _service_validation_error(failure_translation_key, failure_translation_placeholders)
 
 
 async def _collect_mapping_results(
     clients: list[OPNsenseServiceClient],
     log_prefix: str,
-    failure_message: str,
+    failure_translation_key: str,
+    failure_translation_placeholders: dict[str, Any] | None,
     action: Callable[[OPNsenseServiceClient], Awaitable[Any]],
     action_context: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
@@ -445,7 +476,8 @@ async def _collect_mapping_results(
     Args:
         clients: OPNsense clients selected for the service call.
         log_prefix: Prefix used in the debug log message.
-        failure_message: Error message to raise if no clients return data.
+        failure_translation_key: Translation key to raise if no clients return data.
+        failure_translation_placeholders: Values to interpolate into the translated error.
         action: Awaitable client action returning a mapping payload.
         action_context: Optional values to include in debug logs.
 
@@ -472,7 +504,10 @@ async def _collect_mapping_results(
         response_list.append(result)
 
     if not response_list:
-        raise ServiceValidationError(failure_message)
+        raise _service_validation_error(
+            failure_translation_key,
+            failure_translation_placeholders,
+        )
     return response_list
 
 
@@ -512,7 +547,10 @@ async def _collect_kill_state_results(
         if success is None or success:
             success = response.get("success", False)
     if success is None or not success:
-        raise ServiceValidationError(f"Kill States Failed: {ip_addr}")
+        raise _service_validation_error(
+            _TRANSLATION_KEY_KILL_STATES_FAILED,
+            {"ip_addr": ip_addr},
+        )
     return response_list
 
 
@@ -533,7 +571,7 @@ async def _collect_voucher_results(
         ServiceValidationError: If no OPNsense clients are selected or the voucher server fails.
     """
     if not clients:
-        raise ServiceValidationError("Generate Vouchers Failed. No selected OPNsense clients")
+        raise _service_validation_error(_TRANSLATION_KEY_GENERATE_VOUCHERS_FAILED)
 
     voucher_list: list[Any] = []
     for client in clients:
@@ -541,7 +579,10 @@ async def _collect_voucher_results(
             vouchers: list[Any] = await client.generate_vouchers(call_data)
         except OPNsenseVoucherServerError as e:
             _LOGGER.error("Error getting vouchers from %s. %s", client.name, e)
-            raise ServiceValidationError(f"Error getting vouchers from {client.name}. {e}") from e
+            raise _service_validation_error(
+                _TRANSLATION_KEY_VOUCHER_SERVER_ERROR,
+                {"client": client.name, "error": e},
+            ) from e
         _LOGGER.debug(
             "[service_generate_vouchers] client: %s, data: %s, vouchers: %s",
             client.name,
@@ -596,7 +637,8 @@ async def _service_start_service(hass: HomeAssistant, call: ServiceCall) -> None
         action_name=None,
         target_name="service",
         target_value=service_identifier,
-        failure_message=f"Start Service Failed. service: {service_identifier}",
+        failure_translation_key=_TRANSLATION_KEY_START_SERVICE_FAILED,
+        failure_translation_placeholders={"service": service_identifier},
         action=lambda client: client.start_service(service_identifier),
     )
 
@@ -621,7 +663,8 @@ async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
         action_name=None,
         target_name="service",
         target_value=service_identifier,
-        failure_message=f"Stop Service Failed. service: {service_identifier}",
+        failure_translation_key=_TRANSLATION_KEY_STOP_SERVICE_FAILED,
+        failure_translation_placeholders={"service": service_identifier},
         action=lambda client: client.stop_service(service_identifier),
     )
 
@@ -647,7 +690,8 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
             action_name="restart_service_if_running",
             target_name="service",
             target_value=service_identifier,
-            failure_message=f"Restart Service Failed. service: {service_identifier}",
+            failure_translation_key=_TRANSLATION_KEY_RESTART_SERVICE_FAILED,
+            failure_translation_placeholders={"service": service_identifier},
             action=lambda client: client.restart_service_if_running(service_identifier),
         )
     else:
@@ -657,7 +701,8 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
             action_name="restart_service",
             target_name="service",
             target_value=service_identifier,
-            failure_message=f"Restart Service Failed. service: {service_identifier}",
+            failure_translation_key=_TRANSLATION_KEY_RESTART_SERVICE_FAILED,
+            failure_translation_placeholders={"service": service_identifier},
             action=lambda client: client.restart_service(service_identifier),
         )
 
@@ -729,7 +774,8 @@ async def _service_reload_interface(hass: HomeAssistant, call: ServiceCall) -> N
         action_name=None,
         target_name="interface",
         target_value=interface,
-        failure_message=f"Reload Interface Failed: {interface}",
+        failure_translation_key=_TRANSLATION_KEY_RELOAD_INTERFACE_FAILED,
+        failure_translation_placeholders={"interface": interface},
         action=lambda client: client.reload_interface(interface),
     )
 
@@ -786,9 +832,8 @@ async def _service_run_speedtest(hass: HomeAssistant, call: ServiceCall) -> Serv
     response_list = await _collect_mapping_results(
         clients=clients,
         log_prefix="service_run_speedtest",
-        failure_message=(
-            "Run Speedtest Failed. No selected OPNsense clients have Speedtest installed"
-        ),
+        failure_translation_key=_TRANSLATION_KEY_RUN_SPEEDTEST_FAILED,
+        failure_translation_placeholders=None,
         action=lambda client: client.run_speedtest(),
     )
     return_response: dict[str, Any] = {"results": response_list}
@@ -812,7 +857,8 @@ async def _service_get_vnstat_metrics(hass: HomeAssistant, call: ServiceCall) ->
     response_list = await _collect_mapping_results(
         clients=clients,
         log_prefix="service_get_vnstat_metrics",
-        failure_message="Get vnStat Metrics Failed. No selected OPNsense clients vnStat installed",
+        failure_translation_key=_TRANSLATION_KEY_GET_VNSTAT_METRICS_FAILED,
+        failure_translation_placeholders=None,
         action=lambda client: client.get_vnstat_metrics(requested_period),
         action_context={"period": requested_period},
     )
@@ -842,6 +888,7 @@ async def _service_toggle_alias(hass: HomeAssistant, call: ServiceCall) -> None:
         action_name=None,
         target_name="alias",
         target_value=alias,
-        failure_message=f"Toggle Alias Failed. alias: {alias}, action: {toggle_on_off}",
+        failure_translation_key=_TRANSLATION_KEY_TOGGLE_ALIAS_FAILED,
+        failure_translation_placeholders={"alias": alias, "action": toggle_on_off},
         action=lambda client: client.toggle_alias(alias, toggle_on_off),
     )

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -581,17 +581,19 @@ async def _collect_voucher_results(
                 _TRANSLATION_KEY_VOUCHER_SERVER_ERROR,
                 {"client": client.name, "error": e},
             ) from e
+        voucher_count = len(vouchers) if isinstance(vouchers, list) else 0
+        voucher_status = "ok" if isinstance(vouchers, list) else "skipped_non_list"
         _LOGGER.debug(
-            "[service_generate_vouchers] client: %s, data: %s, vouchers: %s",
+            "[service_generate_vouchers] client: %s, voucher_count: %s, status: %s",
             client.name,
-            call_data,
-            vouchers,
+            voucher_count,
+            voucher_status,
         )
         if not isinstance(vouchers, list):
             continue
         for voucher in vouchers:
             if isinstance(voucher, MutableMapping):
-                voucher_list.append({"client": client.name, **voucher})
+                voucher_list.append({**voucher, "client": client.name})
             else:
                 voucher_list.append(voucher)
     return voucher_list
@@ -792,9 +794,11 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
     """
     clients = await _get_target_clients(hass, call)
     voucher_list = await _collect_voucher_results(clients, dict(call.data))
-    final_vouchers: dict[str, Any] = {"vouchers": voucher_list}
-    _LOGGER.debug("[service_generate_vouchers] vouchers: %s", final_vouchers)
-    return final_vouchers
+    _LOGGER.debug(
+        "[service_generate_vouchers] status: ok, voucher_count: %s",
+        len(voucher_list),
+    )
+    return {"vouchers": voucher_list}
 
 
 async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> ServiceResponse:

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -331,6 +331,26 @@ async def _get_clients(
     return clients
 
 
+async def _get_target_clients(
+    hass: HomeAssistant,
+    call: ServiceCall,
+) -> list[OPNsenseServiceClient]:
+    """Return OPNsense clients targeted by a Home Assistant service call.
+
+    Args:
+        hass: Home Assistant instance.
+        call: Service call payload received from Home Assistant.
+
+    Returns:
+        list[OPNsenseServiceClient]: Selected OPNsense clients.
+    """
+    return await _get_clients(
+        hass=hass,
+        opndevice_id=call.data.get("device_id"),
+        opnentity_id=call.data.get("entity_id"),
+    )
+
+
 def _get_service_identifier(call: ServiceCall) -> str:
     """Return the OPNsense service identifier from a service call.
 
@@ -352,6 +372,7 @@ def _get_service_identifier(call: ServiceCall) -> str:
 async def _run_boolean_client_action(
     clients: list[OPNsenseServiceClient],
     log_prefix: str,
+    action_name: str | None,
     target_name: str,
     target_value: Any,
     failure_message: str,
@@ -362,6 +383,7 @@ async def _run_boolean_client_action(
     Args:
         clients: OPNsense clients selected for the service call.
         log_prefix: Prefix used in the debug log message.
+        action_name: Optional action variant to include after the log prefix.
         target_name: Human-readable target field name for logs.
         target_value: Target value passed to the client action.
         failure_message: Error message to raise if no clients or any client action fails.
@@ -373,9 +395,11 @@ async def _run_boolean_client_action(
     success: bool | None = None
     for client in clients:
         response = await action(client)
+        log_action = f"{action_name}, " if action_name else ""
         _LOGGER.debug(
-            "[%s] client: %s, %s: %s, response: %s",
+            "[%s] %sclient: %s, %s: %s, response: %s",
             log_prefix,
+            log_action,
             client.name,
             target_name,
             target_value,
@@ -387,6 +411,49 @@ async def _run_boolean_client_action(
         raise ServiceValidationError(failure_message)
 
 
+async def _collect_mapping_results(
+    clients: list[OPNsenseServiceClient],
+    log_prefix: str,
+    failure_message: str,
+    action: Callable[[OPNsenseServiceClient], Awaitable[Any]],
+    action_context: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Collect non-empty mapping responses from selected clients.
+
+    Args:
+        clients: OPNsense clients selected for the service call.
+        log_prefix: Prefix used in the debug log message.
+        failure_message: Error message to raise if no clients return data.
+        action: Awaitable client action returning a mapping payload.
+        action_context: Optional values to include in debug logs.
+
+    Returns:
+        list[dict[str, Any]]: Per-client mapping results with ``client_name`` included.
+
+    Raises:
+        ServiceValidationError: If no selected client returns a non-empty mapping.
+    """
+    response_list: list[dict[str, Any]] = []
+    for client in clients:
+        response = await action(client)
+        _LOGGER.debug(
+            "[%s] client: %s, context: %s, response: %s",
+            log_prefix,
+            client.name,
+            action_context or {},
+            response,
+        )
+        if not isinstance(response, MutableMapping) or len(response) == 0:
+            continue
+        result: dict[str, Any] = {"client_name": client.name}
+        result.update(dict(response))
+        response_list.append(result)
+
+    if len(response_list) == 0:
+        raise ServiceValidationError(failure_message)
+    return response_list
+
+
 async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
     """Handle the close notice service call.
 
@@ -395,11 +462,7 @@ async def _service_close_notice(hass: HomeAssistant, call: ServiceCall) -> None:
         services.
         call: Service call payload received from Home Assistant.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     for client in clients:
         _LOGGER.debug(
             "[service_close_notice] client: %s, service: %s",
@@ -422,14 +485,11 @@ async def _service_start_service(hass: HomeAssistant, call: ServiceCall) -> None
         required value.
     """
     service_identifier = _get_service_identifier(call)
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     await _run_boolean_client_action(
         clients=clients,
         log_prefix="service_start_service",
+        action_name=None,
         target_name="service",
         target_value=service_identifier,
         failure_message=f"Start Service Failed. service: {service_identifier}",
@@ -450,14 +510,11 @@ async def _service_stop_service(hass: HomeAssistant, call: ServiceCall) -> None:
         required value.
     """
     service_identifier = _get_service_identifier(call)
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     await _run_boolean_client_action(
         clients=clients,
         log_prefix="service_stop_service",
+        action_name=None,
         target_name="service",
         target_value=service_identifier,
         failure_message=f"Stop Service Failed. service: {service_identifier}",
@@ -478,15 +535,12 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
         required value.
     """
     service_identifier = _get_service_identifier(call)
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     if call.data.get("only_if_running"):
         await _run_boolean_client_action(
             clients=clients,
-            log_prefix="service_restart_service] restart_service_if_running",
+            log_prefix="service_restart_service",
+            action_name="restart_service_if_running",
             target_name="service",
             target_value=service_identifier,
             failure_message=f"Restart Service Failed. service: {service_identifier}",
@@ -495,7 +549,8 @@ async def _service_restart_service(hass: HomeAssistant, call: ServiceCall) -> No
     else:
         await _run_boolean_client_action(
             clients=clients,
-            log_prefix="service_restart_service] restart_service",
+            log_prefix="service_restart_service",
+            action_name="restart_service",
             target_name="service",
             target_value=service_identifier,
             failure_message=f"Restart Service Failed. service: {service_identifier}",
@@ -511,11 +566,7 @@ async def _service_system_halt(hass: HomeAssistant, call: ServiceCall) -> None:
         services.
         call: Service call payload received from Home Assistant.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     for client in clients:
         _LOGGER.debug("[service_system_halt] client: %s", client.name)
         await client.system_halt()
@@ -529,11 +580,7 @@ async def _service_system_reboot(hass: HomeAssistant, call: ServiceCall) -> None
         services.
         call: Service call payload received from Home Assistant.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     for client in clients:
         _LOGGER.debug("[service_system_reboot] client: %s", client.name)
         await client.system_reboot()
@@ -547,11 +594,7 @@ async def _service_send_wol(hass: HomeAssistant, call: ServiceCall) -> None:
         services.
         call: Service call payload received from Home Assistant.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     for client in clients:
         _LOGGER.debug(
             "[service_send_wol] client: %s, interface: %s, mac: %s",
@@ -574,15 +617,12 @@ async def _service_reload_interface(hass: HomeAssistant, call: ServiceCall) -> N
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     interface = call.data.get("interface")
     await _run_boolean_client_action(
         clients=clients,
         log_prefix="service_reload_interface",
+        action_name=None,
         target_name="interface",
         target_value=interface,
         failure_message=f"Reload Interface Failed: {interface}",
@@ -602,11 +642,7 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     voucher_list: list = []
     for client in clients:
         try:
@@ -643,11 +679,7 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     success: bool | None = None
     response_list: list = []
     for client in clients:
@@ -686,25 +718,15 @@ async def _service_run_speedtest(hass: HomeAssistant, call: ServiceCall) -> Serv
     Returns:
         ServiceResponse: Response payload containing per-client speedtest results.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
-    response_list: list[dict[str, Any]] = []
-    for client in clients:
-        response = await client.run_speedtest()
-        _LOGGER.debug("[service_run_speedtest] client: %s, response: %s", client.name, response)
-        if not isinstance(response, MutableMapping) or len(response) == 0:
-            continue
-        run_result: dict[str, Any] = {"client_name": client.name}
-        run_result.update(dict(response))
-        response_list.append(run_result)
-
-    if len(response_list) == 0:
-        raise ServiceValidationError(
+    clients = await _get_target_clients(hass, call)
+    response_list = await _collect_mapping_results(
+        clients=clients,
+        log_prefix="service_run_speedtest",
+        failure_message=(
             "Run Speedtest Failed. No selected OPNsense clients have Speedtest installed"
-        )
+        ),
+        action=lambda client: client.run_speedtest(),
+    )
     return_response: dict[str, Any] = {"results": response_list}
     _LOGGER.debug("[service_run_speedtest] return_response: %s", return_response)
     return return_response
@@ -721,31 +743,15 @@ async def _service_get_vnstat_metrics(hass: HomeAssistant, call: ServiceCall) ->
     Returns:
         ServiceResponse: Parsed per-client vnStat payloads from the requested endpoint.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     requested_period: str = call.data["period"]
-    response_list: list[dict[str, Any]] = []
-    for client in clients:
-        response = await client.get_vnstat_metrics(requested_period)
-        _LOGGER.debug(
-            "[service_get_vnstat_metrics] client: %s, period: %s, response: %s",
-            client.name,
-            requested_period,
-            response,
-        )
-        if not isinstance(response, MutableMapping) or len(response) == 0:
-            continue
-        metric_result: dict[str, Any] = {"client_name": client.name}
-        metric_result.update(dict(response))
-        response_list.append(metric_result)
-
-    if len(response_list) == 0:
-        raise ServiceValidationError(
-            "Get vnStat Metrics Failed. No selected OPNsense clients vnStat installed"
-        )
+    response_list = await _collect_mapping_results(
+        clients=clients,
+        log_prefix="service_get_vnstat_metrics",
+        failure_message="Get vnStat Metrics Failed. No selected OPNsense clients vnStat installed",
+        action=lambda client: client.get_vnstat_metrics(requested_period),
+        action_context={"period": requested_period},
+    )
     return_response: dict[str, Any] = {"results": response_list}
     _LOGGER.debug("[service_get_vnstat_metrics] return_response: %s", return_response)
     return return_response
@@ -763,16 +769,13 @@ async def _service_toggle_alias(hass: HomeAssistant, call: ServiceCall) -> None:
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
     """
-    clients: list = await _get_clients(
-        hass=hass,
-        opndevice_id=call.data.get("device_id", []),
-        opnentity_id=call.data.get("entity_id", []),
-    )
+    clients = await _get_target_clients(hass, call)
     alias = call.data.get("alias")
     toggle_on_off = call.data.get("toggle_on_off")
     await _run_boolean_client_action(
         clients=clients,
         log_prefix="service_toggle_alias",
+        action_name=None,
         target_name="alias",
         target_value=alias,
         failure_message=f"Toggle Alias Failed. alias: {alias}, action: {toggle_on_off}",

--- a/custom_components/opnsense/services.yaml
+++ b/custom_components/opnsense/services.yaml
@@ -34,6 +34,10 @@ start_service:
       required: false
       selector:
         text:
+    service_name:
+      required: false
+      selector:
+        text:
     multiple_opnsense:
       collapsed: true
       fields:
@@ -62,6 +66,10 @@ stop_service:
       required: false
       selector:
         text:
+    service_name:
+      required: false
+      selector:
+        text:
     multiple_opnsense:
       collapsed: true
       fields:
@@ -87,6 +95,10 @@ stop_service:
 restart_service:
   fields:
     service_id:
+      required: false
+      selector:
+        text:
+    service_name:
       required: false
       selector:
         text:

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -126,6 +126,44 @@
       "description": "OPNsense Device ID has changed which indicates new or changed hardware. In order to accommodate this, hass-opnsense needs to be removed and reinstalled for this router. hass-opnsense is shutting down."
     }
   },
+  "exceptions": {
+    "generate_vouchers_failed": {
+      "message": "Generate vouchers failed. No selected OPNsense clients."
+    },
+    "get_vnstat_metrics_failed": {
+      "message": "Get vnStat metrics failed. No selected OPNsense clients have vnStat installed."
+    },
+    "kill_states_failed": {
+      "message": "Kill states failed: {ip_addr}"
+    },
+    "no_target_clients": {
+      "message": "No OPNsense clients match the selected target."
+    },
+    "reload_interface_failed": {
+      "message": "Reload interface failed: {interface}"
+    },
+    "restart_service_failed": {
+      "message": "Restart service failed: {service}"
+    },
+    "run_speedtest_failed": {
+      "message": "Run speedtest failed. No selected OPNsense clients have Speedtest installed."
+    },
+    "service_identifier_required": {
+      "message": "Must use service_id or service_name."
+    },
+    "start_service_failed": {
+      "message": "Start service failed: {service}"
+    },
+    "stop_service_failed": {
+      "message": "Stop service failed: {service}"
+    },
+    "toggle_alias_failed": {
+      "message": "Toggle alias failed. Alias: {alias}, action: {action}"
+    },
+    "voucher_server_error": {
+      "message": "Error getting vouchers from {client}. {error}"
+    }
+  },
   "selector": {
     "toggle_on_off": {
       "options": {
@@ -215,6 +253,10 @@
           "name": "Service ID or Name",
           "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
         },
+        "service_name": {
+          "name": "Service Name",
+          "description": "The name of the service. Like: haproxy, dhcp, etc."
+        },
         "device_id": {
           "name": "OPNsense Device",
           "description": "Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers."
@@ -238,6 +280,10 @@
           "name": "Service ID or Name",
           "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
         },
+        "service_name": {
+          "name": "Service Name",
+          "description": "The name of the service. Like: haproxy, dhcp, etc."
+        },
         "device_id": {
           "name": "OPNsense Device",
           "description": "Select the OPNsense Router to call the command on. If not specified, the command will be sent to all OPNsense Routers."
@@ -260,6 +306,10 @@
         "service_id": {
           "name": "Service ID or Name",
           "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+        },
+        "service_name": {
+          "name": "Service Name",
+          "description": "The name of the service. Like: haproxy, dhcp, etc."
         },
         "only_if_running": {
           "name": "Only if Running",

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -250,8 +250,8 @@
       "description": "Starts an OPNsense service",
       "fields": {
         "service_id": {
-          "name": "Service ID or Name",
-          "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+          "name": "Service ID",
+          "description": "The ID of the service. Like: udpbroadcastrelay/3"
         },
         "service_name": {
           "name": "Service Name",
@@ -277,8 +277,8 @@
       "description": "Stops an OPNsense service",
       "fields": {
         "service_id": {
-          "name": "Service ID or Name",
-          "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+          "name": "Service ID",
+          "description": "The ID of the service. Like: udpbroadcastrelay/3"
         },
         "service_name": {
           "name": "Service Name",
@@ -304,8 +304,8 @@
       "description": "Restarts an OPNsense service",
       "fields": {
         "service_id": {
-          "name": "Service ID or Name",
-          "description": "The ID or name of the service. Like: udpbroadcastrelay/3, haproxy, dhcp, etc."
+          "name": "Service ID",
+          "description": "The ID of the service. Like: udpbroadcastrelay/3"
         },
         "service_name": {
           "name": "Service Name",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -497,17 +497,24 @@ async def test_service_restart_only_if_running_and_reload_interface(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("method_name", "method_attr"),
+    ("method_name", "method_attr", "client_order"),
     [
-        ("_service_start_service", "start_service"),
-        ("_service_stop_service", "stop_service"),
-        ("_service_restart_service", "restart_service"),
+        ("_service_start_service", "start_service", "ok-first"),
+        ("_service_start_service", "start_service", "bad-first"),
+        ("_service_stop_service", "stop_service", "ok-first"),
+        ("_service_stop_service", "stop_service", "bad-first"),
+        ("_service_restart_service", "restart_service", "ok-first"),
+        ("_service_restart_service", "restart_service", "bad-first"),
     ],
 )
 async def test_service_start_stop_restart_failure_variants(
-    monkeypatch: pytest.MonkeyPatch, ph_hass: Any, method_name: Any, method_attr: Any
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    method_name: str,
+    method_attr: str,
+    client_order: str,
 ) -> None:
-    """Parameterized failure tests for start/stop/restart service handlers. For each handler, ensure that if any client returns False the handler raises ServiceValidationError."""
+    """Service control handlers fail if any selected client reports failure."""
     hass = ph_hass
     hass.data = {}
     ok_client = MagicMock()
@@ -518,7 +525,10 @@ async def test_service_start_stop_restart_failure_variants(
     setattr(ok_client, method_attr, AsyncMock(return_value=True))
     setattr(bad_client, method_attr, AsyncMock(return_value=False))
 
-    _patch_clients(monkeypatch, [ok_client, bad_client])
+    clients = [ok_client, bad_client]
+    if client_order == "bad-first":
+        clients = [bad_client, ok_client]
+    _patch_clients(monkeypatch, clients)
     call = _service_call({"service_id": "svc"})
 
     handler = getattr(services_mod, method_name)
@@ -671,6 +681,9 @@ async def test_kill_states_success_and_failure(
     c1 = MagicMock()
     c1.name = "c1"
     c1.kill_states = AsyncMock(return_value={"success": True, "dropped_states": 5})
+    c2 = MagicMock()
+    c2.name = "c2"
+    c2.kill_states = AsyncMock(return_value={"success": False})
     hass.data[DOMAIN] = {"e1": c1}
     call = _service_call({"ip_addr": "1.2.3.4"})
 
@@ -679,7 +692,11 @@ async def test_kill_states_success_and_failure(
     expected = {"dropped_states": [{"client_name": "c1", "dropped_states": 5}]}
     assert resp == expected
 
-    c1.kill_states = AsyncMock(return_value={"success": False})
+    _patch_clients(monkeypatch, [c1, c2])
+    with pytest.raises(ServiceValidationError):
+        await services_mod._service_kill_states(hass, call)
+
+    _patch_clients(monkeypatch, [c2, c1])
     with pytest.raises(ServiceValidationError):
         await services_mod._service_kill_states(hass, call)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -242,6 +242,14 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
     registrations[SERVICE_START_SERVICE]["schema"]({"service_id": "svc"})
     registrations[SERVICE_STOP_SERVICE]["schema"]({"service_name": "svc"})
     registrations[SERVICE_RESTART_SERVICE]["schema"]({"service_id": "svc", "only_if_running": True})
+    with pytest.raises(vol.Invalid):
+        registrations[SERVICE_START_SERVICE]["schema"]({"service_id": "svc", "service_name": "svc"})
+    with pytest.raises(vol.Invalid):
+        registrations[SERVICE_STOP_SERVICE]["schema"]({"service_id": "svc", "service_name": "svc"})
+    with pytest.raises(vol.Invalid):
+        registrations[SERVICE_RESTART_SERVICE]["schema"](
+            {"service_id": "svc", "service_name": "svc", "only_if_running": True}
+        )
     assert registrations[SERVICE_START_SERVICE]["schema"]({}) == {}
 
 
@@ -366,6 +374,23 @@ async def test_get_clients_registry_entries_without_config_entry_raise(
 
     with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opnentity_id="ent123")
+
+
+@pytest.mark.asyncio
+async def test_get_clients_unloaded_registry_entry_id_raises_no_target_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit targets resolving to unloaded config entries should fail with no_target_clients."""
+    hass_local = MagicMock(spec=HomeAssistant)
+    c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
+    hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
+
+    _patch_device_registry_entry(monkeypatch, "missing")
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await services_mod._get_clients(hass_local, opndevice_id="dev123")
+
+    assert exc_info.value.translation_key == "no_target_clients"
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -246,6 +246,47 @@ async def test_get_clients_unresolved_explicit_target_raises(
 
 
 @pytest.mark.asyncio
+async def test_get_clients_registry_entries_without_config_entry_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit registry targets without config entries must not broaden to all clients."""
+    hass_local = MagicMock(spec=HomeAssistant)
+    c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
+    hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
+
+    class DevReg:
+        def async_get(self, device_id: Any) -> Any:
+            """Return a device registry entry without an owning config entry.
+
+            Args:
+                device_id: Device identifier used to target a config entry.
+            """
+            device_entry = MagicMock()
+            device_entry.primary_config_entry = None
+            return device_entry
+
+    class EntReg:
+        def async_get(self, entity_id: Any) -> Any:
+            """Return an entity registry entry without an owning config entry.
+
+            Args:
+                entity_id: Entity identifier used to target a config entry.
+            """
+            entity_entry = MagicMock()
+            entity_entry.config_entry_id = None
+            return entity_entry
+
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda hass_in: DevReg())
+    monkeypatch.setattr(services_mod.er, "async_get", lambda hass_in: EntReg())
+
+    with pytest.raises(ServiceValidationError):
+        await services_mod._get_clients(hass_local, opndevice_id="dev123")
+
+    with pytest.raises(ServiceValidationError):
+        await services_mod._get_clients(hass_local, opnentity_id="ent123")
+
+
+@pytest.mark.asyncio
 async def test_service_start_stop_restart_success_and_failure(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -638,7 +638,7 @@ async def test_generate_vouchers_does_not_mutate_client_voucher_response(
     ph_hass: Any,
 ) -> None:
     """Client voucher mappings are copied before adding Home Assistant metadata."""
-    voucher = {"code": "A1"}
+    voucher = {"code": "A1", "client": "upstream"}
     client = MagicMock()
     client.name = "svc1"
     client.generate_vouchers = AsyncMock(return_value=[voucher])
@@ -648,8 +648,8 @@ async def test_generate_vouchers_does_not_mutate_client_voucher_response(
 
     response = await services_mod._service_generate_vouchers(ph_hass, call)
 
-    assert voucher == {"code": "A1"}
-    assert response == {"vouchers": [{"client": "svc1", "code": "A1"}]}
+    assert voucher == {"code": "A1", "client": "upstream"}
+    assert response == {"vouchers": [{"code": "A1", "client": "svc1"}]}
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -484,6 +484,75 @@ async def test_generate_vouchers_success_and_server_error(
 
 
 @pytest.mark.asyncio
+async def test_generate_vouchers_no_clients_raises(
+    ph_hass: Any,
+    fake_get_empty: Any,
+) -> None:
+    """Generating vouchers requires at least one selected OPNsense client."""
+    call = MagicMock()
+    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+
+    with pytest.raises(ServiceValidationError):
+        await services_mod._service_generate_vouchers(ph_hass, call)
+
+
+@pytest.mark.asyncio
+async def test_generate_vouchers_empty_selected_client_response_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+) -> None:
+    """A selected client returning no vouchers is a valid empty voucher response."""
+    client = MagicMock()
+    client.name = "svc1"
+    client.generate_vouchers = AsyncMock(return_value=[])
+    call = MagicMock()
+    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+
+    async def fake_get(*args, **kwargs) -> Any:
+        """Return the selected voucher client for an empty response.
+
+        Args:
+            *args: Additional positional arguments forwarded by the function.
+            **kwargs: Additional keyword arguments forwarded by the function.
+        """
+        return [client]
+
+    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+
+    assert await services_mod._service_generate_vouchers(ph_hass, call) == {"vouchers": []}
+
+
+@pytest.mark.asyncio
+async def test_generate_vouchers_does_not_mutate_client_voucher_response(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+) -> None:
+    """Client voucher mappings are copied before adding Home Assistant metadata."""
+    voucher = {"code": "A1"}
+    client = MagicMock()
+    client.name = "svc1"
+    client.generate_vouchers = AsyncMock(return_value=[voucher])
+    call = MagicMock()
+    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+
+    async def fake_get(*args, **kwargs) -> Any:
+        """Return the selected voucher client for mutation checks.
+
+        Args:
+            *args: Additional positional arguments forwarded by the function.
+            **kwargs: Additional keyword arguments forwarded by the function.
+        """
+        return [client]
+
+    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+
+    response = await services_mod._service_generate_vouchers(ph_hass, call)
+
+    assert voucher == {"code": "A1"}
+    assert response == {"vouchers": [{"client": "svc1", "code": "A1"}]}
+
+
+@pytest.mark.asyncio
 async def test_kill_states_success_and_failure(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -93,8 +93,10 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.asyncio
-async def test_get_clients_registry_errors_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify that _get_clients returns all configured clients even when registry lookups raise exceptions. Device or entity registry lookups may raise exceptions; ensure these are ignored."""
+async def test_get_clients_registry_errors_raise_for_explicit_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registry lookup errors must not broaden explicit targets to all clients."""
     hass_local = MagicMock(spec=HomeAssistant)
     c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
     hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
@@ -123,8 +125,32 @@ async def test_get_clients_registry_errors_are_ignored(monkeypatch: pytest.Monke
 
     monkeypatch.setattr(services_mod.dr, "async_get", _raises(TypeError()))
     monkeypatch.setattr(services_mod.er, "async_get", _raises(AttributeError()))
-    res = await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
-    assert res == [c1, c2]
+    with pytest.raises(ServiceValidationError):
+        await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
+
+
+@pytest.mark.asyncio
+async def test_get_clients_unresolved_explicit_target_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit target selectors must not broaden to all configured clients."""
+    hass_local = MagicMock(spec=HomeAssistant)
+    c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
+    hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
+
+    class DevReg:
+        def async_get(self, device_id: Any) -> Any:
+            """Return no matching device for the requested selector.
+
+            Args:
+                device_id: Device identifier used to target a config entry.
+            """
+            return None
+
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda hass_in: DevReg())
+
+    with pytest.raises(ServiceValidationError):
+        await services_mod._get_clients(hass_local, opndevice_id="missing-device")
 
 
 @pytest.mark.asyncio
@@ -303,6 +329,49 @@ async def test_service_start_stop_restart_failure_variants(
     handler = getattr(services_mod, method_name)
     with pytest.raises(ServiceValidationError):
         await handler(hass, call)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "_service_start_service",
+        "_service_stop_service",
+        "_service_restart_service",
+    ],
+)
+async def test_service_start_stop_restart_require_service_identifier(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    method_name: str,
+) -> None:
+    """Service control handlers require either service_id or service_name."""
+    client = MagicMock()
+    client.name = "c1"
+    client.start_service = AsyncMock(return_value=True)
+    client.stop_service = AsyncMock(return_value=True)
+    client.restart_service = AsyncMock(return_value=True)
+
+    async def fake_get(*args, **kwargs) -> Any:
+        """Return the fake client for service identifier validation.
+
+        Args:
+            *args: Additional positional arguments forwarded by the function.
+            **kwargs: Additional keyword arguments forwarded by the function.
+        """
+        return [client]
+
+    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    call = MagicMock()
+    call.data = {}
+
+    handler = getattr(services_mod, method_name)
+    with pytest.raises(ServiceValidationError):
+        await handler(ph_hass, call)
+
+    client.start_service.assert_not_awaited()
+    client.stop_service.assert_not_awaited()
+    client.restart_service.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ for operations such as starting/stopping services and generating vouchers.
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
@@ -107,20 +108,13 @@ def _patch_device_registry_entry(
         primary_config_entry: Config entry ID exposed by the fake device entry.
         config_entries: Config entry IDs exposed by the fake device entry.
     """
-
-    class DevReg:
-        def async_get(self, device_id: Any) -> Any:
-            """Return a fake device registry entry.
-
-            Args:
-                device_id: Device identifier used to target a config entry.
-            """
-            device_entry = MagicMock()
-            device_entry.primary_config_entry = primary_config_entry
-            device_entry.config_entries = config_entries or set()
-            return device_entry
-
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: DevReg())
+    device_entry = SimpleNamespace(
+        primary_config_entry=primary_config_entry,
+        config_entries=config_entries or set(),
+    )
+    device_registry = MagicMock()
+    device_registry.async_get.return_value = device_entry
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: device_registry)
 
 
 def _patch_entity_registry_entry(
@@ -133,19 +127,10 @@ def _patch_entity_registry_entry(
         monkeypatch: Pytest monkeypatch fixture used to patch the services module.
         config_entry_id: Config entry ID exposed by the fake entity entry.
     """
-
-    class EntReg:
-        def async_get(self, entity_id: Any) -> Any:
-            """Return a fake entity registry entry.
-
-            Args:
-                entity_id: Entity identifier used to target a config entry.
-            """
-            entity_entry = MagicMock()
-            entity_entry.config_entry_id = config_entry_id
-            return entity_entry
-
-    monkeypatch.setattr(services_mod.er, "async_get", lambda _hass: EntReg())
+    entity_entry = SimpleNamespace(config_entry_id=config_entry_id)
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+    monkeypatch.setattr(services_mod.er, "async_get", lambda _hass: entity_registry)
 
 
 def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -154,17 +139,9 @@ def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> Non
     Args:
         monkeypatch: Pytest monkeypatch fixture used to patch the services module.
     """
-
-    class DevReg:
-        def async_get(self, device_id: Any) -> None:
-            """Return no device registry entry.
-
-            Args:
-                device_id: Device identifier used to target a config entry.
-            """
-            return
-
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: DevReg())
+    device_registry = MagicMock()
+    device_registry.async_get.return_value = None
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: device_registry)
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -486,7 +486,7 @@ async def test_service_restart_only_if_running_and_reload_interface(
 )
 async def test_service_start_stop_restart_failure_variants(
     monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
+    ph_hass: HomeAssistant,
     method_name: str,
     method_attr: str,
     client_order: str,
@@ -611,8 +611,8 @@ async def test_generate_vouchers_empty_selected_client_response_returns_empty(
 )
 async def test_generate_vouchers_preserves_existing_edge_response_behavior(
     monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
-    client_response: Any,
+    ph_hass: HomeAssistant,
+    client_response: object,
     expected_vouchers: list[Any],
 ) -> None:
     """Voucher generation preserves non-list skip and non-mapping passthrough behavior."""
@@ -631,7 +631,7 @@ async def test_generate_vouchers_preserves_existing_edge_response_behavior(
 @pytest.mark.asyncio
 async def test_generate_vouchers_does_not_mutate_client_voucher_response(
     monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
+    ph_hass: HomeAssistant,
 ) -> None:
     """Client voucher mappings are copied before adding Home Assistant metadata."""
     voucher = {"code": "A1", "client": "upstream"}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -71,6 +71,75 @@ def _service_call(data: dict[str, Any]) -> MagicMock:
     return call
 
 
+def _patch_device_registry_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    primary_config_entry: str | None,
+) -> None:
+    """Patch device registry lookup to return a fake device entry.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture used to patch the services module.
+        primary_config_entry: Config entry ID exposed by the fake device entry.
+    """
+
+    class DevReg:
+        def async_get(self, device_id: Any) -> Any:
+            """Return a fake device registry entry.
+
+            Args:
+                device_id: Device identifier used to target a config entry.
+            """
+            device_entry = MagicMock()
+            device_entry.primary_config_entry = primary_config_entry
+            return device_entry
+
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: DevReg())
+
+
+def _patch_entity_registry_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    config_entry_id: str | None,
+) -> None:
+    """Patch entity registry lookup to return a fake entity entry.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture used to patch the services module.
+        config_entry_id: Config entry ID exposed by the fake entity entry.
+    """
+
+    class EntReg:
+        def async_get(self, entity_id: Any) -> Any:
+            """Return a fake entity registry entry.
+
+            Args:
+                entity_id: Entity identifier used to target a config entry.
+            """
+            entity_entry = MagicMock()
+            entity_entry.config_entry_id = config_entry_id
+            return entity_entry
+
+    monkeypatch.setattr(services_mod.er, "async_get", lambda _hass: EntReg())
+
+
+def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch device registry lookup to return no device entry.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture used to patch the services module.
+    """
+
+    class DevReg:
+        def async_get(self, device_id: Any) -> None:
+            """Return no device registry entry.
+
+            Args:
+                device_id: Device identifier used to target a config entry.
+            """
+            return
+
+    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: DevReg())
+
+
 @pytest.mark.asyncio
 async def test_async_setup_services_registers_get_vnstat_metrics_case_insensitive_period() -> None:
     """Service setup should register get_vnstat_metrics with normalized period schema."""
@@ -166,34 +235,12 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
     client2.name = "two"
     hass_local.data[DOMAIN] = {"e1": client, "e2": client2}
 
-    class DevReg:
-        def async_get(self, device_id: Any) -> Any:
-            """Async get.
-
-            Args:
-                device_id: Device identifier used to target the correct OPNsense device or config entry.
-            """
-            m = MagicMock()
-            m.primary_config_entry = "e2"
-            return m
-
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda hass_in: DevReg())
+    _patch_device_registry_entry(monkeypatch, "e2")
     res = await services_mod._get_clients(hass_local, opndevice_id="dev123")
     assert res == [client2]
 
     # filter by entity_id
-    class EntReg:
-        def async_get(self, entity_id: Any) -> Any:
-            """Async get.
-
-            Args:
-                entity_id: Entity identifier used to resolve the matching OPNsense entity.
-            """
-            m = MagicMock()
-            m.config_entry_id = "e1"
-            return m
-
-    monkeypatch.setattr(services_mod.er, "async_get", lambda hass_in: EntReg())
+    _patch_entity_registry_entry(monkeypatch, "e1")
     res = await services_mod._get_clients(hass_local, opnentity_id="ent123")
     assert res == [client]
 
@@ -244,16 +291,7 @@ async def test_get_clients_unresolved_explicit_target_raises(
     c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
     hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
 
-    class DevReg:
-        def async_get(self, device_id: Any) -> Any:
-            """Return no matching device for the requested selector.
-
-            Args:
-                device_id: Device identifier used to target a config entry.
-            """
-            return None
-
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda hass_in: DevReg())
+    _patch_missing_device_registry_entry(monkeypatch)
 
     with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opndevice_id="missing-device")
@@ -268,30 +306,8 @@ async def test_get_clients_registry_entries_without_config_entry_raise(
     c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
     hass_local.data = {DOMAIN: {"e1": c1, "e2": c2}}
 
-    class DevReg:
-        def async_get(self, device_id: Any) -> Any:
-            """Return a device registry entry without an owning config entry.
-
-            Args:
-                device_id: Device identifier used to target a config entry.
-            """
-            device_entry = MagicMock()
-            device_entry.primary_config_entry = None
-            return device_entry
-
-    class EntReg:
-        def async_get(self, entity_id: Any) -> Any:
-            """Return an entity registry entry without an owning config entry.
-
-            Args:
-                entity_id: Entity identifier used to target a config entry.
-            """
-            entity_entry = MagicMock()
-            entity_entry.config_entry_id = None
-            return entity_entry
-
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda hass_in: DevReg())
-    monkeypatch.setattr(services_mod.er, "async_get", lambda hass_in: EntReg())
+    _patch_device_registry_entry(monkeypatch, None)
+    _patch_entity_registry_entry(monkeypatch, None)
 
     with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opndevice_id="dev123")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -98,12 +98,14 @@ def _iter_service_field_names(service_definition: dict[str, Any]) -> set[str]:
 def _patch_device_registry_entry(
     monkeypatch: pytest.MonkeyPatch,
     primary_config_entry: str | None,
+    config_entries: set[str] | None = None,
 ) -> None:
     """Patch device registry lookup to return a fake device entry.
 
     Args:
         monkeypatch: Pytest monkeypatch fixture used to patch the services module.
         primary_config_entry: Config entry ID exposed by the fake device entry.
+        config_entries: Config entry IDs exposed by the fake device entry.
     """
 
     class DevReg:
@@ -115,6 +117,7 @@ def _patch_device_registry_entry(
             """
             device_entry = MagicMock()
             device_entry.primary_config_entry = primary_config_entry
+            device_entry.config_entries = config_entries or set()
             return device_entry
 
     monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: DevReg())
@@ -239,8 +242,7 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
     registrations[SERVICE_START_SERVICE]["schema"]({"service_id": "svc"})
     registrations[SERVICE_STOP_SERVICE]["schema"]({"service_name": "svc"})
     registrations[SERVICE_RESTART_SERVICE]["schema"]({"service_id": "svc", "only_if_running": True})
-    with pytest.raises(vol.Invalid):
-        registrations[SERVICE_START_SERVICE]["schema"]({})
+    assert registrations[SERVICE_START_SERVICE]["schema"]({}) == {}
 
 
 def test_service_metadata_fields_have_translations() -> None:
@@ -288,6 +290,10 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
     # filter by entity_id
     _patch_entity_registry_entry(monkeypatch, "e1")
     res = await services_mod._get_clients(hass_local, opnentity_id="ent123")
+    assert res == [client]
+
+    _patch_device_registry_entry(monkeypatch, None, {"e1"})
+    res = await services_mod._get_clients(hass_local, opndevice_id="dev123")
     assert res == [client]
 
 
@@ -360,6 +366,18 @@ async def test_get_clients_registry_entries_without_config_entry_raise(
 
     with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opnentity_id="ent123")
+
+
+@pytest.mark.asyncio
+async def test_get_clients_empty_data_raises_for_explicit_target() -> None:
+    """Explicit target selectors fail clearly when no clients are loaded."""
+    hass_local = MagicMock(spec=HomeAssistant)
+    hass_local.data = {DOMAIN: {}}
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await services_mod._get_clients(hass_local, opndevice_id="dev123")
+
+    assert exc_info.value.translation_key == "no_target_clients"
 
 
 @pytest.mark.asyncio
@@ -523,9 +541,10 @@ async def test_service_start_stop_restart_require_service_identifier(
     call = _service_call({})
 
     handler = getattr(services_mod, method_name)
-    with pytest.raises(ServiceValidationError):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(ph_hass, call)
 
+    assert exc_info.value.translation_key == "service_identifier_required"
     client.start_service.assert_not_awaited()
     client.stop_service.assert_not_awaited()
     client.restart_service.assert_not_awaited()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -328,14 +328,14 @@ async def test_service_start_stop_restart_success_and_failure(
     c1.restart_service_if_running.assert_not_awaited()
     c2.restart_service_if_running.assert_not_awaited()
 
-    # Also verify fallback via service_name works
+    # Also verify the service_name identifier path works
     call2 = MagicMock()
     call2.data = {"service_name": "svc"}
     await services_mod._service_start_service(hass, call2)
     await services_mod._service_stop_service(hass, call2)
     await services_mod._service_restart_service(hass, call2)
 
-    # Confirm fallback path invoked client methods again with same arg
+    # Confirm service_name invoked client methods again with same arg
     c1.start_service.assert_awaited_with("svc")
     c2.start_service.assert_awaited_with("svc")
     assert c1.start_service.await_count == 2

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -57,6 +57,20 @@ def _voucher_call_data() -> dict[str, str]:
     return {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
 
 
+def _service_call(data: dict[str, Any]) -> MagicMock:
+    """Return a fake Home Assistant service call with data.
+
+    Args:
+        data: Service call data exposed through the fake call.
+
+    Returns:
+        MagicMock: Fake Home Assistant service call.
+    """
+    call = MagicMock()
+    call.data = data
+    return call
+
+
 @pytest.mark.asyncio
 async def test_async_setup_services_registers_get_vnstat_metrics_case_insensitive_period() -> None:
     """Service setup should register get_vnstat_metrics with normalized period schema."""
@@ -308,8 +322,7 @@ async def test_service_start_stop_restart_success_and_failure(
     c2.restart_service_if_running = AsyncMock(return_value=True)
     hass.data[DOMAIN] = {"e1": c1, "e2": c2}
 
-    call = MagicMock()
-    call.data = {"service_id": "svc"}
+    call = _service_call({"service_id": "svc"})
 
     _patch_clients(monkeypatch, [c1, c2])
     # start should succeed because c2 returns True
@@ -329,8 +342,7 @@ async def test_service_start_stop_restart_success_and_failure(
     c2.restart_service_if_running.assert_not_awaited()
 
     # Also verify the service_name identifier path works
-    call2 = MagicMock()
-    call2.data = {"service_name": "svc"}
+    call2 = _service_call({"service_name": "svc"})
     await services_mod._service_start_service(hass, call2)
     await services_mod._service_stop_service(hass, call2)
     await services_mod._service_restart_service(hass, call2)
@@ -363,8 +375,7 @@ async def test_service_restart_only_if_running_and_reload_interface(
     hass = ph_hass
     hass.data = {}
     hass.data[DOMAIN] = {"e1": c1}
-    call = MagicMock()
-    call.data = {"service_id": "svc", "only_if_running": True}
+    call = _service_call({"service_id": "svc", "only_if_running": True})
 
     _patch_clients(monkeypatch, [c1])
     # should not raise
@@ -383,8 +394,7 @@ async def test_service_restart_only_if_running_and_reload_interface(
         await services_mod._service_restart_service(hass, call)
 
     # reload_interface success
-    call_iface = MagicMock()
-    call_iface.data = {"interface": "igb0"}
+    call_iface = _service_call({"interface": "igb0"})
     await services_mod._service_reload_interface(hass, call_iface)
     c1.reload_interface.assert_awaited_once_with("igb0")
 
@@ -419,8 +429,7 @@ async def test_service_start_stop_restart_failure_variants(
     setattr(bad_client, method_attr, AsyncMock(return_value=False))
 
     _patch_clients(monkeypatch, [ok_client, bad_client])
-    call = MagicMock()
-    call.data = {"service_id": "svc"}
+    call = _service_call({"service_id": "svc"})
 
     handler = getattr(services_mod, method_name)
     with pytest.raises(ServiceValidationError):
@@ -449,8 +458,7 @@ async def test_service_start_stop_restart_require_service_identifier(
     client.restart_service = AsyncMock(return_value=True)
 
     _patch_clients(monkeypatch, [client])
-    call = MagicMock()
-    call.data = {}
+    call = _service_call({})
 
     handler = getattr(services_mod, method_name)
     with pytest.raises(ServiceValidationError):
@@ -474,8 +482,7 @@ async def test_generate_vouchers_success_and_server_error(
     c1.name = "svc1"
     c1.generate_vouchers = AsyncMock(return_value=vouchers)
     hass.data[DOMAIN] = {"e1": c1}
-    call = MagicMock()
-    call.data = _voucher_call_data()
+    call = _service_call(_voucher_call_data())
 
     _patch_clients(monkeypatch, [c1])
     resp = await services_mod._service_generate_vouchers(hass, call)
@@ -497,8 +504,7 @@ async def test_generate_vouchers_no_clients_raises(
     fake_get_empty: None,
 ) -> None:
     """Generating vouchers requires at least one selected OPNsense client."""
-    call = MagicMock()
-    call.data = _voucher_call_data()
+    call = _service_call(_voucher_call_data())
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_generate_vouchers(ph_hass, call)
@@ -513,8 +519,7 @@ async def test_generate_vouchers_empty_selected_client_response_returns_empty(
     client = MagicMock()
     client.name = "svc1"
     client.generate_vouchers = AsyncMock(return_value=[])
-    call = MagicMock()
-    call.data = _voucher_call_data()
+    call = _service_call(_voucher_call_data())
 
     _patch_clients(monkeypatch, [client])
 
@@ -531,8 +536,7 @@ async def test_generate_vouchers_does_not_mutate_client_voucher_response(
     client = MagicMock()
     client.name = "svc1"
     client.generate_vouchers = AsyncMock(return_value=[voucher])
-    call = MagicMock()
-    call.data = _voucher_call_data()
+    call = _service_call(_voucher_call_data())
 
     _patch_clients(monkeypatch, [client])
 
@@ -553,8 +557,7 @@ async def test_kill_states_success_and_failure(
     c1.name = "c1"
     c1.kill_states = AsyncMock(return_value={"success": True, "dropped_states": 5})
     hass.data[DOMAIN] = {"e1": c1}
-    call = MagicMock()
-    call.data = {"ip_addr": "1.2.3.4"}
+    call = _service_call({"ip_addr": "1.2.3.4"})
 
     _patch_clients(monkeypatch, [c1])
     resp = await services_mod._service_kill_states(hass, call)
@@ -585,8 +588,7 @@ async def test_run_speedtest_success_and_unavailable(
     c2.run_speedtest = AsyncMock(return_value={})
 
     _patch_clients(monkeypatch, [c1, c2])
-    call = MagicMock()
-    call.data = {}
+    call = _service_call({})
 
     response = await services_mod._service_run_speedtest(hass, call)
     assert response is not None
@@ -627,8 +629,7 @@ async def test_get_vnstat_metrics_success_and_unavailable(
     c2.get_vnstat_metrics = AsyncMock(return_value={})
 
     _patch_clients(monkeypatch, [c1, c2])
-    call = MagicMock()
-    call.data = {"period": "yearly"}
+    call = _service_call({"period": "yearly"})
 
     response = await services_mod._service_get_vnstat_metrics(hass, call)
     assert response is not None
@@ -670,8 +671,7 @@ async def test_restart_service_no_clients_raises(ph_hass: Any, fake_get_empty: N
     hass = ph_hass
     hass.data = {}
 
-    call = MagicMock()
-    call.data = {"service_id": "svc"}
+    call = _service_call({"service_id": "svc"})
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_restart_service(hass, call)
@@ -683,8 +683,7 @@ async def test_start_service_no_clients_raises(ph_hass: Any, fake_get_empty: Non
     hass = ph_hass
     hass.data = {}
 
-    call = MagicMock()
-    call.data = {"service_id": "svc"}
+    call = _service_call({"service_id": "svc"})
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_start_service(hass, call)
@@ -696,8 +695,7 @@ async def test_stop_service_no_clients_raises(ph_hass: Any, fake_get_empty: None
     hass = ph_hass
     hass.data = {}
 
-    call = MagicMock()
-    call.data = {"service_id": "svc"}
+    call = _service_call({"service_id": "svc"})
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_stop_service(hass, call)
@@ -720,20 +718,17 @@ async def test_close_send_wol_and_system_calls(monkeypatch: pytest.MonkeyPatch) 
     hass.data = {DOMAIN: {"e1": c}}
 
     # close notice
-    call = MagicMock()
-    call.data = {"id": "all"}
+    call = _service_call({"id": "all"})
     await services_mod._service_close_notice(hass, call)
     c.close_notice.assert_awaited_once_with("all")
 
     # send wol
-    call_wol = MagicMock()
-    call_wol.data = {"interface": "lan", "mac": "aa:bb:cc:dd:ee:ff"}
+    call_wol = _service_call({"interface": "lan", "mac": "aa:bb:cc:dd:ee:ff"})
     await services_mod._service_send_wol(hass, call_wol)
     c.send_wol.assert_awaited_once_with("lan", "aa:bb:cc:dd:ee:ff")
 
     # system halt and reboot
-    call_sys = MagicMock()
-    call_sys.data = {}
+    call_sys = _service_call({})
     await services_mod._service_system_halt(hass, call_sys)
     c.system_halt.assert_awaited_once()
     await services_mod._service_system_reboot(hass, call_sys)
@@ -751,8 +746,7 @@ async def test_toggle_alias_success_and_failure(monkeypatch: pytest.MonkeyPatch)
     _patch_clients(monkeypatch, [c1])
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {"e1": c1}}
-    call = MagicMock()
-    call.data = {"alias": "a1", "toggle_on_off": "on"}
+    call = _service_call({"alias": "a1", "toggle_on_off": "on"})
     # should not raise
     await services_mod._service_toggle_alias(hass, call)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -278,7 +278,6 @@ def test_service_validation_error_uses_translation_metadata() -> None:
 @pytest.mark.asyncio
 async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
     """_get_clients returns clients from hass.data and supports filtering."""
-    # use a plain hass-like object so .data is a real dict
     hass_local = MagicMock(spec=HomeAssistant)
     client = MagicMock()
     client.name = "one"
@@ -286,7 +285,6 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
     res = await services_mod._get_clients(hass_local)
     assert res == [client]
 
-    # multiple entries and filter by device_id
     client2 = MagicMock()
     client2.name = "two"
     hass_local.data[DOMAIN] = {"e1": client, "e2": client2}
@@ -295,7 +293,6 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
     res = await services_mod._get_clients(hass_local, opndevice_id="dev123")
     assert res == [client2]
 
-    # filter by entity_id
     _patch_entity_registry_entry(monkeypatch, "e1")
     res = await services_mod._get_clients(hass_local, opnentity_id="ent123")
     assert res == [client]
@@ -412,7 +409,6 @@ async def test_service_start_stop_restart_success_and_failure(
     """Start/stop/restart service handlers call client methods correctly."""
     hass = ph_hass
     hass.data = {}
-    # make both clients return True initially so the service calls succeed
     c1 = MagicMock()
     c1.name = "c1"
     c1.start_service = AsyncMock(return_value=True)
@@ -430,12 +426,9 @@ async def test_service_start_stop_restart_success_and_failure(
     call = _service_call({"service_id": "svc"})
 
     _patch_clients(monkeypatch, [c1, c2])
-    # start should succeed because c2 returns True
     await services_mod._service_start_service(hass, call)
-    # stop should succeed
     await services_mod._service_stop_service(hass, call)
 
-    # restart without only_if_running uses restart_service
     await services_mod._service_restart_service(hass, call)
     c1.start_service.assert_awaited_once_with("svc")
     c2.start_service.assert_awaited_once_with("svc")
@@ -446,13 +439,11 @@ async def test_service_start_stop_restart_success_and_failure(
     c1.restart_service_if_running.assert_not_awaited()
     c2.restart_service_if_running.assert_not_awaited()
 
-    # Also verify the service_name identifier path works
     call2 = _service_call({"service_name": "svc"})
     await services_mod._service_start_service(hass, call2)
     await services_mod._service_stop_service(hass, call2)
     await services_mod._service_restart_service(hass, call2)
 
-    # Confirm service_name invoked client methods again with same arg
     c1.start_service.assert_awaited_with("svc")
     c2.start_service.assert_awaited_with("svc")
     assert c1.start_service.await_count == 2
@@ -483,27 +474,22 @@ async def test_service_restart_only_if_running_and_reload_interface(
     call = _service_call({"service_id": "svc", "only_if_running": True})
 
     _patch_clients(monkeypatch, [c1])
-    # should not raise
     caplog.set_level("DEBUG", logger=services_mod.__name__)
     await services_mod._service_restart_service(hass, call)
     c1.restart_service_if_running.assert_awaited_once_with("svc")
     assert "[service_restart_service] restart_service_if_running, client: c1" in caplog.text
     assert "[service_restart_service] restart_service_if_running] client: c1" not in caplog.text
-    # Ensure the non-conditional restart path was not used
     c1.restart_service.assert_not_awaited()
 
-    # Failure path: client reports not running -> should raise ServiceValidationError
     c1.restart_service_if_running = AsyncMock(return_value=False)
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_restart_service(hass, call)
 
-    # reload_interface success
     call_iface = _service_call({"interface": "igb0"})
     await services_mod._service_reload_interface(hass, call_iface)
     c1.reload_interface.assert_awaited_once_with("igb0")
 
-    # reload_interface failure should raise
     c1.reload_interface = AsyncMock(return_value=False)
     with pytest.raises(ServiceValidationError):
         await services_mod._service_reload_interface(hass, call_iface)
@@ -524,7 +510,6 @@ async def test_service_start_stop_restart_failure_variants(
     """Parameterized failure tests for start/stop/restart service handlers. For each handler, ensure that if any client returns False the handler raises ServiceValidationError."""
     hass = ph_hass
     hass.data = {}
-    # ok client returns True, bad client returns False for the method under test
     ok_client = MagicMock()
     ok_client.name = "ok"
     bad_client = MagicMock()
@@ -582,7 +567,6 @@ async def test_generate_vouchers_success_and_server_error(
     """Generating vouchers returns assembled list and handles server errors."""
     hass = ph_hass
     hass.data = {}
-    # client returns a list of mapping vouchers
     vouchers = [{"code": "A1"}, {"code": "B2"}]
     c1 = MagicMock()
     c1.name = "svc1"
@@ -595,10 +579,8 @@ async def test_generate_vouchers_success_and_server_error(
     assert resp is not None
     assert "vouchers" in resp and isinstance(resp["vouchers"], list)
     response_vouchers: list[Any] = resp["vouchers"]
-    # confirm client name was injected into voucher entries
     assert all(isinstance(v, dict) and v.get("client") == "svc1" for v in response_vouchers)
 
-    # server error should raise ServiceValidationError
     c1.generate_vouchers = AsyncMock(side_effect=OPNsenseVoucherServerError("boom"))
     with pytest.raises(ServiceValidationError):
         await services_mod._service_generate_vouchers(hass, call)
@@ -630,6 +612,33 @@ async def test_generate_vouchers_empty_selected_client_response_returns_empty(
     _patch_clients(monkeypatch, [client])
 
     assert await services_mod._service_generate_vouchers(ph_hass, call) == {"vouchers": []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("client_response", "expected_vouchers"),
+    [
+        ("unexpected", []),
+        (["raw-voucher"], ["raw-voucher"]),
+    ],
+)
+async def test_generate_vouchers_preserves_existing_edge_response_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    client_response: Any,
+    expected_vouchers: list[Any],
+) -> None:
+    """Voucher generation preserves non-list skip and non-mapping passthrough behavior."""
+    client = MagicMock()
+    client.name = "svc1"
+    client.generate_vouchers = AsyncMock(return_value=client_response)
+    call = _service_call(_voucher_call_data())
+
+    _patch_clients(monkeypatch, [client])
+
+    assert await services_mod._service_generate_vouchers(ph_hass, call) == {
+        "vouchers": expected_vouchers
+    }
 
 
 @pytest.mark.asyncio
@@ -667,11 +676,9 @@ async def test_kill_states_success_and_failure(
 
     _patch_clients(monkeypatch, [c1])
     resp = await services_mod._service_kill_states(hass, call)
-    # Expect a payload containing the client name and dropped_states value
     expected = {"dropped_states": [{"client_name": "c1", "dropped_states": 5}]}
     assert resp == expected
 
-    # failure -> raise
     c1.kill_states = AsyncMock(return_value={"success": False})
     with pytest.raises(ServiceValidationError):
         await services_mod._service_kill_states(hass, call)
@@ -810,7 +817,6 @@ async def test_stop_service_no_clients_raises(ph_hass: Any, fake_get_empty: None
 @pytest.mark.asyncio
 async def test_close_send_wol_and_system_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     """Close/send_wol/system calls are forwarded to clients."""
-    # single client that should receive calls
     c = MagicMock()
     c.name = "one"
     c.close_notice = AsyncMock(return_value=None)
@@ -823,17 +829,14 @@ async def test_close_send_wol_and_system_calls(monkeypatch: pytest.MonkeyPatch) 
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {"e1": c}}
 
-    # close notice
     call = _service_call({"id": "all"})
     await services_mod._service_close_notice(hass, call)
     c.close_notice.assert_awaited_once_with("all")
 
-    # send wol
     call_wol = _service_call({"interface": "lan", "mac": "aa:bb:cc:dd:ee:ff"})
     await services_mod._service_send_wol(hass, call_wol)
     c.send_wol.assert_awaited_once_with("lan", "aa:bb:cc:dd:ee:ff")
 
-    # system halt and reboot
     call_sys = _service_call({})
     await services_mod._service_system_halt(hass, call_sys)
     c.system_halt.assert_awaited_once()
@@ -844,7 +847,6 @@ async def test_close_send_wol_and_system_calls(monkeypatch: pytest.MonkeyPatch) 
 @pytest.mark.asyncio
 async def test_toggle_alias_success_and_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Toggle alias success and failure paths raise or not appropriately."""
-    # success path
     c1 = MagicMock()
     c1.name = "c1"
     c1.toggle_alias = AsyncMock(return_value=True)
@@ -853,10 +855,8 @@ async def test_toggle_alias_success_and_failure(monkeypatch: pytest.MonkeyPatch)
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {"e1": c1}}
     call = _service_call({"alias": "a1", "toggle_on_off": "on"})
-    # should not raise
     await services_mod._service_toggle_alias(hass, call)
 
-    # failure path
     c2 = MagicMock()
     c2.name = "c2"
     c2.toggle_alias = AsyncMock(return_value=False)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,12 +4,15 @@ These tests exercise service helpers, validation paths, and error handling
 for operations such as starting/stopping services and generating vouchers.
 """
 
+import json
+from pathlib import Path
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
 from aiopnsense.exceptions import OPNsenseVoucherServerError
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util.yaml import load_yaml_dict
 import pytest
 import voluptuous as vol
 
@@ -30,6 +33,8 @@ from custom_components.opnsense.const import (
     SERVICE_SYSTEM_REBOOT,
     SERVICE_TOGGLE_ALIAS,
 )
+
+_INTEGRATION_ROOT = Path(__file__).parents[1] / "custom_components" / "opnsense"
 
 
 def _patch_clients(monkeypatch: pytest.MonkeyPatch, clients: list[Any]) -> None:
@@ -69,6 +74,25 @@ def _service_call(data: dict[str, Any]) -> MagicMock:
     call = MagicMock()
     call.data = data
     return call
+
+
+def _iter_service_field_names(service_definition: dict[str, Any]) -> set[str]:
+    """Return all top-level and section service field names.
+
+    Args:
+        service_definition: Service definition loaded from ``services.yaml``.
+
+    Returns:
+        set[str]: Field names that should have service translations.
+    """
+    fields = service_definition.get("fields", {})
+    field_names = set()
+    for field_name, field_definition in fields.items():
+        if "fields" not in field_definition:
+            field_names.add(field_name)
+            continue
+        field_names.update(field_definition["fields"])
+    return field_names
 
 
 def _patch_device_registry_entry(
@@ -217,6 +241,28 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
     registrations[SERVICE_RESTART_SERVICE]["schema"]({"service_id": "svc", "only_if_running": True})
     with pytest.raises(vol.Invalid):
         registrations[SERVICE_START_SERVICE]["schema"]({})
+
+
+def test_service_metadata_fields_have_translations() -> None:
+    """Every service field exposed in services.yaml has an English translation."""
+    services_yaml = load_yaml_dict(_INTEGRATION_ROOT / "services.yaml")
+    translations = json.loads((_INTEGRATION_ROOT / "translations" / "en.json").read_text())
+
+    translated_services = translations["services"]
+    for service_name, service_definition in services_yaml.items():
+        assert service_name in translated_services
+        translated_fields = translated_services[service_name].get("fields", {})
+        for field_name in _iter_service_field_names(service_definition):
+            assert field_name in translated_fields, f"{service_name}.{field_name}"
+
+
+def test_service_validation_error_uses_translation_metadata() -> None:
+    """Service validation errors should be localizable by Home Assistant."""
+    error = services_mod._service_validation_error("start_service_failed", {"service": "svc"})
+
+    assert error.translation_domain == DOMAIN
+    assert error.translation_key == "start_service_failed"
+    assert error.translation_placeholders == {"service": "svc"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -14,7 +14,22 @@ import pytest
 import voluptuous as vol
 
 from custom_components.opnsense import services as services_mod
-from custom_components.opnsense.const import DOMAIN, SERVICE_GET_VNSTAT_METRICS
+from custom_components.opnsense.const import (
+    DOMAIN,
+    SERVICE_CLOSE_NOTICE,
+    SERVICE_GENERATE_VOUCHERS,
+    SERVICE_GET_VNSTAT_METRICS,
+    SERVICE_KILL_STATES,
+    SERVICE_RELOAD_INTERFACE,
+    SERVICE_RESTART_SERVICE,
+    SERVICE_RUN_SPEEDTEST,
+    SERVICE_SEND_WOL,
+    SERVICE_START_SERVICE,
+    SERVICE_STOP_SERVICE,
+    SERVICE_SYSTEM_HALT,
+    SERVICE_SYSTEM_REBOOT,
+    SERVICE_TOGGLE_ALIAS,
+)
 
 
 @pytest.mark.asyncio
@@ -42,6 +57,58 @@ async def test_async_setup_services_registers_get_vnstat_metrics_case_insensitiv
     assert validated["period"] == "yearly"
     with pytest.raises(vol.Invalid):
         schema({"period": "weekly"})
+
+
+@pytest.mark.asyncio
+async def test_async_setup_services_registers_expected_service_contracts() -> None:
+    """Service setup registers every OPNsense action with expected response behavior."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.services = MagicMock()
+    hass.services.async_register = MagicMock()
+
+    await services_mod.async_setup_services(hass)
+
+    registrations = {
+        call.kwargs["service"]: call.kwargs for call in hass.services.async_register.call_args_list
+    }
+
+    assert list(registrations) == [
+        SERVICE_CLOSE_NOTICE,
+        SERVICE_START_SERVICE,
+        SERVICE_STOP_SERVICE,
+        SERVICE_RESTART_SERVICE,
+        SERVICE_SYSTEM_HALT,
+        SERVICE_SYSTEM_REBOOT,
+        SERVICE_SEND_WOL,
+        SERVICE_RELOAD_INTERFACE,
+        SERVICE_GENERATE_VOUCHERS,
+        SERVICE_KILL_STATES,
+        SERVICE_RUN_SPEEDTEST,
+        SERVICE_GET_VNSTAT_METRICS,
+        SERVICE_TOGGLE_ALIAS,
+    ]
+    assert registrations[SERVICE_GENERATE_VOUCHERS]["supports_response"] == SupportsResponse.ONLY
+    assert registrations[SERVICE_KILL_STATES]["supports_response"] == SupportsResponse.OPTIONAL
+    assert registrations[SERVICE_RUN_SPEEDTEST]["supports_response"] == SupportsResponse.ONLY
+    assert registrations[SERVICE_GET_VNSTAT_METRICS]["supports_response"] == SupportsResponse.ONLY
+    for service in (
+        SERVICE_CLOSE_NOTICE,
+        SERVICE_START_SERVICE,
+        SERVICE_STOP_SERVICE,
+        SERVICE_RESTART_SERVICE,
+        SERVICE_SYSTEM_HALT,
+        SERVICE_SYSTEM_REBOOT,
+        SERVICE_SEND_WOL,
+        SERVICE_RELOAD_INTERFACE,
+        SERVICE_TOGGLE_ALIAS,
+    ):
+        assert "supports_response" not in registrations[service]
+
+    registrations[SERVICE_START_SERVICE]["schema"]({"service_id": "svc"})
+    registrations[SERVICE_STOP_SERVICE]["schema"]({"service_name": "svc"})
+    registrations[SERVICE_RESTART_SERVICE]["schema"]({"service_id": "svc", "only_if_running": True})
+    with pytest.raises(vol.Invalid):
+        registrations[SERVICE_START_SERVICE]["schema"]({})
 
 
 @pytest.mark.asyncio
@@ -229,7 +296,7 @@ async def test_service_start_stop_restart_success_and_failure(
 
 @pytest.mark.asyncio
 async def test_service_restart_only_if_running_and_reload_interface(
-    monkeypatch: pytest.MonkeyPatch, ph_hass: Any
+    monkeypatch: pytest.MonkeyPatch, ph_hass: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Restart service honors only_if_running and reload_interface behavior."""
     c1 = MagicMock()
@@ -254,8 +321,11 @@ async def test_service_restart_only_if_running_and_reload_interface(
 
     monkeypatch.setattr(services_mod, "_get_clients", fake_get)
     # should not raise
+    caplog.set_level("DEBUG", logger=services_mod.__name__)
     await services_mod._service_restart_service(hass, call)
     c1.restart_service_if_running.assert_awaited_once_with("svc")
+    assert "[service_restart_service] restart_service_if_running, client: c1" in caplog.text
+    assert "[service_restart_service] restart_service_if_running] client: c1" not in caplog.text
     # Ensure the non-conditional restart path was not used
     c1.restart_service.assert_not_awaited()
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -32,6 +32,31 @@ from custom_components.opnsense.const import (
 )
 
 
+def _patch_clients(monkeypatch: pytest.MonkeyPatch, clients: list[Any]) -> None:
+    """Patch service client resolution to return selected fake clients.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture used to patch the services module.
+        clients: Fake OPNsense clients returned by ``_get_clients``.
+    """
+
+    async def fake_get(*_args: Any, **_kwargs: Any) -> list[Any]:
+        """Return the selected fake clients for a service handler test.
+
+        Args:
+            *_args: Positional arguments forwarded to ``_get_clients`` and ignored.
+            **_kwargs: Keyword arguments forwarded to ``_get_clients`` and ignored.
+        """
+        return clients
+
+    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+
+
+def _voucher_call_data() -> dict[str, str]:
+    """Return a valid voucher service payload."""
+    return {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+
+
 @pytest.mark.asyncio
 async def test_async_setup_services_registers_get_vnstat_metrics_case_insensitive_period() -> None:
     """Service setup should register get_vnstat_metrics with normalized period schema."""
@@ -245,17 +270,7 @@ async def test_service_start_stop_restart_success_and_failure(
     call = MagicMock()
     call.data = {"service_id": "svc"}
 
-    # monkeypatch _get_clients to return our clients
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return both fake clients for the service start/stop/restart tests.
-
-        Args:
-            *args: Positional arguments forwarded to ``_get_clients`` and ignored.
-            **kwargs: Keyword arguments forwarded to ``_get_clients`` and ignored.
-        """
-        return [c1, c2]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1, c2])
     # start should succeed because c2 returns True
     await services_mod._service_start_service(hass, call)
     # stop should succeed
@@ -310,16 +325,7 @@ async def test_service_restart_only_if_running_and_reload_interface(
     call = MagicMock()
     call.data = {"service_id": "svc", "only_if_running": True}
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the single fake client for restart-if-running tests.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1])
     # should not raise
     caplog.set_level("DEBUG", logger=services_mod.__name__)
     await services_mod._service_restart_service(hass, call)
@@ -331,18 +337,6 @@ async def test_service_restart_only_if_running_and_reload_interface(
 
     # Failure path: client reports not running -> should raise ServiceValidationError
     c1.restart_service_if_running = AsyncMock(return_value=False)
-
-    # ensure _get_clients still returns our single client
-    async def fake_get_single(*args, **kwargs) -> Any:
-        """Return the same fake client for the restart failure branch.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get_single)
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_restart_service(hass, call)
@@ -383,16 +377,7 @@ async def test_service_start_stop_restart_failure_variants(
     setattr(ok_client, method_attr, AsyncMock(return_value=True))
     setattr(bad_client, method_attr, AsyncMock(return_value=False))
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return both clients so the service handler sees one success and one failure.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [ok_client, bad_client]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [ok_client, bad_client])
     call = MagicMock()
     call.data = {"service_id": "svc"}
 
@@ -422,16 +407,7 @@ async def test_service_start_stop_restart_require_service_identifier(
     client.stop_service = AsyncMock(return_value=True)
     client.restart_service = AsyncMock(return_value=True)
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the fake client for service identifier validation.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [client]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [client])
     call = MagicMock()
     call.data = {}
 
@@ -458,18 +434,9 @@ async def test_generate_vouchers_success_and_server_error(
     c1.generate_vouchers = AsyncMock(return_value=vouchers)
     hass.data[DOMAIN] = {"e1": c1}
     call = MagicMock()
-    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+    call.data = _voucher_call_data()
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the voucher-generating fake client for this service call.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1])
     resp = await services_mod._service_generate_vouchers(hass, call)
     assert resp is not None
     assert "vouchers" in resp and isinstance(resp["vouchers"], list)
@@ -486,11 +453,11 @@ async def test_generate_vouchers_success_and_server_error(
 @pytest.mark.asyncio
 async def test_generate_vouchers_no_clients_raises(
     ph_hass: Any,
-    fake_get_empty: Any,
+    fake_get_empty: None,
 ) -> None:
     """Generating vouchers requires at least one selected OPNsense client."""
     call = MagicMock()
-    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+    call.data = _voucher_call_data()
 
     with pytest.raises(ServiceValidationError):
         await services_mod._service_generate_vouchers(ph_hass, call)
@@ -506,18 +473,9 @@ async def test_generate_vouchers_empty_selected_client_response_returns_empty(
     client.name = "svc1"
     client.generate_vouchers = AsyncMock(return_value=[])
     call = MagicMock()
-    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+    call.data = _voucher_call_data()
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the selected voucher client for an empty response.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [client]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [client])
 
     assert await services_mod._service_generate_vouchers(ph_hass, call) == {"vouchers": []}
 
@@ -533,18 +491,9 @@ async def test_generate_vouchers_does_not_mutate_client_voucher_response(
     client.name = "svc1"
     client.generate_vouchers = AsyncMock(return_value=[voucher])
     call = MagicMock()
-    call.data = {"validity": "1", "expirytime": "2", "count": "2", "vouchergroup": "g1"}
+    call.data = _voucher_call_data()
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the selected voucher client for mutation checks.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [client]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [client])
 
     response = await services_mod._service_generate_vouchers(ph_hass, call)
 
@@ -566,16 +515,7 @@ async def test_kill_states_success_and_failure(
     call = MagicMock()
     call.data = {"ip_addr": "1.2.3.4"}
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the fake client used by the kill-states service test.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1])
     resp = await services_mod._service_kill_states(hass, call)
     # Expect a payload containing the client name and dropped_states value
     expected = {"dropped_states": [{"client_name": "c1", "dropped_states": 5}]}
@@ -603,16 +543,7 @@ async def test_run_speedtest_success_and_unavailable(
     c2.name = "c2"
     c2.run_speedtest = AsyncMock(return_value={})
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return both vnStat clients so the service can aggregate their results.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1, c2]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1, c2])
     call = MagicMock()
     call.data = {}
 
@@ -654,16 +585,7 @@ async def test_get_vnstat_metrics_success_and_unavailable(
     c2.name = "c2"
     c2.get_vnstat_metrics = AsyncMock(return_value={})
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return both vnStat clients so the service can aggregate their results.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c1, c2]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c1, c2])
     call = MagicMock()
     call.data = {"period": "yearly"}
 
@@ -696,24 +618,13 @@ async def test_get_clients_no_data_returns_empty() -> None:
 
 
 @pytest.fixture
-def fake_get_empty(monkeypatch: pytest.MonkeyPatch) -> Any:
+def fake_get_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fixture that monkeypatches services_mod._get_clients to return an empty list."""
-
-    async def _fake_get_empty(*args, **kwargs) -> Any:
-        """Return no clients so service handlers exercise their validation errors.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return []
-
-    monkeypatch.setattr(services_mod, "_get_clients", _fake_get_empty)
-    return _fake_get_empty
+    _patch_clients(monkeypatch, [])
 
 
 @pytest.mark.asyncio
-async def test_restart_service_no_clients_raises(ph_hass: Any, fake_get_empty: Any) -> None:
+async def test_restart_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
     """If no clients are found, restarting a service should raise ServiceValidationError."""
     hass = ph_hass
     hass.data = {}
@@ -726,7 +637,7 @@ async def test_restart_service_no_clients_raises(ph_hass: Any, fake_get_empty: A
 
 
 @pytest.mark.asyncio
-async def test_start_service_no_clients_raises(ph_hass: Any, fake_get_empty: Any) -> None:
+async def test_start_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
     """If no clients are found, starting a service should raise ServiceValidationError."""
     hass = ph_hass
     hass.data = {}
@@ -739,7 +650,7 @@ async def test_start_service_no_clients_raises(ph_hass: Any, fake_get_empty: Any
 
 
 @pytest.mark.asyncio
-async def test_stop_service_no_clients_raises(ph_hass: Any, fake_get_empty: Any) -> None:
+async def test_stop_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
     """If no clients are found, stopping a service should raise ServiceValidationError."""
     hass = ph_hass
     hass.data = {}
@@ -762,16 +673,7 @@ async def test_close_send_wol_and_system_calls(monkeypatch: pytest.MonkeyPatch) 
     c.system_halt = AsyncMock(return_value=None)
     c.system_reboot = AsyncMock(return_value=None)
 
-    async def fake_get(*args, **kwargs) -> Any:
-        """Return the single client used for notice, WOL, and system action tests.
-
-        Args:
-            *args: Additional positional arguments forwarded by the function.
-            **kwargs: Additional keyword arguments forwarded by the function.
-        """
-        return [c]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get)
+    _patch_clients(monkeypatch, [c])
 
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {"e1": c}}
@@ -805,16 +707,7 @@ async def test_toggle_alias_success_and_failure(monkeypatch: pytest.MonkeyPatch)
     c1.name = "c1"
     c1.toggle_alias = AsyncMock(return_value=True)
 
-    async def fake_get_ok(*args, **kwargs) -> Any:
-        """Return the client that reports alias toggling success.
-
-        Args:
-            *args: Positional arguments forwarded to ``_get_clients`` and ignored.
-            **kwargs: Keyword arguments forwarded to ``_get_clients`` and ignored.
-        """
-        return [c1]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get_ok)
+    _patch_clients(monkeypatch, [c1])
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {DOMAIN: {"e1": c1}}
     call = MagicMock()
@@ -827,16 +720,7 @@ async def test_toggle_alias_success_and_failure(monkeypatch: pytest.MonkeyPatch)
     c2.name = "c2"
     c2.toggle_alias = AsyncMock(return_value=False)
 
-    async def fake_get_fail(*args, **kwargs) -> Any:
-        """Return the client that reports alias toggling failure.
-
-        Args:
-            *args: Positional arguments forwarded to ``_get_clients`` and ignored.
-            **kwargs: Keyword arguments forwarded to ``_get_clients`` and ignored.
-        """
-        return [c2]
-
-    monkeypatch.setattr(services_mod, "_get_clients", fake_get_fail)
+    _patch_clients(monkeypatch, [c2])
     hass.data = {DOMAIN: {"e2": c2}}
     with pytest.raises(ServiceValidationError):
         await services_mod._service_toggle_alias(hass, call)


### PR DESCRIPTION
## Summary
Refines the OPNsense service layer so service registration, target resolution, service identifier handling, and localized validation errors are centralized and consistently tested on top of the pyopnsense-removal branch.

This keeps the public service surface intact while making failure behavior explicit for selected clients and service actions.

## What Changed
- Added shared helpers for service registration, common target selector schema fields, service identifier schema fields, and localized `ServiceValidationError` construction.
- Split `service_id` and `service_name` into explicit fields for start, stop, and restart services in `services.yaml` and English translations.
- Added translated exception messages for service action failures, missing target clients, missing service identifiers, voucher server errors, Speedtest/vnStat availability, alias toggles, and interface reload failures.
- Tightened target resolution so explicit device or entity targets that do not resolve to OPNsense clients raise a localized validation error instead of silently running against no clients.
- Refactored boolean client actions for start, stop, restart, reload interface, and toggle alias so any selected-client failure is treated as service failure.
- Preserved response aggregation behavior for vouchers, kill states, Speedtest, and vnStat while expanding edge-case coverage.
- Reworked `tests/test_services.py` fixtures and parameterized cases to cover service registration schemas, target selection, failure ordering, missing identifiers, and response edge behavior.

## Why
The service module had repeated schema and handler patterns that made validation behavior easy to drift between services. Centralizing those paths keeps service behavior consistent as the integration moves forward on the `Remove-pyopnsense` base and makes Home Assistant-facing errors localizable instead of relying on ad hoc messages.

## Validation
- `./.venv/bin/pytest` - 683 passed
- `./.venv/bin/prek run -a` - passed
- `git diff --check` - passed

## Related Issues
Refs the pyopnsense-removal work in `Remove-pyopnsense`.
