### PR TITLE
Harden entity setup against malformed rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__
 pyvenv.cfg
 $RECYCLE.BIN/
 coverage.xml
+coverage.json
 env.bak/
 env/
 ENV/

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -75,6 +75,8 @@ async def async_setup_entry(
         for mac_address in mac_addresses:
             device: dict[str, Any] = {"mac": mac_address}
             for arp_entry in arp_entries:
+                if not isinstance(arp_entry, MutableMapping):
+                    continue
                 if mac_address == arp_entry.get("mac", ""):
                     try:
                         for attr in ("hostname", "manufacturer"):
@@ -87,6 +89,8 @@ async def async_setup_entry(
             devices.append(device)
     elif config_entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED):
         for arp_entry in arp_entries:
+            if not isinstance(arp_entry, MutableMapping):
+                continue
             mac_address = arp_entry.get("mac", None)
             if mac_address and mac_address not in mac_addresses:
                 device = {"mac": mac_address}

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -211,30 +211,27 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             self.async_write_ha_state()
             return
         self._available = True
-        entry: dict[str, Any] | None = None
+        entry: MutableMapping[str, object] | None = None
         for arp_entry in arp_table:
-            if arp_entry.get("mac", "").lower() == self._attr_mac_address:
-                entry = arp_entry
+            if not isinstance(arp_entry, MutableMapping):
+                continue
+            arp_row: MutableMapping[str, object] = arp_entry
+            mac = arp_row.get("mac")
+            if isinstance(mac, str) and mac.lower() == self._attr_mac_address:
+                entry = arp_row
                 break
         if not entry:
             entry = {}
         # _LOGGER.debug(f"[OPNsenseScannerEntity handle_coordinator_update] entry: {entry}")
-        try:
-            self._attr_ip_address = entry.get("ip") if len(entry.get("ip", 0)) > 0 else None
-        except TypeError, KeyError, AttributeError:
-            self._attr_ip_address = None
+        ip_address = entry.get("ip")
+        self._attr_ip_address = ip_address if isinstance(ip_address, str) and ip_address else None
 
         if self._attr_ip_address:
             self._last_known_ip = self._attr_ip_address
 
-        try:
-            self._attr_hostname = (
-                entry.get("hostname", "").strip("?")
-                if len(entry.get("hostname", "").strip("?")) > 0
-                else None
-            )
-        except TypeError, KeyError, AttributeError:
-            self._attr_hostname = None
+        hostname = entry.get("hostname")
+        stripped_hostname = hostname.strip("?") if isinstance(hostname, str) else ""
+        self._attr_hostname = stripped_hostname or None
 
         if self._attr_hostname:
             self._last_known_hostname = self._attr_hostname
@@ -278,7 +275,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
                     if prop_name == "expires":
                         if prop == -1:
                             self._attr_extra_state_attributes[prop_name] = "Never"
-                        else:
+                        elif isinstance(prop, int | float):
                             self._attr_extra_state_attributes[prop_name] = (
                                 datetime.now().astimezone() + timedelta(seconds=prop)
                             )

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -1,5 +1,6 @@
 """Define the base entities for OPNsense."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -18,6 +19,30 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
     """Base entity for OPNsense."""
+
+    @staticmethod
+    def payload_display_name(
+        payload: Mapping[str, Any],
+        fallback: str,
+        *fields: str,
+    ) -> str:
+        """Return a stable display label from a dynamic state payload.
+
+        Args:
+            payload: Mapping payload that may contain one of the display fields.
+            fallback: Value to use when none of the fields contain a displayable value.
+            *fields: Ordered field names to prefer for the display label.
+
+        Returns:
+            String display label from the first usable field, otherwise the fallback.
+        """
+        for field in fields:
+            value = payload.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if value is not None and not isinstance(value, Mapping | list | tuple | set):
+                return str(value)
+        return fallback
 
     def __init__(
         self,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -401,7 +401,13 @@ async def _compile_filesystem_sensors(
         return []
     entities: list = []
 
-    for filesystem in dict_get(state, "telemetry.filesystems", []) or []:
+    filesystems = dict_get(state, "telemetry.filesystems", []) or []
+    if not isinstance(filesystems, list):
+        return entities
+
+    for filesystem in filesystems:
+        if not isinstance(filesystem, MutableMapping):
+            continue
         filesystem_slug: str = slugify_filesystem_mountpoint(filesystem.get("mountpoint", None))
         enabled_default = False
         if filesystem_slug == "root":
@@ -572,7 +578,13 @@ async def _compile_interface_sensors(
     entities: list = []
 
     # interfaces
-    for interface_name, interface in (dict_get(state, "interfaces", {}) or {}).items():
+    interfaces = dict_get(state, "interfaces", {}) or {}
+    if not isinstance(interfaces, MutableMapping):
+        return entities
+
+    for interface_name, interface in interfaces.items():
+        if not isinstance(interface, MutableMapping):
+            continue
         for prop_name in (
             "status",
             "inerrs",
@@ -670,7 +682,14 @@ async def _compile_gateway_sensors(
         return []
     entities: list = []
 
-    for gateway in (dict_get(state, "gateways", {}) or {}).values():
+    gateways = dict_get(state, "gateways", {}) or {}
+    if not isinstance(gateways, MutableMapping):
+        return entities
+
+    for gateway_id, gateway in gateways.items():
+        if not isinstance(gateway, MutableMapping):
+            continue
+        gateway_name = str(gateway.get("name") or gateway_id)
         for prop_name in ("status", "delay", "stddev", "loss", "address"):
             native_unit_of_measurement = None
             device_class: SensorDeviceClass | None = None
@@ -698,8 +717,8 @@ async def _compile_gateway_sensors(
                 config_entry=config_entry,
                 coordinator=coordinator,
                 entity_description=SensorEntityDescription(
-                    key=f"gateway.{gateway['name']}.{prop_name}",
-                    name=f"Gateway {gateway['name']} {prop_name}",
+                    key=f"gateway.{gateway_name}.{prop_name}",
+                    name=f"Gateway {gateway_name} {prop_name}",
                     native_unit_of_measurement=native_unit_of_measurement,
                     device_class=device_class,
                     icon=icon,
@@ -730,7 +749,13 @@ async def _compile_temperature_sensors(
     entities: list = []
 
     # temperatures
-    for temp_device, temp in state.get("telemetry", {}).get("temps", {}).items():
+    temps = dict_get(state, "telemetry.temps", {}) or {}
+    if not isinstance(temps, MutableMapping):
+        return entities
+
+    for temp_device, temp in temps.items():
+        if not isinstance(temp, MutableMapping):
+            continue
         entity = OPNsenseTempSensor(
             config_entry=config_entry,
             coordinator=coordinator,
@@ -768,9 +793,11 @@ async def _compile_dhcp_leases_sensors(
     entities: list = []
 
     # interfaces
-    for interface, interface_name in (
-        dict_get(state, "dhcp_leases.lease_interfaces", {}) or {}
-    ).items():
+    lease_interfaces = dict_get(state, "dhcp_leases.lease_interfaces", {}) or {}
+    if not isinstance(lease_interfaces, MutableMapping):
+        lease_interfaces = {}
+
+    for interface, interface_name in lease_interfaces.items():
         entity = OPNsenseDHCPLeasesSensor(
             config_entry=config_entry,
             coordinator=coordinator,
@@ -806,6 +833,25 @@ async def _compile_dhcp_leases_sensors(
     return entities
 
 
+def _get_vpn_instance_name(instance: MutableMapping[str, Any], uuid: str) -> str:
+    """Return a stable display name for a VPN instance.
+
+    Args:
+        instance: VPN instance payload from the coordinator state.
+        uuid: VPN instance UUID used as the last-resort display value.
+
+    Returns:
+        VPN display name from the preferred payload fields or the UUID.
+    """
+    for field in ("name", "description"):
+        value = instance.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if value is not None and not isinstance(value, MutableMapping | list | tuple | set):
+            return str(value)
+    return uuid
+
+
 async def _compile_vpn_sensors(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -832,6 +878,7 @@ async def _compile_vpn_sensors(
             ).items():
                 if not isinstance(instance, MutableMapping) or len(instance) == 0:
                     continue
+                instance_name = _get_vpn_instance_name(instance, uuid)
                 properties: list[str] = [
                     "total_bytes_recv",
                     "total_bytes_sent",
@@ -884,7 +931,7 @@ async def _compile_vpn_sensors(
                         entity_description=SensorEntityDescription(
                             key=f"{vpn_type}.{clients_servers}.{uuid}.{prop_name}",
                             name=f"{'OpenVPN' if vpn_type == 'openvpn' else vpn_type.title()} "
-                            f"{clients_servers.title().rstrip('s')} {instance['name']} "
+                            f"{clients_servers.title().rstrip('s')} {instance_name} "
                             f"{prop_name}",
                             native_unit_of_measurement=native_unit_of_measurement,
                             device_class=device_class,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -727,6 +727,7 @@ async def _compile_gateway_sensors(
                     entity_registry_enabled_default=enabled_default,
                     # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
+                unique_id_suffix=f"gateway.{gateway_name}.{prop_name}",
             )
             entities.append(entity)
 
@@ -1004,14 +1005,21 @@ class OPNsenseSensor(OPNsenseEntity, SensorEntity):
         config_entry: ConfigEntry,
         coordinator: OPNsenseDataUpdateCoordinator,
         entity_description: SensorEntityDescription,
+        unique_id_suffix: str | None = None,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the sensor.
+
+        Args:
+            config_entry: Config entry that owns this sensor.
+            coordinator: Coordinator providing OPNsense state updates.
+            entity_description: Description containing the sensor lookup key and metadata.
+            unique_id_suffix: Optional unique ID suffix when it differs from the lookup key.
+        """
         name_suffix: str | None = (
             entity_description.name if isinstance(entity_description.name, str) else None
         )
-        unique_id_suffix: str | None = (
-            entity_description.key if isinstance(entity_description.key, str) else None
-        )
+        if unique_id_suffix is None and isinstance(entity_description.key, str):
+            unique_id_suffix = entity_description.key
         super().__init__(
             config_entry,
             coordinator,
@@ -1530,6 +1538,30 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
 
 class OPNsenseGatewaySensor(OPNsenseSensor):
     """Class for OPNsense Gateway Sensors."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+        unique_id_suffix: str | None = None,
+    ) -> None:
+        """Initialize a gateway sensor with optional unique-id override.
+
+        Args:
+            config_entry: Config entry that owns this sensor.
+            coordinator: Coordinator providing OPNsense state updates.
+            entity_description: Description containing the raw gateway lookup key.
+            unique_id_suffix: Optional legacy/display-name-based unique ID suffix.
+        """
+        if unique_id_suffix is None:
+            unique_id_suffix = entity_description.key
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+            unique_id_suffix=unique_id_suffix,
+        )
 
     def _opnsense_get_gateway_property_name(self) -> str:
         """Opnsense get gateway property name."""

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -854,9 +854,10 @@ async def _compile_vpn_sensors(
         if vpn_type == "wireguard":
             cs = ["clients", "servers"]
         for clients_servers in cs:
-            for uuid, instance in (
-                dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
-            ).items():
+            vpn_instances = dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
+            if not isinstance(vpn_instances, MutableMapping):
+                continue
+            for uuid, instance in vpn_instances.items():
                 if not isinstance(instance, MutableMapping) or len(instance) == 0:
                     continue
                 instance_name = OPNsenseEntity.payload_display_name(
@@ -1272,7 +1273,17 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
             self._available = False
             self.async_write_ha_state()
             return
-        for fsystem in state.get("telemetry", {}).get("filesystems", []):
+        telemetry = state.get("telemetry")
+        if not isinstance(telemetry, Mapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+        filesystems = telemetry.get("filesystems")
+        if not isinstance(filesystems, list):
+            self._available = False
+            self.async_write_ha_state()
+            return
+        for fsystem in filesystems:
             if not isinstance(fsystem, Mapping):
                 continue
             filesystem_row: Mapping[str, object] = fsystem
@@ -1591,9 +1602,12 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             return
         uuid: str = self.entity_description.key.split(".")[2]
         instance: Mapping[str, object] = {}
-        for instance_uuid, ins in (
-            dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
-        ).items():
+        vpn_instances = dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
+        if not isinstance(vpn_instances, Mapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+        for instance_uuid, ins in vpn_instances.items():
             if not isinstance(ins, Mapping):
                 continue
             instance_row: Mapping[str, object] = ins

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -689,7 +689,7 @@ async def _compile_gateway_sensors(
     for gateway_id, gateway in gateways.items():
         if not isinstance(gateway, MutableMapping):
             continue
-        gateway_name = str(gateway.get("name") or gateway_id)
+        gateway_name = OPNsenseEntity.payload_display_name(gateway, str(gateway_id), "name")
         for prop_name in ("status", "delay", "stddev", "loss", "address"):
             native_unit_of_measurement = None
             device_class: SensorDeviceClass | None = None
@@ -833,25 +833,6 @@ async def _compile_dhcp_leases_sensors(
     return entities
 
 
-def _get_vpn_instance_name(instance: MutableMapping[str, Any], uuid: str) -> str:
-    """Return a stable display name for a VPN instance.
-
-    Args:
-        instance: VPN instance payload from the coordinator state.
-        uuid: VPN instance UUID used as the last-resort display value.
-
-    Returns:
-        VPN display name from the preferred payload fields or the UUID.
-    """
-    for field in ("name", "description"):
-        value = instance.get(field)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-        if value is not None and not isinstance(value, MutableMapping | list | tuple | set):
-            return str(value)
-    return uuid
-
-
 async def _compile_vpn_sensors(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -878,7 +859,12 @@ async def _compile_vpn_sensors(
             ).items():
                 if not isinstance(instance, MutableMapping) or len(instance) == 0:
                     continue
-                instance_name = _get_vpn_instance_name(instance, uuid)
+                instance_name = OPNsenseEntity.payload_display_name(
+                    instance,
+                    str(uuid),
+                    "name",
+                    "description",
+                )
                 properties: list[str] = [
                     "total_bytes_recv",
                     "total_bytes_sent",

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -690,6 +690,7 @@ async def _compile_gateway_sensors(
         if not isinstance(gateway, MutableMapping):
             continue
         gateway_name = OPNsenseEntity.payload_display_name(gateway, str(gateway_id), "name")
+        gateway_key = str(gateway_id)
         for prop_name in ("status", "delay", "stddev", "loss", "address"):
             native_unit_of_measurement = None
             device_class: SensorDeviceClass | None = None
@@ -717,7 +718,7 @@ async def _compile_gateway_sensors(
                 config_entry=config_entry,
                 coordinator=coordinator,
                 entity_description=SensorEntityDescription(
-                    key=f"gateway.{gateway_name}.{prop_name}",
+                    key=f"gateway.{gateway_key}.{prop_name}",
                     name=f"Gateway {gateway_name} {prop_name}",
                     native_unit_of_measurement=native_unit_of_measurement,
                     device_class=device_class,
@@ -1309,7 +1310,8 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
 
         self._attr_extra_state_attributes = {}
         for attr in ("mountpoint", "device", "type", "blocks", "used", "available"):
-            self._attr_extra_state_attributes[attr] = filesystem[attr]
+            if attr in filesystem:
+                self._attr_extra_state_attributes[attr] = filesystem[attr]
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1266,18 +1266,23 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        filesystem: dict[str, Any] = {}
+        filesystem: Mapping[str, object] = {}
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
             self._available = False
             self.async_write_ha_state()
             return
         for fsystem in state.get("telemetry", {}).get("filesystems", []):
+            if not isinstance(fsystem, Mapping):
+                continue
+            filesystem_row: Mapping[str, object] = fsystem
+            mountpoint = filesystem_row.get("mountpoint")
             if (
-                self.entity_description.key == "telemetry.filesystems."
-                f"{slugify_filesystem_mountpoint(fsystem.get('mountpoint', None))}"
+                isinstance(mountpoint, str)
+                and self.entity_description.key
+                == f"telemetry.filesystems.{slugify_filesystem_mountpoint(mountpoint)}"
             ):
-                filesystem = fsystem
+                filesystem = filesystem_row
         if not filesystem:
             self._available = False
             self.async_write_ha_state()
@@ -1585,12 +1590,15 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
         uuid: str = self.entity_description.key.split(".")[2]
-        instance: dict[str, Any] = {}
+        instance: Mapping[str, object] = {}
         for instance_uuid, ins in (
             dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
         ).items():
+            if not isinstance(ins, Mapping):
+                continue
+            instance_row: Mapping[str, object] = ins
             if uuid == instance_uuid:
-                instance = ins
+                instance = instance_row
                 break
         prop_name: str = self._get_property_name()
         if not instance or (
@@ -1665,13 +1673,21 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             if instance.get(attr, None) is not None:
                 self._attr_extra_state_attributes[attr] = instance.get(attr)
 
+        clients = instance.get("clients")
         if (
-            isinstance(instance.get("clients", None), list)
+            isinstance(clients, list)
             and clients_servers == "servers"
-            and prop_name in {"connected_clients", "status"}
+            and prop_name
+            in {
+                "connected_clients",
+                "status",
+            }
         ):
             self._attr_extra_state_attributes["clients"] = []
-            for clnt in instance.get("clients", {}):
+            for clnt in clients:
+                if not isinstance(clnt, Mapping):
+                    continue
+                client_row: Mapping[str, object] = clnt
                 client: dict[str, Any] = {}
                 for client_attr in (
                     "name",
@@ -1682,8 +1698,8 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                     "bytes_sent",
                     "bytes_recv",
                 ):
-                    if clnt.get(client_attr, None) is not None:
-                        client[client_attr] = clnt.get(client_attr)
+                    if client_row.get(client_attr, None) is not None:
+                        client[client_attr] = client_row.get(client_attr)
                 self._attr_extra_state_attributes["clients"].append(client)
         self.async_write_ha_state()
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1532,6 +1532,8 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             return None
         service_id: str = self._opnsense_get_service_id()
         for service in state.get("services", []):
+            if not isinstance(service, MutableMapping):
+                continue
             if service.get("id", None) == service_id:
                 return service
         return None

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -199,6 +199,8 @@ async def _compile_service_switches(
     entities: list = []
     # services
     for service in state.get("services", []):
+        if not isinstance(service, MutableMapping):
+            continue
         if service.get("locked", 1) == 1:
             continue
         for prop_name in ["status"]:
@@ -239,12 +241,21 @@ async def _compile_vpn_switches(
         for clients_servers in ("clients", "servers"):
             if not isinstance(state, MutableMapping):
                 return []
-            for uuid, instance in state.get(vpn_type, {}).get(clients_servers, {}).items():
+            vpn_instances = dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
+            if not isinstance(vpn_instances, MutableMapping):
+                continue
+            for uuid, instance in vpn_instances.items():
                 if (
                     not isinstance(instance, MutableMapping)
                     or instance.get("enabled", None) is None
                 ):
                     continue
+                instance_name = OPNsenseEntity.payload_display_name(
+                    instance,
+                    str(uuid),
+                    "name",
+                    "description",
+                )
 
                 entity = OPNsenseVPNSwitch(
                     config_entry=config_entry,
@@ -252,7 +263,7 @@ async def _compile_vpn_switches(
                     entity_description=SwitchEntityDescription(
                         key=f"{vpn_type}.{clients_servers}.{uuid}",
                         name=f"{'OpenVPN' if vpn_type == 'openvpn' else vpn_type.title()} "
-                        f"{clients_servers.title().rstrip('s')} {instance['name']}",
+                        f"{clients_servers.title().rstrip('s')} {instance_name}",
                         icon="mdi:folder-key-network-outline",
                         # entity_category=ENTITY_CATEGORY_CONFIG,
                         device_class=SwitchDeviceClass.SWITCH,
@@ -349,7 +360,10 @@ async def _compile_unbound_switches(
     if not isinstance(state, MutableMapping):
         return []
     entities: list = []
-    for uuid, dnsbl in state.get(ATTR_UNBOUND_BLOCKLIST, {}).items():
+    dnsbl_entries = state.get(ATTR_UNBOUND_BLOCKLIST, {})
+    if not isinstance(dnsbl_entries, MutableMapping):
+        return []
+    for uuid, dnsbl in dnsbl_entries.items():
         if not isinstance(dnsbl, MutableMapping):
             continue
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1531,7 +1531,10 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         if not isinstance(state, MutableMapping):
             return None
         service_id: str = self._opnsense_get_service_id()
-        for service in state.get("services", []):
+        services = state.get("services")
+        if not isinstance(services, list):
+            return None
+        for service in services:
             if not isinstance(service, MutableMapping):
                 continue
             if service.get("id", None) == service_id:

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1551,6 +1551,8 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             return
         self._service = self._opnsense_get_service()
         if not isinstance(self._service, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
             return
         try:
             self._attr_is_on = self._service[self._prop_name]

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -249,6 +249,40 @@ def test_handle_coordinator_update_entry_present(
     assert ent.icon == "mdi:lan-connect"
 
 
+def test_handle_coordinator_update_skips_malformed_arp_rows(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed rows in arp_table should be skipped and valid rows still apply."""
+    coordinator.data = {
+        "arp_table": [
+            "not-an-arp-row",
+            {
+                "mac": "aa:bb:cc",
+                "ip": "1.2.3.4",
+                "hostname": "host?",
+                "manufacturer": "m",
+            },
+        ]
+    }
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.ip_address == "1.2.3.4"
+    assert ent.hostname == "host"
+
+
 def test_handle_coordinator_update_missing_entry_consider_home(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -91,6 +91,39 @@ async def test_async_setup_entry_configured_devices(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_skips_malformed_arp_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Malformed ARP rows should not prevent valid device trackers from being created."""
+    coordinator.data = {
+        "arp_table": [
+            "not-an-arp-row",
+            {"mac": "aa:bb:cc", "ip": "1.2.3.4", "hostname": "dev", "manufacturer": "m"},
+        ]
+    }
+    entry = make_config_entry(
+        data={dt_mod.TRACKED_MACS: [], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        entry_id="eid",
+    )
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    hass = ph_hass
+    hass.config_entries.async_update_entry = MagicMock()
+    fake = fake_reg_factory(device_exists=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    added: list[Any] = []
+
+    await dt_mod.async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 1
+    assert added[0].mac_address == "aa:bb:cc"
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -28,7 +28,10 @@ async def test_async_setup_entry_configured_devices(
 ) -> None:
     """Setup creates device tracker entities for configured MACs."""
     coordinator.data = {
-        "arp_table": [{"mac": "aa:bb:cc", "ip": "1.2.3.4", "hostname": "dev", "manufacturer": "m"}]
+        "arp_table": [
+            "not-an-arp-row",
+            {"mac": "aa:bb:cc", "ip": "1.2.3.4", "hostname": "dev", "manufacturer": "m"},
+        ]
     }
 
     entry = make_config_entry(
@@ -247,6 +250,43 @@ def test_handle_coordinator_update_entry_present(
     assert ent.extra_state_attributes.get("interface") == "lan0"
     assert ent.extra_state_attributes.get("type") == "arp"
     assert ent.icon == "mdi:lan-connect"
+
+
+def test_handle_coordinator_update_skips_malformed_arp_rows(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed rows in arp_table should be skipped and valid rows still apply."""
+    coordinator.data = {
+        "arp_table": [
+            "not-an-arp-row",
+            {"mac": "dd:ee:ff", "ip": "5.6.7.8"},
+            {
+                "mac": "aa:bb:cc",
+                "ip": "1.2.3.4",
+                "hostname": "host?",
+                "manufacturer": "m",
+                "expires": "not-a-duration",
+            },
+        ]
+    }
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.ip_address == "1.2.3.4"
+    assert ent.hostname == "host"
+    assert "expires" not in ent.extra_state_attributes
 
 
 def test_handle_coordinator_update_missing_entry_consider_home(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,6 +12,11 @@ from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.entity import OPNsenseBaseEntity, OPNsenseEntity
 
 
+def test_payload_display_name_uses_scalar_fallback() -> None:
+    """Display names use scalar payload values when no string field is available."""
+    assert OPNsenseEntity.payload_display_name({"name": 42}, "fallback", "name") == "42"
+
+
 def test_init_sets_unique_and_name_suffixes(
     make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2022,20 +2022,65 @@ async def test_async_setup_entry_creates_entities(
     assert any(isinstance(e, OPNsenseStaticKeySensor) for e in created)
 
 
+@pytest.mark.parametrize(
+    ("state", "expected_key", "expected_name", "absent_classes"),
+    [
+        (
+            {
+                "telemetry": {"filesystems": [], "temps": {}},
+                "interfaces": {},
+                "gateways": {},
+                "openvpn": {
+                    "servers": {"server-uuid": {"description": "Remote Access", "status": "up"}}
+                },
+            },
+            "openvpn.servers.server-uuid.status",
+            "OpenVPN Server Remote Access status",
+            (),
+        ),
+        (
+            {
+                "telemetry": {"filesystems": [], "temps": {}},
+                "interfaces": {},
+                "gateways": {"wan": {"status": "online", "delay": "12ms", "loss": "0%"}},
+                "openvpn": {"servers": {}},
+            },
+            "gateway.wan.status",
+            "Gateway wan status",
+            (),
+        ),
+        (
+            {
+                "telemetry": {
+                    "filesystems": ["not-a-filesystem"],
+                    "temps": {"cpu": "not-a-temp"},
+                },
+                "interfaces": {"wan": "not-an-interface"},
+                "gateways": {"wan": "not-a-gateway"},
+                "openvpn": {"servers": {}},
+            },
+            None,
+            None,
+            (
+                OPNsenseFilesystemSensor,
+                OPNsenseTempSensor,
+                OPNsenseInterfaceSensor,
+                OPNsenseGatewaySensor,
+            ),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_async_setup_entry_creates_entities_when_vpn_name_is_missing(
+async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_payloads(
     make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    expected_key: str | None,
+    expected_name: str | None,
+    absent_classes: tuple[type[object], ...],
 ) -> None:
-    """Missing VPN instance names should not prevent other sensors from being created."""
-    state: dict[str, Any] = {
-        "telemetry": {"filesystems": [], "temps": {}},
-        "interfaces": {},
-        "gateways": {},
-        "openvpn": {"servers": {"server-uuid": {"description": "Remote Access", "status": "up"}}},
-    }
+    """Partial or malformed dynamic sensor payloads should not block setup."""
     entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
-
-    created: list = []
+    created: list[Any] = []
 
     def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
         """Add entities.
@@ -2048,76 +2093,13 @@ async def test_async_setup_entry_creates_entities_when_vpn_name_is_missing(
     await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
 
     assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
-    vpn_status = next(
-        entity
-        for entity in created
-        if entity.entity_description.key == "openvpn.servers.server-uuid.status"
-    )
-    assert vpn_status.entity_description.name == "OpenVPN Server Remote Access status"
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_creates_entities_when_gateway_name_is_missing(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing gateway names should not prevent other sensors from being created."""
-    state: dict[str, Any] = {
-        "telemetry": {"filesystems": [], "temps": {}},
-        "interfaces": {},
-        "gateways": {"wan": {"status": "online", "delay": "12ms", "loss": "0%"}},
-        "openvpn": {"servers": {}},
-    }
-    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
-
-    created: list = []
-
-    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
-        """Add entities.
-
-        Args:
-            entities: Entities provided by pytest or the test case.
-        """
-        created.extend(entities)
-
-    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
-
-    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
-    gateway_status = next(
-        entity for entity in created if entity.entity_description.key == "gateway.wan.status"
-    )
-    assert gateway_status.entity_description.name == "Gateway wan status"
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_creates_entities_with_malformed_dynamic_sensor_rows(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Malformed dynamic sensor rows should not prevent other sensors from being created."""
-    state: dict[str, Any] = {
-        "telemetry": {"filesystems": ["not-a-filesystem"], "temps": {"cpu": "not-a-temp"}},
-        "interfaces": {"wan": "not-an-interface"},
-        "gateways": {"wan": "not-a-gateway"},
-        "openvpn": {"servers": {}},
-    }
-    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
-
-    created: list = []
-
-    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
-        """Add entities.
-
-        Args:
-            entities: Entities provided by pytest or the test case.
-        """
-        created.extend(entities)
-
-    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
-
-    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
-    assert not any(isinstance(entity, OPNsenseFilesystemSensor) for entity in created)
-    assert not any(isinstance(entity, OPNsenseTempSensor) for entity in created)
-    assert not any(isinstance(entity, OPNsenseInterfaceSensor) for entity in created)
-    assert not any(isinstance(entity, OPNsenseGatewaySensor) for entity in created)
+    if expected_key is not None:
+        matched = next(
+            entity for entity in created if entity.entity_description.key == expected_key
+        )
+        assert matched.entity_description.name == expected_name
+    for entity_class in absent_classes:
+        assert not any(isinstance(entity, entity_class) for entity in created)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2241,38 +2241,18 @@ def test_filesystem_sensor_skips_malformed_rows(
     assert attrs.get("mountpoint") == "/"
 
 
-def test_filesystem_sensor_unavailable_with_malformed_filesystems_container(
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"telemetry": {"filesystems": "bad-filesystems"}},
+        {"telemetry": "bad-telemetry"},
+    ],
+)
+def test_filesystem_sensor_unavailable_with_malformed_containers(
     make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
 ) -> None:
-    """Malformed filesystem container should mark filesystem sensor as unavailable."""
-    state = {
-        "telemetry": {"filesystems": "bad-filesystems"},
-    }
-    entry = make_config_entry()
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = state
-    desc = MagicMock()
-    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
-    desc.name = "Filesystem Test"
-
-    sensor = OPNsenseFilesystemSensor(
-        config_entry=entry,
-        coordinator=coord,
-        entity_description=desc,
-    )
-    sensor.hass = MagicMock()
-    sensor.entity_id = "sensor.fs_root"
-    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
-    sensor._handle_coordinator_update()
-
-    assert sensor.available is False
-
-
-def test_filesystem_sensor_unavailable_with_malformed_telemetry_container(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Malformed telemetry container should mark filesystem sensor as unavailable."""
-    state = {"telemetry": "bad-telemetry"}
+    """Malformed telemetry or filesystem containers should mark the sensor unavailable."""
     entry = make_config_entry()
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = state

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -143,7 +143,7 @@ async def test_compile_gateway_sensors_keeps_gateway_id_in_entity_key(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Gateway display name should not be used as the entity key."""
-    entry = make_config_entry()
+    entry = make_config_entry({"device_unique_id": "router-id"})
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coordinator.data = {
         "gateways": {
@@ -159,8 +159,19 @@ async def test_compile_gateway_sensors_keeps_gateway_id_in_entity_key(
     }
 
     entities = await sensor_module._compile_gateway_sensors(entry, coordinator, coordinator.data)
-    assert any(entity.entity_description.key == "gateway.wan.address" for entity in entities)
-    assert any(entity.entity_description.name == "Gateway WAN_GW address" for entity in entities)
+    address_entity = next(
+        entity for entity in entities if entity.entity_description.key == "gateway.wan.address"
+    )
+    status_entity = next(
+        entity for entity in entities if entity.entity_description.key == "gateway.wan.status"
+    )
+    assert address_entity.entity_description.name == "Gateway WAN_GW address"
+    assert address_entity._attr_unique_id == sensor_module.slugify(
+        f"{entry.data['device_unique_id']}_gateway.WAN_GW.address"
+    )
+    assert status_entity._attr_unique_id == sensor_module.slugify(
+        f"{entry.data['device_unique_id']}_gateway.WAN_GW.status"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2286,6 +2297,39 @@ def test_filesystem_sensor_handles_partial_telemetry_row(
     assert attrs.get("mountpoint") == "/"
     assert attrs.get("type") == "ext4"
     assert "device" not in attrs
+
+
+def test_filesystem_sensor_unavailable_when_used_percent_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Filesystem sensor should become unavailable when the matched row lacks usage."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                {"mountpoint": "/", "type": "ext4"},
+            ],
+            "temps": {},
+        },
+        "interfaces": {},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -139,6 +139,30 @@ async def test_compile_gateway_sensors_creates_disabled_address_sensor(
     assert address_sensor.entity_description.entity_registry_enabled_default is False
 
 
+async def test_compile_gateway_sensors_keeps_gateway_id_in_entity_key(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Gateway display name should not be used as the entity key."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {
+        "gateways": {
+            "wan": {
+                "name": "WAN_GW",
+                "address": "203.0.113.1",
+                "delay": "15ms",
+                "stddev": "1ms",
+                "loss": "0%",
+                "status": "online",
+            }
+        }
+    }
+
+    entities = await sensor_module._compile_gateway_sensors(entry, coordinator, coordinator.data)
+    assert any(entity.entity_description.key == "gateway.wan.address" for entity in entities)
+    assert any(entity.entity_description.name == "Gateway WAN_GW address" for entity in entities)
+
+
 @pytest.mark.parametrize(
     ("coord_data", "desc_subnet"),
     [
@@ -2223,6 +2247,45 @@ def test_filesystem_sensor_skips_malformed_rows(
     attrs = sensor.extra_state_attributes
     assert attrs is not None
     assert attrs.get("mountpoint") == "/"
+
+
+def test_filesystem_sensor_handles_partial_telemetry_row(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Filesystem sensor should tolerate partial telemetry rows and keep available state."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                {"mountpoint": "/", "used_pct": 12, "type": "ext4"},
+            ],
+            "temps": {},
+        },
+        "interfaces": {},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 12
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("mountpoint") == "/"
+    assert attrs.get("type") == "ext4"
+    assert "device" not in attrs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -929,6 +929,45 @@ def test_vpn_sensor_variants(
                 assert key in attrs
 
 
+def test_vpn_sensor_skips_malformed_client_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed nested VPN client rows should be skipped and valid clients still parsed."""
+    state = {
+        "openvpn": {
+            "servers": {
+                "uuid1": {
+                    "name": "ovpn1",
+                    "status": "up",
+                    "clients": [
+                        "bad-client-row",
+                        {"name": "good", "status": "up", "bytes_recv": 5},
+                    ],
+                }
+            }
+        }
+    }
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Test"
+
+    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.vpn_malformed_client"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is True
+    attrs = s.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("clients", []) == [{"name": "good", "status": "up", "bytes_recv": 5}]
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_vpn_sensor_handles_exceptions_from_instance_get(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
@@ -2054,6 +2093,91 @@ async def test_async_setup_entry_creates_entities_with_malformed_dynamic_sensor_
     assert not any(isinstance(entity, OPNsenseTempSensor) for entity in created)
     assert not any(isinstance(entity, OPNsenseInterfaceSensor) for entity in created)
     assert not any(isinstance(entity, OPNsenseGatewaySensor) for entity in created)
+
+
+@pytest.mark.parametrize(
+    ("compile_helper", "state"),
+    [
+        (sensor_module._compile_filesystem_sensors, {"telemetry": {"filesystems": "bad"}}),
+        (sensor_module._compile_interface_sensors, {"interfaces": "bad"}),
+        (sensor_module._compile_gateway_sensors, {"gateways": "bad"}),
+        (sensor_module._compile_temperature_sensors, {"telemetry": {"temps": "bad"}}),
+    ],
+)
+async def test_dynamic_sensor_compile_helpers_skip_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+    compile_helper: Callable[
+        [MockConfigEntry, OPNsenseDataUpdateCoordinator, dict[str, Any]],
+        Any,
+    ],
+    state: dict[str, Any],
+) -> None:
+    """Malformed dynamic sensor containers should compile to no entities."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert await compile_helper(entry, coordinator, state) == []
+
+
+async def test_dhcp_leases_compile_helper_uses_all_sensor_for_malformed_interfaces(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed DHCP lease interface containers should still create aggregate sensor."""
+    state: dict[str, Any] = {"dhcp_leases": {"lease_interfaces": "bad"}}
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_dhcp_leases_sensors(entry, coordinator, state)
+
+    assert [entity.entity_description.key for entity in entities] == ["dhcp_leases.all"]
+
+
+def test_filesystem_sensor_skips_malformed_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed filesystem rows should be skipped while reading a valid filesystem."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                "bad-row",
+                {
+                    "mountpoint": "/",
+                    "used_pct": 42,
+                    "device": "/dev/sda1",
+                    "type": "ext4",
+                    "blocks": 1000,
+                    "used": 420,
+                    "available": 580,
+                },
+            ],
+            "temps": {},
+        },
+        "interfaces": {},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 42
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("mountpoint") == "/"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -929,6 +929,45 @@ def test_vpn_sensor_variants(
                 assert key in attrs
 
 
+def test_vpn_sensor_skips_malformed_client_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed nested VPN client rows should be skipped and valid clients still parsed."""
+    state = {
+        "openvpn": {
+            "servers": {
+                "uuid1": {
+                    "name": "ovpn1",
+                    "status": "up",
+                    "clients": [
+                        "bad-client-row",
+                        {"name": "good", "status": "up", "bytes_recv": 5},
+                    ],
+                }
+            }
+        }
+    }
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Test"
+
+    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.vpn_malformed_client"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is True
+    attrs = s.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("clients", []) == [{"name": "good", "status": "up", "bytes_recv": 5}]
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_vpn_sensor_handles_exceptions_from_instance_get(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
@@ -2054,6 +2093,52 @@ async def test_async_setup_entry_creates_entities_with_malformed_dynamic_sensor_
     assert not any(isinstance(entity, OPNsenseTempSensor) for entity in created)
     assert not any(isinstance(entity, OPNsenseInterfaceSensor) for entity in created)
     assert not any(isinstance(entity, OPNsenseGatewaySensor) for entity in created)
+
+
+def test_filesystem_sensor_skips_malformed_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed filesystem rows should be skipped while reading a valid filesystem."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                "bad-row",
+                {
+                    "mountpoint": "/",
+                    "used_pct": 42,
+                    "device": "/dev/sda1",
+                    "type": "ext4",
+                    "blocks": 1000,
+                    "used": 420,
+                    "available": 580,
+                },
+            ],
+            "temps": {},
+        },
+        "interfaces": {},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 42
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("mountpoint") == "/"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -929,6 +929,31 @@ def test_vpn_sensor_variants(
                 assert key in attrs
 
 
+def test_vpn_sensor_unavailable_when_instance_container_is_not_mapping(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed VPN instance container should mark VPNSensor unavailable."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "openvpn": {
+            "servers": "bad-servers",
+        }
+    }
+
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Test"
+
+    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.vpn_test"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
 def test_vpn_sensor_skips_malformed_client_rows(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -2120,6 +2145,42 @@ async def test_dynamic_sensor_compile_helpers_skip_malformed_containers(
     assert await compile_helper(entry, coordinator, state) == []
 
 
+@pytest.mark.asyncio
+async def test_compile_vpn_sensors_skips_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed VPN setup containers should not produce any VPN sensors."""
+    state: dict[str, Any] = {
+        "openvpn": {"servers": "bad-servers"},
+        "wireguard": {"clients": "bad-clients", "servers": "bad-servers"},
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_vpn_sensors(entry, coordinator, state)
+
+    assert entities == []
+
+
+@pytest.mark.asyncio
+async def test_compile_vpn_sensors_skips_empty_instances(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Empty VPN instances should be skipped during VPN sensor setup."""
+    state: dict[str, Any] = {
+        "openvpn": {"servers": {"server-uuid": {}}},
+        "wireguard": {"clients": {}, "servers": {}},
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_vpn_sensors(entry, coordinator, state)
+
+    assert entities == []
+
+
 async def test_dhcp_leases_compile_helper_uses_all_sensor_for_malformed_interfaces(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -2178,6 +2239,58 @@ def test_filesystem_sensor_skips_malformed_rows(
     attrs = sensor.extra_state_attributes
     assert attrs is not None
     assert attrs.get("mountpoint") == "/"
+
+
+def test_filesystem_sensor_unavailable_with_malformed_filesystems_container(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed filesystem container should mark filesystem sensor as unavailable."""
+    state = {
+        "telemetry": {"filesystems": "bad-filesystems"},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_filesystem_sensor_unavailable_with_malformed_telemetry_container(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed telemetry container should mark filesystem sensor as unavailable."""
+    state = {"telemetry": "bad-telemetry"}
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,6 +30,7 @@ from custom_components.opnsense.sensor import (
     OPNsenseCarpInterfaceSensor,
     OPNsenseCarpStatusSensor,
     OPNsenseDHCPLeasesSensor,
+    OPNsenseFilesystemSensor,
     OPNsenseGatewaySensor,
     OPNsenseInterfaceSensor,
     OPNsenseSmartSensor,
@@ -1955,6 +1956,104 @@ async def test_async_setup_entry_creates_entities(
     # Ensure setup produced at least one created entity
     assert created, "no entities created"
     assert any(isinstance(e, OPNsenseStaticKeySensor) for e in created)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_entities_when_vpn_name_is_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing VPN instance names should not prevent other sensors from being created."""
+    state: dict[str, Any] = {
+        "telemetry": {"filesystems": [], "temps": {}},
+        "interfaces": {},
+        "gateways": {},
+        "openvpn": {"servers": {"server-uuid": {"description": "Remote Access", "status": "up"}}},
+    }
+    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
+
+    created: list = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities.
+
+        Args:
+            entities: Entities provided by pytest or the test case.
+        """
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
+    vpn_status = next(
+        entity
+        for entity in created
+        if entity.entity_description.key == "openvpn.servers.server-uuid.status"
+    )
+    assert vpn_status.entity_description.name == "OpenVPN Server Remote Access status"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_entities_when_gateway_name_is_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing gateway names should not prevent other sensors from being created."""
+    state: dict[str, Any] = {
+        "telemetry": {"filesystems": [], "temps": {}},
+        "interfaces": {},
+        "gateways": {"wan": {"status": "online", "delay": "12ms", "loss": "0%"}},
+        "openvpn": {"servers": {}},
+    }
+    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
+
+    created: list = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities.
+
+        Args:
+            entities: Entities provided by pytest or the test case.
+        """
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
+    gateway_status = next(
+        entity for entity in created if entity.entity_description.key == "gateway.wan.status"
+    )
+    assert gateway_status.entity_description.name == "Gateway wan status"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_entities_with_malformed_dynamic_sensor_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed dynamic sensor rows should not prevent other sensors from being created."""
+    state: dict[str, Any] = {
+        "telemetry": {"filesystems": ["not-a-filesystem"], "temps": {"cpu": "not-a-temp"}},
+        "interfaces": {"wan": "not-an-interface"},
+        "gateways": {"wan": "not-a-gateway"},
+        "openvpn": {"servers": {}},
+    }
+    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
+
+    created: list = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities.
+
+        Args:
+            entities: Entities provided by pytest or the test case.
+        """
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
+    assert not any(isinstance(entity, OPNsenseFilesystemSensor) for entity in created)
+    assert not any(isinstance(entity, OPNsenseTempSensor) for entity in created)
+    assert not any(isinstance(entity, OPNsenseInterfaceSensor) for entity in created)
+    assert not any(isinstance(entity, OPNsenseGatewaySensor) for entity in created)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2105,8 +2105,10 @@ async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_pay
 @pytest.mark.parametrize(
     ("compile_helper", "state"),
     [
+        (sensor_module._compile_filesystem_sensors, []),
         (sensor_module._compile_filesystem_sensors, {"telemetry": {"filesystems": "bad"}}),
         (sensor_module._compile_interface_sensors, {"interfaces": "bad"}),
+        (sensor_module._compile_gateway_sensors, []),
         (sensor_module._compile_gateway_sensors, {"gateways": "bad"}),
         (sensor_module._compile_temperature_sensors, {"telemetry": {"temps": "bad"}}),
     ],
@@ -2114,10 +2116,10 @@ async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_pay
 async def test_dynamic_sensor_compile_helpers_skip_malformed_containers(
     make_config_entry: Callable[..., MockConfigEntry],
     compile_helper: Callable[
-        [MockConfigEntry, OPNsenseDataUpdateCoordinator, dict[str, Any]],
+        [MockConfigEntry, OPNsenseDataUpdateCoordinator, Any],
         Any,
     ],
-    state: dict[str, Any],
+    state: Any,
 ) -> None:
     """Malformed dynamic sensor containers should compile to no entities."""
     entry = make_config_entry()
@@ -2226,15 +2228,17 @@ def test_filesystem_sensor_skips_malformed_rows(
 @pytest.mark.parametrize(
     "state",
     [
+        [],
         {"telemetry": {"filesystems": "bad-filesystems"}},
+        {"telemetry": {"filesystems": [{"mountpoint": "/var", "used_pct": 12}]}},
         {"telemetry": "bad-telemetry"},
     ],
 )
 def test_filesystem_sensor_unavailable_with_malformed_containers(
     make_config_entry: Callable[..., MockConfigEntry],
-    state: dict[str, Any],
+    state: Any,
 ) -> None:
-    """Malformed telemetry or filesystem containers should mark the sensor unavailable."""
+    """Missing or malformed filesystem state should mark the sensor unavailable."""
     entry = make_config_entry()
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = state

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2279,6 +2279,28 @@ async def test_async_setup_entry_skips_malformed_switch_rows(
     assert [entity.entity_description.key for entity in created] == ["service.svc.status"]
 
 
+def test_opnsense_get_service_skips_malformed_service_rows(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed service rows should be ignored while matching a valid service."""
+    coordinator.data = {
+        "services": [
+            "bad-row",
+            {"id": "svc", "name": "service"},
+        ]
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+    found = entity._opnsense_get_service()
+    assert isinstance(found, MutableMapping)
+    assert found.get("name") == "service"
+
+
 @pytest.mark.asyncio
 async def test_vpn_servers_properties_and_toggle(
     coordinator: MagicMock, ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2178,21 +2178,25 @@ async def test_async_setup_entry_respects_config_flags(
     assert calls.get("len") == 1
 
 
+@pytest.mark.parametrize(
+    ("client_payload", "expected_name"),
+    [
+        ({"description": "Remote Access", "enabled": True}, "OpenVPN Client Remote Access"),
+        ({"enabled": True}, "OpenVPN Client client-uuid"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_async_setup_entry_creates_vpn_switch_when_name_is_missing(
+async def test_async_setup_entry_uses_vpn_description_or_uuid_when_name_is_missing(
     coordinator: MagicMock,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    client_payload: dict[str, Any],
+    expected_name: str,
 ) -> None:
-    """Missing VPN instance names should not prevent switch setup."""
+    """Missing VPN names should fall back to description or the instance UUID."""
     coordinator.data = {
         "openvpn": {
-            "clients": {
-                "client-uuid": {
-                    "description": "Remote Access",
-                    "enabled": True,
-                }
-            },
+            "clients": {"client-uuid": client_payload},
             "servers": {},
         },
         "wireguard": {"clients": {}, "servers": {}},
@@ -2229,56 +2233,7 @@ async def test_async_setup_entry_creates_vpn_switch_when_name_is_missing(
         for entity in created
         if entity.entity_description.key == "openvpn.clients.client-uuid"
     )
-    assert vpn_switch.entity_description.name == "OpenVPN Client Remote Access"
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_uses_uuid_when_vpn_name_and_description_missing(
-    coordinator: MagicMock,
-    ph_hass: Any,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing VPN instance name and description should fall back to the instance UUID."""
-    coordinator.data = {
-        "openvpn": {
-            "clients": {"client-uuid": {"enabled": True}},
-            "servers": {},
-        },
-        "wireguard": {"clients": {}, "servers": {}},
-    }
-    config_entry = make_config_entry(
-        data={
-            CONF_DEVICE_UNIQUE_ID: "dev1",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: True,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    created: list[Any] = []
-
-    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
-        """Capture switch entities emitted by setup.
-
-        Args:
-            entities: Switch entities emitted by setup.
-            _update_before_add: Whether HA should refresh entities before adding them.
-        """
-        created.extend(entities)
-
-    await switch_mod.async_setup_entry(
-        ph_hass,
-        config_entry,
-        cast("AddEntitiesCallback", add_entities),
-    )
-
-    vpn_switch = next(
-        entity
-        for entity in created
-        if entity.entity_description.key == "openvpn.clients.client-uuid"
-    )
-    assert vpn_switch.entity_description.name == "OpenVPN Client client-uuid"
+    assert vpn_switch.entity_description.name == expected_name
 
 
 @pytest.mark.asyncio
@@ -2356,6 +2311,25 @@ def test_opnsense_get_service_with_malformed_services_container(
     """Malformed service containers should return None instead of iterating."""
     coordinator.data = {
         "services": "bad-services",
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+    assert entity._opnsense_get_service() is None
+
+
+def test_opnsense_get_service_returns_none_when_service_id_is_missing(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Missing service IDs should return None after scanning valid service rows."""
+    coordinator.data = {
+        "services": [
+            {"id": "other", "name": "other-service"},
+        ],
     }
     config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
     setattr(config_entry.runtime_data, COORDINATOR, coordinator)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2179,6 +2179,107 @@ async def test_async_setup_entry_respects_config_flags(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_creates_vpn_switch_when_name_is_missing(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing VPN instance names should not prevent switch setup."""
+    coordinator.data = {
+        "openvpn": {
+            "clients": {
+                "client-uuid": {
+                    "description": "Remote Access",
+                    "enabled": True,
+                }
+            },
+            "servers": {},
+        },
+        "wireguard": {"clients": {}, "servers": {}},
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        created.extend(entities)
+
+    await switch_mod.async_setup_entry(
+        ph_hass,
+        config_entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    vpn_switch = next(
+        entity
+        for entity in created
+        if entity.entity_description.key == "openvpn.clients.client-uuid"
+    )
+    assert vpn_switch.entity_description.name == "OpenVPN Client Remote Access"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_malformed_switch_rows(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed switch rows should not prevent valid switches from being created."""
+    coordinator.data = {
+        "host_firmware_version": "25.7.8",
+        "services": [
+            "not-a-service",
+            {"id": "svc", "description": "Valid Service", "locked": 0, "status": True},
+        ],
+        "openvpn": "not-openvpn-data",
+        "wireguard": {"clients": "not-client-data", "servers": {"bad": "not-a-server"}},
+        "unbound_blocklist": "not-unbound-data",
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: True,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_UNBOUND: True,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        created.extend(entities)
+
+    await switch_mod.async_setup_entry(
+        ph_hass,
+        config_entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    assert [entity.entity_description.key for entity in created] == ["service.svc.status"]
+
+
+@pytest.mark.asyncio
 async def test_vpn_servers_properties_and_toggle(
     coordinator: MagicMock, ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -20,6 +20,7 @@ from custom_components.opnsense import switch as switch_mod
 from custom_components.opnsense.const import (
     ATTR_NAT_OUTBOUND,
     ATTR_NAT_PORT_FORWARD,
+    ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_CARP,
     CONF_SYNC_FIREWALL_AND_NAT,
@@ -2283,6 +2284,26 @@ async def test_async_setup_entry_skips_malformed_switch_rows(
     assert [entity.entity_description.key for entity in created] == ["service.svc.status"]
 
 
+@pytest.mark.parametrize(
+    ("compile_helper", "state"),
+    [
+        (_compile_unbound_switches, []),
+        (_compile_unbound_switches, {ATTR_UNBOUND_BLOCKLIST: {"bad-row": "bad-row"}}),
+    ],
+)
+async def test_dynamic_switch_compile_helpers_skip_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+    compile_helper: Callable[[MockConfigEntry, OPNsenseDataUpdateCoordinator, Any], Any],
+    state: Any,
+) -> None:
+    """Malformed dynamic switch containers should compile to no entities."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert await compile_helper(config_entry, coordinator, state) == []
+
+
 def test_opnsense_get_service_skips_malformed_service_rows(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -2312,6 +2333,21 @@ def test_opnsense_get_service_with_malformed_services_container(
     coordinator.data = {
         "services": "bad-services",
     }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+    assert entity._opnsense_get_service() is None
+
+
+def test_opnsense_get_service_returns_none_when_state_is_malformed(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed top-level service state should return None."""
+    coordinator.data = []
     config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
     setattr(config_entry.runtime_data, COORDINATOR, coordinator)
     entity = OPNsenseServiceSwitch(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2233,6 +2233,55 @@ async def test_async_setup_entry_creates_vpn_switch_when_name_is_missing(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_uses_uuid_when_vpn_name_and_description_missing(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing VPN instance name and description should fall back to the instance UUID."""
+    coordinator.data = {
+        "openvpn": {
+            "clients": {"client-uuid": {"enabled": True}},
+            "servers": {},
+        },
+        "wireguard": {"clients": {}, "servers": {}},
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        created.extend(entities)
+
+    await switch_mod.async_setup_entry(
+        ph_hass,
+        config_entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    vpn_switch = next(
+        entity
+        for entity in created
+        if entity.entity_description.key == "openvpn.clients.client-uuid"
+    )
+    assert vpn_switch.entity_description.name == "OpenVPN Client client-uuid"
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_malformed_switch_rows(
     coordinator: MagicMock,
     ph_hass: Any,
@@ -2299,6 +2348,23 @@ def test_opnsense_get_service_skips_malformed_service_rows(
     found = entity._opnsense_get_service()
     assert isinstance(found, MutableMapping)
     assert found.get("name") == "service"
+
+
+def test_opnsense_get_service_with_malformed_services_container(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed service containers should return None instead of iterating."""
+    coordinator.data = {
+        "services": "bad-services",
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+    assert entity._opnsense_get_service() is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2974,6 +2974,30 @@ def test_service_handle_exceptions_sets_unavailable(
     assert ent.available is False
 
 
+def test_service_handle_malformed_payload_makes_switch_unavailable(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Service switches should become unavailable when service payload becomes malformed."""
+    desc = SwitchEntityDescription(key="service.svc1.status", name="Svc")
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry, coordinator=coordinator, entity_description=desc
+    )
+    ent.hass = MagicMock(spec=HomeAssistant)
+    ent.entity_id = f"switch.{ent.entity_description.key}"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    coordinator.data = {"services": [{"id": "svc1", "status": True}]}
+    ent._handle_coordinator_update()
+    assert ent.available is True
+    assert ent.is_on is True
+
+    coordinator.data = {}
+    ent._handle_coordinator_update()
+    assert ent.available is False
+
+
 @pytest.mark.asyncio
 async def test_unbound_legacy_switch_toggle_failures(
     coordinator: MagicMock, ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]


### PR DESCRIPTION
## Summary

Harden dynamic entity setup so incomplete or malformed OPNsense payload rows do not abort platform setup before Home Assistant can add unrelated entities. This addresses the failure mode where missing VPN sensor names could prevent all sensor entities from being created, and applies the same containment pattern across related dynamic entity platforms.

## What Changed

- Added shared dynamic payload display-name fallback handling for entity labels.
- Made VPN sensor and switch names tolerate missing `name` values by falling back to `description` and then the payload UUID/key.
- Hardened sensor setup for malformed filesystem, gateway, interface, temperature, DHCP lease, and VPN rows.
- Hardened switch setup for malformed service, VPN, and Unbound blocklist rows.
- Hardened device tracker setup for malformed ARP rows.
- Added regression coverage for missing VPN/gateway names and malformed dynamic setup rows.
- Added `coverage.json` to `.gitignore` so local coverage runs do not dirty the tree.

## Why

A single incomplete dynamic row could raise during entity compilation before `async_add_entities()` was called, which made one bad VPN, gateway, switch, or tracker payload block creation of otherwise valid entities. The fix keeps malformed rows local to their own entity family and preserves valid entity setup.

## Related Issues

Fixes #608

## Validation

- `/Users/snuffy2/GitHub/hass-opnsense/.venv/bin/pytest --cov-report=json` - 899 passed
- `/Users/snuffy2/GitHub/hass-opnsense/.venv/bin/prek run -a` - passed
- `git diff --check` - passed
- `review-until-passed` - `VERDICT: PASSED`
