### PR TITLE
Refine aiopnsense error handling

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -211,8 +211,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     Raises:
         OPNsenseError: Raised when validation cannot complete because of
             authentication, privilege, firmware, or transport failures.
-        TimeoutError: Raised when an initial OPNsense request times out during
-            setup or the first coordinator refresh.
     """
     config: Mapping[str, Any] = entry.data
     options: Mapping[str, Any] = entry.options
@@ -235,9 +233,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         try:
             await client.validate()
-        except TimeoutError:
-            await client.async_close()
-            raise
         except OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware:
             _LOGGER.debug(
                 "Client validation reported firmware issues; continuing to firmware probes"

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -7,7 +7,6 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -146,23 +145,10 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                             if not isinstance(device_name, str) or not device_name.strip():
                                 continue
                             normalized_device_name = device_name.strip()
-                            try:
-                                smart_info[normalized_device_name] = await method(
-                                    device=normalized_device_name,
-                                    info_type=cat.get("info_type", "A"),
-                                )
-                            except (
-                                aiohttp.ClientError,
-                                OSError,
-                                TimeoutError,
-                                TypeError,
-                                ValueError,
-                            ):
-                                _LOGGER.exception(
-                                    "Failed to fetch SMART info for device %s",
-                                    normalized_device_name,
-                                )
-                                continue
+                            smart_info[normalized_device_name] = await method(
+                                device=normalized_device_name,
+                                info_type=cat.get("info_type", "A"),
+                            )
                     state[cat.get("state_key")] = smart_info
                 else:
                     state[cat.get("state_key")] = await method()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -158,10 +158,10 @@ async def test_get_states_fetches_smart_info_for_each_smart_device(
 
 
 @pytest.mark.asyncio
-async def test_get_states_continues_when_one_smart_device_lookup_fails(
+async def test_get_states_does_not_catch_raw_smart_info_timeout(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """SMART attribute data should keep processing after one per-device lookup fails."""
+    """SMART info errors should be handled by aiopnsense before reaching the coordinator."""
     client = MagicMock()
     client.get_smart = AsyncMock(
         return_value=[
@@ -172,7 +172,6 @@ async def test_get_states_continues_when_one_smart_device_lookup_fails(
     client.get_smart_info = AsyncMock(
         side_effect=[
             TimeoutError("nvme0 timed out"),
-            {"temperature": {"current": 42}},
         ]
     )
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
@@ -185,18 +184,15 @@ async def test_get_states_continues_when_one_smart_device_lookup_fails(
         config_entry=entry,
     )
 
-    state = await coordinator._get_states(
-        [
-            {"function": "get_smart", "state_key": "smart"},
-            {"function": "get_smart_info", "state_key": "smart_info"},
-        ]
-    )
+    with pytest.raises(TimeoutError, match="nvme0 timed out"):
+        await coordinator._get_states(
+            [
+                {"function": "get_smart", "state_key": "smart"},
+                {"function": "get_smart_info", "state_key": "smart_info"},
+            ]
+        )
 
-    assert state["smart_info"] == {"ada0": {"temperature": {"current": 42}}}
-    assert client.get_smart_info.await_args_list == [
-        call(device="nvme0", info_type="A"),
-        call(device="ada0", info_type="A"),
-    ]
+    assert client.get_smart_info.await_args_list == [call(device="nvme0", info_type="A")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -241,12 +241,12 @@ async def test_async_setup_entry_closes_client_when_validation_fails(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_closes_client_when_validation_times_out(
+async def test_async_setup_entry_does_not_catch_raw_validation_timeout(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """async_setup_entry should close and re-raise when validation times out."""
+    """Validation timeout mapping belongs to aiopnsense, not setup-entry cleanup."""
     client = MagicMock()
     client.validate = AsyncMock(side_effect=TimeoutError)
     client.async_close = AsyncMock(return_value=True)
@@ -275,7 +275,7 @@ async def test_async_setup_entry_closes_client_when_validation_times_out(
     with pytest.raises(TimeoutError):
         await init_mod.async_setup_entry(hass, entry)
 
-    client.async_close.assert_awaited_once()
+    client.async_close.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Aligns hass-opnsense error handling with the current aiopnsense contract by removing redundant raw `TimeoutError` handling from setup validation and SMART detail polling.

## What Changed
- Removed the dedicated raw `TimeoutError` cleanup path around `client.validate()` in setup entry.
- Removed the integration-level SMART detail `try`/`except` block that duplicated aiopnsense decorated request handling.
- Updated coordinator and setup-entry tests to document that raw timeout handling belongs in aiopnsense before these call sites see the result.

## Why
aiopnsense maps validation transport failures into its public `OPNsenseError` hierarchy, and SMART request errors are handled by the library decorated methods. Keeping separate raw timeout catches in hass-opnsense made the integration carry behavior that no longer matches the current library boundary.