### PR TITLE
Harden dynamic entity payload guards

### DIFF
--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -41,15 +41,29 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
             String display label from the first usable field, otherwise the fallback.
         """
         for field in fields:
-            value = payload.get(field)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+            value: Any | None
+            try:
+                value = payload.get(field)
+            except AttributeError, KeyError, RuntimeError, TypeError, ValueError:
+                value = None
+
+            if isinstance(value, str):
+                try:
+                    stripped_value = value.strip()
+                except AttributeError, RuntimeError, TypeError, ValueError:
+                    stripped_value = ""
+                if stripped_value:
+                    return stripped_value
+
             if (
                 allow_scalar
                 and value is not None
                 and not isinstance(value, str | Mapping | list | tuple | set)
             ):
-                return str(value)
+                try:
+                    return str(value)
+                except AttributeError, RuntimeError, TypeError, ValueError:
+                    pass
         return fallback
 
     def __init__(

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -1,6 +1,6 @@
 """Define the base entities for OPNsense."""
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +21,36 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
     """Base entity for OPNsense."""
+
+    @staticmethod
+    def payload_display_name(
+        payload: Mapping[str, Any],
+        fallback: str,
+        *fields: str,
+        allow_scalar: bool = True,
+    ) -> str:
+        """Return a stable display label from a dynamic state payload.
+
+        Args:
+            payload: Mapping payload that may contain one of the display fields.
+            fallback: Value to use when none of the fields contain a displayable value.
+            *fields: Ordered field names to prefer for the display label.
+            allow_scalar: Whether non-container scalar values should be stringified.
+
+        Returns:
+            String display label from the first usable field, otherwise the fallback.
+        """
+        for field in fields:
+            value = payload.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if (
+                allow_scalar
+                and value is not None
+                and not isinstance(value, str | Mapping | list | tuple | set)
+            ):
+                return str(value)
+        return fallback
 
     def __init__(
         self,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -901,13 +901,17 @@ async def _compile_filesystem_sensors(
     """
     if not isinstance(state, MutableMapping):
         return []
+    filesystems = dict_get(state, "telemetry.filesystems", []) or []
+    if not isinstance(filesystems, list):
+        return []
     return _create_sensors(
         OPNsenseFilesystemSensor,
         config_entry,
         coordinator,
         [
             _build_filesystem_sensor_description(filesystem)
-            for filesystem in dict_get(state, "telemetry.filesystems", []) or []
+            for filesystem in filesystems
+            if isinstance(filesystem, Mapping)
         ],
     )
 
@@ -1059,7 +1063,13 @@ async def _compile_interface_sensors(
         return []
     entities: list[OPNsenseInterfaceSensor] = []
 
-    for interface_name, interface in (dict_get(state, "interfaces", {}) or {}).items():
+    interfaces = dict_get(state, "interfaces", {}) or {}
+    if not isinstance(interfaces, MutableMapping):
+        return []
+
+    for interface_name, interface in interfaces.items():
+        if not isinstance(interface, MutableMapping):
+            continue
         entities.extend(
             _create_sensor(
                 OPNsenseInterfaceSensor,
@@ -1089,8 +1099,14 @@ async def _compile_gateway_sensors(
         return []
     entities: list[OPNsenseGatewaySensor] = []
 
-    for gateway_key, gateway in (dict_get(state, "gateways", {}) or {}).items():
-        gateway_name = gateway.get("name", gateway_key)
+    gateways = dict_get(state, "gateways", {}) or {}
+    if not isinstance(gateways, MutableMapping):
+        return []
+
+    for gateway_key, gateway in gateways.items():
+        if not isinstance(gateway, MutableMapping):
+            continue
+        gateway_name = OPNsenseEntity.payload_display_name(gateway, str(gateway_key), "name")
         entities.extend(
             _create_sensor(
                 OPNsenseGatewaySensor,
@@ -1120,7 +1136,13 @@ async def _compile_temperature_sensors(
         return []
     entities: list = []
 
-    for temp_device, temp in state.get("telemetry", {}).get("temps", {}).items():
+    temps = dict_get(state, "telemetry.temps", {}) or {}
+    if not isinstance(temps, MutableMapping):
+        return []
+
+    for temp_device, temp in temps.items():
+        if not isinstance(temp, MutableMapping):
+            continue
         entities.append(
             _create_sensor(
                 OPNsenseTempSensor,
@@ -1148,9 +1170,11 @@ async def _compile_dhcp_leases_sensors(
         return []
     entities: list = []
 
-    for interface, interface_name in (
-        dict_get(state, "dhcp_leases.lease_interfaces", {}) or {}
-    ).items():
+    lease_interfaces = dict_get(state, "dhcp_leases.lease_interfaces", {}) or {}
+    if not isinstance(lease_interfaces, MutableMapping):
+        lease_interfaces = {}
+
+    for interface, interface_name in lease_interfaces.items():
         entities.append(
             _create_sensor(
                 OPNsenseDHCPLeasesSensor,
@@ -1191,14 +1215,19 @@ async def _compile_vpn_sensors(
     for vpn_type in ("openvpn", "wireguard"):
         clients_servers_groups = ["servers"] if vpn_type == "openvpn" else ["clients", "servers"]
         for clients_servers in clients_servers_groups:
-            for uuid, instance in (
-                dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
-            ).items():
+            vpn_instances = dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
+            if not isinstance(vpn_instances, MutableMapping):
+                continue
+            for uuid, instance in vpn_instances.items():
                 if not isinstance(instance, MutableMapping) or len(instance) == 0:
                     continue
-                instance_name = instance.get("name")
-                if not isinstance(instance_name, str) or not instance_name.strip():
-                    instance_name = uuid
+                instance_name = OPNsenseEntity.payload_display_name(
+                    instance,
+                    str(uuid),
+                    "name",
+                    "description",
+                    allow_scalar=False,
+                )
                 properties = list(_VPN_TRAFFIC_PROPERTIES)
                 if clients_servers == "servers":
                     properties.extend(_VPN_SERVER_PROPERTIES)
@@ -1541,9 +1570,11 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
         for fsystem in filesystems:
             if not isinstance(fsystem, MutableMapping):
                 continue
+            mountpoint = fsystem.get("mountpoint")
             if (
-                self.entity_description.key == "telemetry.filesystems."
-                f"{slugify_filesystem_mountpoint(fsystem.get('mountpoint', None))}"
+                isinstance(mountpoint, str)
+                and self.entity_description.key
+                == f"telemetry.filesystems.{slugify_filesystem_mountpoint(mountpoint)}"
             ):
                 filesystem = dict(fsystem)
         if not filesystem:
@@ -1854,6 +1885,8 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             return
         instance: MutableMapping[str, Any] = {}
         for instance_uuid, ins in instances.items():
+            if not isinstance(ins, MutableMapping):
+                continue
             if uuid == instance_uuid:
                 instance = ins
                 break
@@ -1931,16 +1964,20 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             if instance.get(attr, None) is not None:
                 self._attr_extra_state_attributes[attr] = instance.get(attr)
 
+        clients = instance.get("clients")
         if (
-            isinstance(instance.get("clients", None), list)
+            isinstance(clients, list)
             and clients_servers == "servers"
-            and prop_name in {"connected_clients", "status"}
+            and prop_name
+            in {
+                "connected_clients",
+                "status",
+            }
         ):
             self._attr_extra_state_attributes["clients"] = []
-            for clnt in instance.get("clients", {}):
+            for clnt in clients:
                 if not isinstance(clnt, MutableMapping):
-                    self._mark_unavailable()
-                    return
+                    continue
                 client: dict[str, Any] = {}
                 for client_attr in (
                     "name",

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1174,7 +1174,13 @@ async def _compile_dhcp_leases_sensors(
     if not isinstance(lease_interfaces, MutableMapping):
         lease_interfaces = {}
 
-    for interface, interface_name in lease_interfaces.items():
+    lease_interface_items: Iterable[tuple[Any, Any]] = ()
+    try:
+        lease_interface_items = lease_interfaces.items()
+    except AttributeError, RuntimeError, TypeError, ValueError:
+        lease_interface_items = ()
+
+    for interface, interface_name in lease_interface_items:
         entities.append(
             _create_sensor(
                 OPNsenseDHCPLeasesSensor,
@@ -1183,7 +1189,6 @@ async def _compile_dhcp_leases_sensors(
                 _build_dhcp_leases_sensor_description(interface, interface_name),
             )
         )
-
     entities.append(
         _create_sensor(
             OPNsenseDHCPLeasesSensor,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1805,16 +1805,13 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
         if isinstance(gateways.get(gateway_name), Mapping):
             return dict(gateways[gateway_name])
         gateway_name_normalized = gateway_name.strip()
-        for gateway in gateways.values():
+        for gateway_key, gateway in gateways.items():
             if not isinstance(gateway, Mapping):
                 continue
-            configured_name = gateway.get("name")
+            configured_name = OPNsenseEntity.payload_display_name(gateway, str(gateway_key), "name")
             if configured_name == gateway_name_normalized:
                 return dict(gateway)
-            if (
-                isinstance(configured_name, str)
-                and configured_name.casefold() == gateway_name_normalized.casefold()
-            ):
+            if configured_name.casefold() == gateway_name_normalized.casefold():
                 return dict(gateway)
         return {}
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -2021,9 +2021,11 @@ class OPNsenseTempSensor(OPNsenseSensor):
         if temps is None:
             self._mark_unavailable()
             return
-        temp: dict[str, Any] = {}
+        temp: MutableMapping[str, Any] = {}
         for temp_device, temp_temp in temps.items():
             if temp_device == sensor_temp_device:
+                if not isinstance(temp_temp, MutableMapping):
+                    break
                 temp = temp_temp
                 break
         if not temp:

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1963,15 +1963,14 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                 self._attr_extra_state_attributes[attr] = instance.get(attr)
 
         clients = instance.get("clients")
-        if (
-            isinstance(clients, list)
-            and clients_servers == "servers"
-            and prop_name
-            in {
-                "connected_clients",
-                "status",
-            }
-        ):
+        include_clients = clients_servers == "servers" and prop_name in {
+            "connected_clients",
+            "status",
+        }
+        if include_clients and clients is not None and not isinstance(clients, list):
+            self._mark_unavailable()
+            return
+        if include_clients and isinstance(clients, list):
             self._attr_extra_state_attributes["clients"] = []
             for clnt in clients:
                 if not isinstance(clnt, MutableMapping):
@@ -1989,6 +1988,9 @@ class OPNsenseVPNSensor(OPNsenseSensor):
                     if clnt.get(client_attr, None) is not None:
                         client[client_attr] = clnt.get(client_attr)
                 self._attr_extra_state_attributes["clients"].append(client)
+            if clients and not self._attr_extra_state_attributes["clients"]:
+                self._mark_unavailable()
+                return
         self.async_write_ha_state()
 
     @property

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -463,14 +463,12 @@ def _build_smart_sensor_description(device_name: str) -> SensorEntityDescription
 
 def _build_filesystem_sensor_description(filesystem: Mapping[str, Any]) -> SensorEntityDescription:
     """Build a filesystem usage sensor description."""
-    filesystem_slug = slugify_filesystem_mountpoint(filesystem.get("mountpoint", None))
+    mountpoint = filesystem["mountpoint"]
+    filesystem_slug = slugify_filesystem_mountpoint(mountpoint)
     enabled_default = filesystem_slug == "root"
     return SensorEntityDescription(
         key=f"telemetry.filesystems.{filesystem_slug}",
-        name=(
-            "Filesystem Used Percentage "
-            f"{normalize_filesystem_mountpoint(filesystem.get('mountpoint', None))}"
-        ),
+        name=(f"Filesystem Used Percentage {normalize_filesystem_mountpoint(mountpoint)}"),
         native_unit_of_measurement=PERCENTAGE,
         device_class=None,
         icon="mdi:harddisk",
@@ -912,6 +910,8 @@ async def _compile_filesystem_sensors(
             _build_filesystem_sensor_description(filesystem)
             for filesystem in filesystems
             if isinstance(filesystem, Mapping)
+            and isinstance(filesystem.get("mountpoint"), str)
+            and filesystem["mountpoint"].strip()
         ],
     )
 
@@ -1590,7 +1590,8 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
 
         self._attr_extra_state_attributes = {}
         for attr in ("mountpoint", "device", "type", "blocks", "used", "available"):
-            self._attr_extra_state_attributes[attr] = filesystem[attr]
+            if attr in filesystem:
+                self._attr_extra_state_attributes[attr] = filesystem[attr]
         self.async_write_ha_state()
 
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -89,11 +89,18 @@ def _build_vpn_switch_description(
     Returns:
         A switch entity description for the VPN instance.
     """
+    instance_name = OPNsenseEntity.payload_display_name(
+        instance,
+        str(uuid),
+        "name",
+        "description",
+        allow_scalar=False,
+    )
     return SwitchEntityDescription(
         key=f"{vpn_type}.{clients_servers}.{uuid}",
         name=(
             f"{'OpenVPN' if vpn_type == 'openvpn' else vpn_type.title()} "
-            f"{clients_servers.title().rstrip('s')} {instance['name']}"
+            f"{clients_servers.title().rstrip('s')} {instance_name}"
         ),
         icon="mdi:folder-key-network-outline",
         device_class=SwitchDeviceClass.SWITCH,
@@ -253,7 +260,10 @@ async def _compile_vpn_switches(
         for clients_servers in ("clients", "servers"):
             if not isinstance(state, MutableMapping):
                 return []
-            for uuid, instance in state.get(vpn_type, {}).get(clients_servers, {}).items():
+            vpn_instances = dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
+            if not isinstance(vpn_instances, MutableMapping):
+                continue
+            for uuid, instance in vpn_instances.items():
                 if (
                     not isinstance(instance, MutableMapping)
                     or instance.get("enabled", None) is None
@@ -1122,7 +1132,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         if state is None:
             return None
         service_id: str = self._opnsense_get_service_id()
-        services = state.get("services", [])
+        services = state.get("services")
         if not isinstance(services, list):
             return None
         for service in services:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -24,6 +24,20 @@ class _BadStrValue:
         raise ValueError("string conversion failure")
 
 
+class _BadStripValue(str):
+    """String value that raises when stripped."""
+
+    __slots__ = ()
+
+    def strip(self, chars: str | None = None) -> str:
+        """Raise when display-name normalization strips whitespace.
+
+        Args:
+            chars: Optional characters to strip, matching ``str.strip``.
+        """
+        raise ValueError("strip failure")
+
+
 class _FaultyPayload(Mapping[str, object]):
     """Payload whose get() raises for a target field."""
 
@@ -47,11 +61,22 @@ class _FaultyPayload(Mapping[str, object]):
 
 def test_payload_display_name_skips_get_and_str_failures() -> None:
     """Display-name lookup should skip bad fields and return the fallback."""
-    payload = _FaultyPayload({"broken_get": "ignored", "broken_str": _BadStrValue()})
+    payload = _FaultyPayload(
+        {
+            "broken_get": "ignored",
+            "broken_strip": _BadStripValue("ignored"),
+            "broken_str": _BadStrValue(),
+        }
+    )
 
     assert (
         OPNsenseEntity.payload_display_name(
-            payload, "fallback", "broken_get", "broken_str", "missing"
+            payload,
+            "fallback",
+            "broken_get",
+            "broken_strip",
+            "broken_str",
+            "missing",
         )
         == "fallback"
     )

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,6 +1,6 @@
 """Unit tests for custom_components.opnsense.entity."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Mapping
 from unittest.mock import MagicMock
 
 from homeassistant.util import slugify
@@ -15,6 +15,46 @@ from custom_components.opnsense.entity import OPNsenseBaseEntity, OPNsenseEntity
 def test_payload_display_name_uses_scalar_fallback() -> None:
     """Display names use scalar payload values when no string field is available."""
     assert OPNsenseEntity.payload_display_name({"name": 42}, "fallback", "name") == "42"
+
+
+class _BadStrValue:
+    """Value object that raises when converted to a string."""
+
+    def __str__(self) -> str:
+        raise ValueError("string conversion failure")
+
+
+class _FaultyPayload(Mapping[str, object]):
+    """Payload whose get() raises for a target field."""
+
+    def __init__(self, values: dict[str, object]) -> None:
+        self._values = values
+
+    def get(self, key: str, default: object | None = None) -> object | None:
+        if key == "broken_get":
+            raise ValueError("payload get failed")
+        return self._values.get(key, default)
+
+    def __getitem__(self, key: str) -> object:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+def test_payload_display_name_skips_get_and_str_failures() -> None:
+    """Display-name lookup should skip bad fields and return the fallback."""
+    payload = _FaultyPayload({"broken_get": "ignored", "broken_str": _BadStrValue()})
+
+    assert (
+        OPNsenseEntity.payload_display_name(
+            payload, "fallback", "broken_get", "broken_str", "missing"
+        )
+        == "fallback"
+    )
 
 
 def test_init_sets_unique_and_name_suffixes(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,6 +12,11 @@ from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.entity import OPNsenseBaseEntity, OPNsenseEntity
 
 
+def test_payload_display_name_uses_scalar_fallback() -> None:
+    """Display names use scalar payload values when no string field is available."""
+    assert OPNsenseEntity.payload_display_name({"name": 42}, "fallback", "name") == "42"
+
+
 def test_init_sets_unique_and_name_suffixes(
     make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2439,6 +2439,288 @@ def _setup_entry_with_all_syncs(
     return entry, coord
 
 
+@pytest.mark.parametrize(
+    ("state", "expected_key", "expected_name", "absent_classes"),
+    [
+        (
+            {
+                "telemetry": {"filesystems": [], "temps": {}},
+                "interfaces": {},
+                "gateways": {},
+                "openvpn": {
+                    "servers": {"server-uuid": {"description": "Remote Access", "status": "up"}}
+                },
+            },
+            "openvpn.servers.server-uuid.status",
+            "OpenVPN Server Remote Access status",
+            (),
+        ),
+        (
+            {
+                "telemetry": {"filesystems": [], "temps": {}},
+                "interfaces": {},
+                "gateways": {"wan": {"status": "online", "delay": "12ms", "loss": "0%"}},
+                "openvpn": {"servers": {}},
+            },
+            "gateway.wan.status",
+            "Gateway wan status",
+            (),
+        ),
+        (
+            {
+                "telemetry": {
+                    "filesystems": ["not-a-filesystem"],
+                    "temps": {"cpu": "not-a-temp"},
+                },
+                "interfaces": {"wan": "not-an-interface"},
+                "gateways": {"wan": "not-a-gateway"},
+                "openvpn": {"servers": {}},
+            },
+            None,
+            None,
+            (
+                OPNsenseFilesystemSensor,
+                OPNsenseTempSensor,
+                OPNsenseInterfaceSensor,
+                OPNsenseGatewaySensor,
+            ),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_payloads(
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    expected_key: str | None,
+    expected_name: str | None,
+    absent_classes: tuple[type[object], ...],
+) -> None:
+    """Partial or malformed dynamic sensor payloads should not block setup."""
+    entry, _coord = _setup_entry_with_all_syncs(state, make_config_entry)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities.
+
+        Args:
+            entities: Entities provided by pytest or the test case.
+        """
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    assert any(isinstance(entity, OPNsenseStaticKeySensor) for entity in created)
+    if expected_key is not None:
+        matched = next(
+            entity for entity in created if entity.entity_description.key == expected_key
+        )
+        assert matched.entity_description.name == expected_name
+    for entity_class in absent_classes:
+        assert not any(isinstance(entity, entity_class) for entity in created)
+
+
+@pytest.mark.parametrize(
+    ("compile_helper", "state"),
+    [
+        (sensor_module._compile_filesystem_sensors, []),
+        (sensor_module._compile_filesystem_sensors, {"telemetry": {"filesystems": "bad"}}),
+        (sensor_module._compile_interface_sensors, {"interfaces": "bad"}),
+        (sensor_module._compile_gateway_sensors, []),
+        (sensor_module._compile_gateway_sensors, {"gateways": "bad"}),
+        (sensor_module._compile_temperature_sensors, {"telemetry": {"temps": "bad"}}),
+    ],
+)
+async def test_dynamic_sensor_compile_helpers_skip_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+    compile_helper: Callable[
+        [MockConfigEntry, OPNsenseDataUpdateCoordinator, Any],
+        Any,
+    ],
+    state: Any,
+) -> None:
+    """Malformed dynamic sensor containers should compile to no entities."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert await compile_helper(entry, coordinator, state) == []
+
+
+@pytest.mark.asyncio
+async def test_compile_vpn_sensors_skips_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed VPN setup containers should not produce any VPN sensors."""
+    state: dict[str, Any] = {
+        "openvpn": {"servers": "bad-servers"},
+        "wireguard": {"clients": "bad-clients", "servers": "bad-servers"},
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_vpn_sensors(entry, coordinator, state)
+
+    assert entities == []
+
+
+async def test_dhcp_leases_compile_helper_uses_all_sensor_for_malformed_interfaces(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed DHCP lease interface containers should still create aggregate sensor."""
+    state: dict[str, Any] = {"dhcp_leases": {"lease_interfaces": "bad"}}
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_dhcp_leases_sensors(entry, coordinator, state)
+
+    assert [entity.entity_description.key for entity in entities] == ["dhcp_leases.all"]
+
+
+def test_filesystem_sensor_skips_malformed_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed filesystem rows should be skipped while reading a valid filesystem."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                "bad-row",
+                {
+                    "mountpoint": "/",
+                    "used_pct": 42,
+                    "device": "/dev/sda1",
+                    "type": "ext4",
+                    "blocks": 1000,
+                    "used": 420,
+                    "available": 580,
+                },
+            ],
+            "temps": {},
+        },
+        "interfaces": {},
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 42
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs.get("mountpoint") == "/"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        [],
+        {"telemetry": {"filesystems": "bad-filesystems"}},
+        {"telemetry": {"filesystems": [{"mountpoint": "/var", "used_pct": 12}]}},
+        {"telemetry": "bad-telemetry"},
+    ],
+)
+def test_filesystem_sensor_unavailable_with_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: Any,
+) -> None:
+    """Missing or malformed filesystem state should mark the sensor unavailable."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_vpn_sensor_unavailable_when_instance_container_is_not_mapping(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed VPN instance container should mark VPNSensor unavailable."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "openvpn": {
+            "servers": "bad-servers",
+        }
+    }
+
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Test"
+
+    sensor = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.vpn_test"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_vpn_sensor_skips_malformed_client_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed nested VPN client rows should be skipped and valid clients still parsed."""
+    state = {
+        "openvpn": {
+            "servers": {
+                "uuid1": {
+                    "name": "ovpn1",
+                    "status": "up",
+                    "clients": [
+                        "bad-client-row",
+                        {"name": "good", "status": "up", "bytes_recv": 5},
+                    ],
+                }
+            }
+        }
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Test"
+
+    sensor = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.vpn_malformed_client"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.extra_state_attributes is not None
+    assert sensor.extra_state_attributes.get("clients", []) == [
+        {"name": "good", "status": "up", "bytes_recv": 5}
+    ]
+
+
 @pytest.mark.asyncio
 async def test_compile_and_handle_many_entities(
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2578,6 +2578,25 @@ async def test_dhcp_leases_compile_helper_uses_all_sensor_for_malformed_interfac
     assert [entity.entity_description.key for entity in entities] == ["dhcp_leases.all"]
 
 
+async def test_filesystem_compile_helper_skips_rows_without_mountpoint(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Filesystem rows without a usable mountpoint should not create entities."""
+    state: dict[str, Any] = {
+        "telemetry": {
+            "filesystems": [
+                {"used_pct": 42},
+                {"mountpoint": "", "used_pct": 12},
+            ]
+        }
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert await sensor_module._compile_filesystem_sensors(entry, coordinator, state) == []
+
+
 def test_filesystem_sensor_skips_malformed_rows(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -2622,6 +2641,43 @@ def test_filesystem_sensor_skips_malformed_rows(
     attrs = sensor.extra_state_attributes
     assert attrs is not None
     assert attrs.get("mountpoint") == "/"
+
+
+def test_filesystem_sensor_handles_partial_matching_row(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Partial matching filesystem rows should not raise while updating state."""
+    state = {
+        "telemetry": {
+            "filesystems": [
+                {
+                    "mountpoint": "/",
+                    "used_pct": 42,
+                },
+            ],
+            "temps": {},
+        },
+    }
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    desc = MagicMock()
+    desc.key = f"telemetry.filesystems.{slugify_filesystem_mountpoint('/')}"
+    desc.name = "Filesystem Test"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.fs_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 42
+    assert sensor.extra_state_attributes == {"mountpoint": "/"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2599,10 +2599,13 @@ async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_pay
     [
         (sensor_module._compile_filesystem_sensors, []),
         (sensor_module._compile_filesystem_sensors, {"telemetry": {"filesystems": "bad"}}),
+        (sensor_module._compile_interface_sensors, []),
         (sensor_module._compile_interface_sensors, {"interfaces": "bad"}),
         (sensor_module._compile_gateway_sensors, []),
         (sensor_module._compile_gateway_sensors, {"gateways": "bad"}),
+        (sensor_module._compile_temperature_sensors, []),
         (sensor_module._compile_temperature_sensors, {"telemetry": {"temps": "bad"}}),
+        (sensor_module._compile_dhcp_leases_sensors, []),
     ],
 )
 async def test_dynamic_sensor_compile_helpers_skip_malformed_containers(
@@ -2627,8 +2630,11 @@ async def test_compile_vpn_sensors_skips_malformed_containers(
 ) -> None:
     """Malformed VPN setup containers should not produce any VPN sensors."""
     state: dict[str, Any] = {
-        "openvpn": {"servers": "bad-servers"},
-        "wireguard": {"clients": "bad-clients", "servers": "bad-servers"},
+        "openvpn": {"servers": {"empty-server": {}}},
+        "wireguard": {
+            "clients": "bad-clients",
+            "servers": {"bad-server": "bad-server"},
+        },
     }
     entry = make_config_entry()
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2649,6 +2649,32 @@ async def test_dhcp_leases_compile_helper_uses_all_sensor_for_malformed_interfac
     assert [entity.entity_description.key for entity in entities] == ["dhcp_leases.all"]
 
 
+class _BadDHCPLeaseInterfaces(dict):
+    """Mapping that raises when items() is queried."""
+
+    def items(self) -> Never:  # type: ignore[override]
+        raise RuntimeError("items failure for test")
+
+
+async def test_dhcp_leases_compile_helper_skips_on_items_failure(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """items() failures should be ignored but still produce the aggregate DHCP sensor."""
+    state: dict[str, Any] = {
+        "dhcp_leases": {
+            "lease_interfaces": _BadDHCPLeaseInterfaces({"lan": "LAN", "wan": "WAN"}),
+            "leases": {"lan": [{"address": "192.168.1.2"}], "wan": []},
+        }
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_dhcp_leases_sensors(entry, coordinator, state)
+
+    assert [entity.entity_description.key for entity in entities] == ["dhcp_leases.all"]
+
+
 async def test_filesystem_compile_helper_skips_rows_without_mountpoint(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1279,6 +1279,10 @@ def test_vpn_sensor_fails_closed_for_malformed_instance_collection(
     [
         ({"openvpn": {"servers": {"uuid1": "not-a-mapping"}}}, "openvpn.servers.uuid1.status"),
         (
+            {"openvpn": {"servers": {"uuid1": {"clients": "not-a-list", "status": "up"}}}},
+            "openvpn.servers.uuid1.status",
+        ),
+        (
             {"openvpn": {"servers": {"uuid1": {"clients": ["not-a-mapping"], "status": "up"}}}},
             "openvpn.servers.uuid1.status",
         ),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1352,6 +1352,34 @@ def test_temp_sensor_key_wrong_prefix_marked_unavailable(
     assert s.available is False
 
 
+def test_temp_sensor_malformed_temps_container_on_update(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Temp sensor should become unavailable when a later update has malformed temps."""
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}},
+    }
+
+    desc = MagicMock()
+    desc.key = "telemetry.temps.sensor1"
+    desc.name = "Temp Test"
+
+    s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.temp_test"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+    assert s.available is True
+    assert s.native_value == 55
+
+    coord.data = {"telemetry": {"temps": "bad"}}
+    s._handle_coordinator_update()
+    assert s.available is False
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_temp_sensor_handles_index_exceptions(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -354,6 +354,49 @@ def test_gateway_sensor_resolves_display_name_when_mapping_key_differs(
 
 
 @pytest.mark.parametrize(
+    ("gateway_key", "gateway_name", "expected_display_name"),
+    [
+        ("gw1", " WAN Gateway ", "WAN Gateway"),
+        ("gw2", 42, "42"),
+    ],
+    ids=["whitespace-padded-name", "scalar-name"],
+)
+@pytest.mark.asyncio
+async def test_gateway_compile_and_lookup_normalizes_display_name(
+    make_config_entry: Callable[..., MockConfigEntry],
+    gateway_key: str,
+    gateway_name: Any,
+    expected_display_name: str,
+) -> None:
+    """Compile and lookup should agree on normalized gateway display names."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "gateways": {
+            gateway_key: {"name": gateway_name, "status": "online"},
+        }
+    }
+
+    entities = await sensor_module._compile_gateway_sensors(entry, coord, coord.data)
+    expected_key = f"gateway.{expected_display_name}.status"
+    s = next(entity for entity in entities if entity.entity_description.key == expected_key)
+
+    assert isinstance(s, OPNsenseGatewaySensor)
+    assert s._opnsense_get_gateway_entry(expected_display_name) == {
+        "name": gateway_name,
+        "status": "online",
+    }
+
+    s.hass = MagicMock()
+    s.entity_id = "sensor.gateway_status"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is True
+    assert s.native_value == "online"
+
+
+@pytest.mark.parametrize(
     "instance",
     [
         {"enabled": True},

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2850,6 +2850,55 @@ def test_vpn_handle_coordinator_update_state_not_mapping(
     assert ent.available is False
 
 
+def test_unbound_blocklist_switch_update_handles_malformed_container(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed Unbound blocklist containers should mark the switch unavailable."""
+    desc = SwitchEntityDescription(key="unbound_blocklist.switch.u1", name="Unbound u1")
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseUnboundBlocklistSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    coordinator.data = {"unbound_blocklist": "bad-container"}
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"openvpn": "bad-openvpn"},
+        {"openvpn": {"clients": "bad-clients"}},
+    ],
+)
+def test_vpn_switch_update_handles_malformed_instance_container(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+) -> None:
+    """Malformed VPN containers should mark the switch unavailable."""
+    desc = SwitchEntityDescription(key="openvpn.clients.c1", name="VPNC")
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseVPNSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    coordinator.data = state
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
 @pytest.mark.asyncio
 async def test_compile_vpn_wireguard_variations(
     coordinator: MagicMock, ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2909,6 +2909,26 @@ def test_unbound_blocklist_switch_update_handles_malformed_container(
     assert ent.available is False
 
 
+def test_unbound_legacy_switch_update_handles_malformed_container(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed legacy Unbound blocklist containers should mark the legacy switch unavailable."""
+    desc = SwitchEntityDescription(key="unbound_blocklist.switch", name="Unbound Blocklist")
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseUnboundBlocklistSwitchLegacy(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    coordinator.data = {"unbound_blocklist": "bad-container"}
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
 @pytest.mark.parametrize(
     "state",
     [

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2123,6 +2123,45 @@ def test_service_switch_ignores_malformed_service_rows(
     assert ent._opnsense_get_service() is None
 
 
+@pytest.mark.asyncio
+async def test_service_switch_malformed_services_container_on_update(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Service switch should become unavailable when services container becomes malformed."""
+    hass_local = MagicMock(spec=HomeAssistant)
+    loop = asyncio.new_event_loop()
+    try:
+        hass_local.loop = loop
+        hass_local.data = {}
+
+        config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+        coordinator.data = {"services": [{"id": "svc1", "name": "svc1", "status": True}]}
+        setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+        ent = OPNsenseServiceSwitch(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=SwitchEntityDescription(
+                key="service.svc1.status",
+                name="Svc",
+            ),
+        )
+        ent.hass = hass_local
+        ent.entity_id = "switch.svc"
+        object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+        ent._handle_coordinator_update()
+        assert ent.available is True
+        assert ent.is_on is True
+
+        coordinator.data = {"services": "bad-services"}
+        ent._handle_coordinator_update()
+        assert ent.available is False
+    finally:
+        # make sure we close the loop created for this test
+        with contextlib.suppress(RuntimeError):
+            loop.close()
+
+
 def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None:
     """Switch entities expose the correct platform icons based on type."""
     # firewall icon

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2123,6 +2123,23 @@ def test_service_switch_ignores_malformed_service_rows(
     assert ent._opnsense_get_service() is None
 
 
+def test_service_switch_ignores_non_mapping_state(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Service lookup should return None when coordinator state is malformed."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = []
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Service"),
+    )
+
+    assert ent._opnsense_get_service() is None
+
+
 @pytest.mark.asyncio
 async def test_service_switch_malformed_services_container_on_update(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -18,6 +18,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import switch as switch_mod
 from custom_components.opnsense.const import (
+    ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_CARP,
     CONF_SYNC_FIREWALL_AND_NAT,
@@ -2450,6 +2451,173 @@ async def test_async_setup_entry_unbound_uses_state_shape_for_unknown_firmware_e
     )
 
     assert len(calls.get("entities", [])) == 2
+
+
+@pytest.mark.parametrize(
+    ("client_payload", "expected_name"),
+    [
+        ({"description": "Remote Access", "enabled": True}, "OpenVPN Client Remote Access"),
+        ({"enabled": True}, "OpenVPN Client client-uuid"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_uses_vpn_description_or_uuid_when_name_is_missing(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    client_payload: dict[str, Any],
+    expected_name: str,
+) -> None:
+    """Missing VPN names should fall back to description or the instance UUID."""
+    coordinator.data = {
+        "openvpn": {
+            "clients": {"client-uuid": client_payload},
+            "servers": {},
+        },
+        "wireguard": {"clients": {}, "servers": {}},
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        created.extend(entities)
+
+    await switch_mod.async_setup_entry(
+        ph_hass,
+        config_entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    vpn_switch = next(
+        entity
+        for entity in created
+        if entity.entity_description.key == "openvpn.clients.client-uuid"
+    )
+    assert vpn_switch.entity_description.name == expected_name
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_malformed_switch_rows(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed switch rows should not prevent valid switches from being created."""
+    coordinator.data = {
+        "host_firmware_version": "25.7.8",
+        "services": [
+            "not-a-service",
+            {"id": "svc", "description": "Valid Service", "locked": 0, "status": True},
+        ],
+        "openvpn": "not-openvpn-data",
+        "wireguard": {"clients": "not-client-data", "servers": {"bad": "not-a-server"}},
+        "unbound_blocklist": "not-unbound-data",
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: True,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_UNBOUND: True,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        created.extend(entities)
+
+    await switch_mod.async_setup_entry(
+        ph_hass,
+        config_entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    assert [entity.entity_description.key for entity in created] == ["service.svc.status"]
+
+
+@pytest.mark.parametrize(
+    ("compile_helper", "state"),
+    [
+        (_compile_unbound_switches, []),
+        (_compile_unbound_switches, {ATTR_UNBOUND_BLOCKLIST: {"bad-row": "bad-row"}}),
+    ],
+)
+async def test_dynamic_switch_compile_helpers_skip_malformed_containers(
+    make_config_entry: Callable[..., MockConfigEntry],
+    compile_helper: Callable[[MockConfigEntry, OPNsenseDataUpdateCoordinator, Any], Any],
+    state: Any,
+) -> None:
+    """Malformed dynamic switch containers should compile to no entities."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert await compile_helper(config_entry, coordinator, state) == []
+
+
+def test_opnsense_get_service_skips_malformed_service_rows(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed service rows should be ignored while matching a valid service."""
+    coordinator.data = {
+        "services": [
+            "bad-row",
+            {"id": "svc", "name": "service"},
+        ]
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+
+    found = entity._opnsense_get_service()
+
+    assert isinstance(found, MutableMapping)
+    assert found.get("name") == "service"
+
+
+def test_opnsense_get_service_with_malformed_services_container(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Malformed service containers should return None instead of iterating."""
+    coordinator.data = {
+        "services": "bad-services",
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
+    )
+
+    assert entity._opnsense_get_service() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Ports the issue-608 dynamic malformed-payload guards onto the aiopnsense-only `Remove-pyopnsense` branch. This keeps entity setup and refresh paths resilient when OPNsense returns partial, missing, or unexpectedly typed rows.

## What Changed

- Added shared dynamic payload display-name handling for entity labels.
- Hardened dynamic sensor compilation for filesystem, interface, gateway, temperature, DHCP lease, and VPN payload containers.
- Hardened filesystem, temperature, and VPN sensor refresh paths so malformed payloads mark entities unavailable or skip only bad nested rows where valid data remains.
- Hardened service, VPN, and Unbound switch refresh paths against malformed coordinator containers.
- Added regression coverage for malformed dynamic sensor and switch setup/update payloads.

## Why

The `Remove-pyopnsense` branch uses the newer aiopnsense data shape, but it still needs the same defensive behavior from the issue-608 fixes so bad dynamic rows do not block setup or crash entity refreshes.

## Validation

- `/Users/snuffy2/GitHub/hass-opnsense/.venv/bin/pytest tests/test_sensor.py tests/test_switch.py`
- `/Users/snuffy2/GitHub/hass-opnsense/.venv/bin/pytest`
- `/Users/snuffy2/GitHub/hass-opnsense/.venv/bin/prek run -a`
- `git diff --check`
