### PR TITLE
Bump aiopnsense to 1.0.15

### DIFF
--- a/custom_components/opnsense/manifest.json
+++ b/custom_components/opnsense/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "python-dateutil",
     "awesomeversion",
-    "aiopnsense==1.0.14"
+    "aiopnsense==1.0.15"
   ],
   "version":"v0.7.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.opnsense.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "aiopnsense==1.0.14",
+    "aiopnsense==1.0.15",
     "homeassistant",
 ]
 lint = [


### PR DESCRIPTION
Automated update of aiopnsense dependency pins.

- Previous manifest pinned version: `aiopnsense==1.0.14`
- Previous pyproject pinned version: `aiopnsense==1.0.14`
- Updated pinned version: `aiopnsense==1.0.15`

## aiopnsense release notes in range
### v1.0.15 (v1.0.15)
https://github.com/Snuffy2/aiopnsense/releases/tag/v1.0.15

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🐛 Bug Fixes
* Exclude automatic firewall rules by @<!-- -->Snuffy2 in https://github.com/Snuffy2/aiopnsense/pull/59


**Full Changelog**: https://github.com/Snuffy2/aiopnsense/compare/v1.0.14...v1.0.15
