### PR TITLE
Run prek cleanup daily

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -2,7 +2,7 @@ name: prek Autoupdate
 
 on:
   schedule:
-    - cron: '47 7 * * 4'
+    - cron: '47 7 * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,3 +12,9 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+    with:
+      update-day: "4"
+      dispatch-workflows: |
+        linters.yml
+        pytest_coverage.yml
+        validate.yml


### PR DESCRIPTION
## Summary
Updates the reusable prek autoupdate caller so cleanup can run daily while update checks stay weekly.

## What Changed
- Changes the caller cron to run every day.
- Preserves the previous weekly update day with `update-day`.
- Adds `dispatch-workflows` for existing validation workflows and keeps `actions: write` for that dispatch path.

## Why
The reusable workflow now separates daily cleanup from weekly update checks. This keeps stale update PR and branch cleanup running nightly without opening hook update PRs every day.