### PR TITLE
Use public ScannerEntity import

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -6,8 +6,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback


### PR DESCRIPTION
## Summary

Imports `ScannerEntity` from Home Assistant's supported public device-tracker module, removing the deprecation warning from the OPNsense integration.

## What Changed

- Replaced the deprecated `device_tracker.config_entry.ScannerEntity` alias with `device_tracker.ScannerEntity`.

## Why

Home Assistant will remove the compatibility alias in Core 2027.6. Using the public import keeps the integration compatible before that removal.

Fixes #602 