### PR TITLE
Add independent CARP VIP entries

### DIFF
--- a/.github/scripts/build_aiopnsense_release_notes.py
+++ b/.github/scripts/build_aiopnsense_release_notes.py
@@ -142,6 +142,7 @@ def write_pr_body(
     releases: Sequence[Mapping[str, object]],
     current_version: str,
     pyproject_current_version: str,
+    prek_current_version: str,
     latest_version: str,
 ) -> None:
     """Write the generated aiopnsense update PR body.
@@ -151,6 +152,7 @@ def write_pr_body(
         releases: GitHub releases from the aiopnsense repository.
         current_version: Currently pinned manifest version.
         pyproject_current_version: Currently pinned pyproject version.
+        prek_current_version: Currently pinned prek mypy-hook version.
         latest_version: Target aiopnsense version.
     """
     release_notes = build_release_notes(
@@ -165,6 +167,7 @@ def write_pr_body(
                 "",
                 f"- Previous manifest pinned version: `aiopnsense=={current_version}`",
                 f"- Previous pyproject pinned version: `aiopnsense=={pyproject_current_version}`",
+                f"- Previous prek mypy pin: `aiopnsense=={prek_current_version}`",
                 f"- Updated pinned version: `aiopnsense=={latest_version}`",
                 "",
                 "## aiopnsense release notes in range",
@@ -248,6 +251,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--current-version", required=True)
     parser.add_argument("--pyproject-current-version", required=True)
+    parser.add_argument("--prek-current-version", required=True)
     parser.add_argument("--latest-version", required=True)
     parser.add_argument("--release-owner", required=True)
     parser.add_argument("--release-repo", required=True)
@@ -291,6 +295,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         releases=releases,
         current_version=args.current_version,
         pyproject_current_version=args.pyproject_current_version,
+        prek_current_version=args.prek_current_version,
         latest_version=args.latest_version,
     )
     return 0

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -1,4 +1,4 @@
-"""Update aiopnsense dependency pins in manifest and pyproject files."""
+"""Update aiopnsense dependency pins in manifest, pyproject, and prek files."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from urllib.request import urlopen
 
 PYPI_URL = "https://pypi.org/pypi/aiopnsense/json"
 PIN_PREFIX = "aiopnsense=="
-PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+"(,?)\s*$')
+TOML_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+"(,?)\s*$')
 PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
 
 
@@ -25,12 +25,14 @@ class UpdateResult:
     Attributes:
         current: Current manifest aiopnsense pin version.
         pyproject_current: Current pyproject aiopnsense pin version.
+        prek_current: Current prek mypy-hook aiopnsense pin version.
         latest: aiopnsense version selected as the update target.
         update_needed: Whether at least one pin should be updated.
     """
 
     current: str
     pyproject_current: str
+    prek_current: str
     latest: str
     update_needed: bool
 
@@ -206,6 +208,46 @@ def _read_pyproject_version(pyproject_path: Path) -> str:
     return pins[0].removeprefix(PIN_PREFIX)
 
 
+def _read_prek_version(prek_path: Path) -> str:
+    """Read the aiopnsense pin from the prek mypy hook dependencies.
+
+    Args:
+        prek_path: Path to prek.toml.
+
+    Returns:
+        Current aiopnsense version used by the isolated mypy hook.
+
+    Raises:
+        ValueError: If the mypy hook does not contain exactly one aiopnsense pin.
+    """
+    prek_config = tomllib.loads(prek_path.read_text())
+    repos = prek_config.get("repos", [])
+    if not isinstance(repos, list):
+        raise TypeError(f"Expected repos list in {prek_path}")
+
+    pins: list[str] = []
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        hooks = repo.get("hooks", [])
+        if not isinstance(hooks, list):
+            continue
+        for hook in hooks:
+            if not isinstance(hook, dict) or hook.get("id") != "mypy":
+                continue
+            dependencies = hook.get("additional_dependencies", [])
+            if not isinstance(dependencies, list):
+                raise TypeError(f"Expected mypy additional_dependencies list in {prek_path}")
+            pins.extend(dependency for dependency in dependencies if _is_aiopnsense_pin(dependency))
+
+    if len(pins) != 1:
+        raise ValueError(
+            f"Expected exactly one pinned aiopnsense dependency in the mypy hook in {prek_path}; "
+            f"found {len(pins)}"
+        )
+    return pins[0].removeprefix(PIN_PREFIX)
+
+
 def _is_aiopnsense_pin(requirement: object) -> bool:
     """Return whether a dependency entry is an aiopnsense exact pin.
 
@@ -263,7 +305,7 @@ def _write_pyproject_version(pyproject_path: Path, latest_version: str) -> None:
         ValueError: If there is not exactly one pinned aiopnsense dependency line.
     """
     text = pyproject_path.read_text()
-    updated, count = PYPROJECT_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}"\2', text)
+    updated, count = TOML_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}"\2', text)
     if count != 1:
         raise ValueError(
             f"Expected to update exactly one aiopnsense pin in {pyproject_path}; updated {count}"
@@ -271,10 +313,30 @@ def _write_pyproject_version(pyproject_path: Path, latest_version: str) -> None:
     pyproject_path.write_text(updated)
 
 
+def _write_prek_version(prek_path: Path, latest_version: str) -> None:
+    """Write the aiopnsense pin into the prek mypy hook dependencies.
+
+    Args:
+        prek_path: Path to prek.toml.
+        latest_version: Version to pin.
+
+    Raises:
+        ValueError: If there is not exactly one aiopnsense dependency line.
+    """
+    text = prek_path.read_text()
+    updated, count = TOML_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}"\2', text)
+    if count != 1:
+        raise ValueError(
+            f"Expected to update exactly one aiopnsense pin in {prek_path}; updated {count}"
+        )
+    prek_path.write_text(updated)
+
+
 def update_pins(
     *,
     manifest_path: Path,
     pyproject_path: Path,
+    prek_path: Path,
     latest_version: str,
     write: bool = True,
 ) -> UpdateResult:
@@ -283,6 +345,7 @@ def update_pins(
     Args:
         manifest_path: Path to manifest.json.
         pyproject_path: Path to pyproject.toml.
+        prek_path: Path to prek.toml.
         latest_version: Latest aiopnsense version available for evaluation.
         write: Whether to rewrite dependency files when an update is needed.
 
@@ -291,17 +354,22 @@ def update_pins(
     """
     current = _read_manifest_version(manifest_path)
     pyproject_current = _read_pyproject_version(pyproject_path)
+    prek_current = _read_prek_version(prek_path)
     latest_is_newer = _latest_is_newer(current, latest_version)
     target_version = latest_version if latest_is_newer else current
-    update_needed = latest_is_newer or pyproject_current != target_version
+    update_needed = (
+        latest_is_newer or pyproject_current != target_version or prek_current != target_version
+    )
 
     if write and update_needed:
         _write_manifest_version(manifest_path, target_version)
         _write_pyproject_version(pyproject_path, target_version)
+        _write_prek_version(prek_path, target_version)
 
     return UpdateResult(
         current=current,
         pyproject_current=pyproject_current,
+        prek_current=prek_current,
         latest=target_version,
         update_needed=update_needed,
     )
@@ -317,6 +385,7 @@ def _write_github_outputs(result: UpdateResult, output_path: Path) -> None:
     with output_path.open("a") as output_file:
         output_file.write(f"current={result.current}\n")
         output_file.write(f"pyproject_current={result.pyproject_current}\n")
+        output_file.write(f"prek_current={result.prek_current}\n")
         output_file.write(f"latest={result.latest}\n")
         output_file.write(f"update_needed={str(result.update_needed).lower()}\n")
 
@@ -333,6 +402,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest-path", type=Path, required=True)
     parser.add_argument("--pyproject-path", type=Path, required=True)
+    parser.add_argument("--prek-path", type=Path, required=True)
     parser.add_argument("--latest-version")
     parser.add_argument("--write", action="store_true")
     parser.add_argument("--github-output", type=Path)
@@ -353,6 +423,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     result = update_pins(
         manifest_path=args.manifest_path,
         pyproject_path=args.pyproject_path,
+        prek_path=args.prek_path,
         latest_version=latest_version,
         write=args.write,
     )

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -45,6 +45,7 @@ jobs:
           python .github/scripts/update_aiopnsense_pins.py \
             --manifest-path custom_components/opnsense/manifest.json \
             --pyproject-path pyproject.toml \
+            --prek-path prek.toml \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Update aiopnsense dependency pins
@@ -57,6 +58,7 @@ jobs:
           python .github/scripts/update_aiopnsense_pins.py \
             --manifest-path custom_components/opnsense/manifest.json \
             --pyproject-path pyproject.toml \
+            --prek-path prek.toml \
             --latest-version "$LATEST_VERSION" \
             --write
 
@@ -66,6 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           CURRENT_VERSION: ${{ steps.versions.outputs.current }}
           PYPROJECT_CURRENT_VERSION: ${{ steps.versions.outputs.pyproject_current }}
+          PREK_CURRENT_VERSION: ${{ steps.versions.outputs.prek_current }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest }}
           REPO_OWNER: ${{ github.event.inputs.aiopnsense_release_owner || vars.AIOPNSENSE_RELEASE_OWNER || 'Snuffy2' }}
           REPO_NAME: ${{ github.event.inputs.aiopnsense_release_repo || vars.AIOPNSENSE_RELEASE_REPO || 'aiopnsense' }}
@@ -75,6 +78,7 @@ jobs:
           python .github/scripts/build_aiopnsense_release_notes.py \
             --current-version "$CURRENT_VERSION" \
             --pyproject-current-version "$PYPROJECT_CURRENT_VERSION" \
+            --prek-current-version "$PREK_CURRENT_VERSION" \
             --latest-version "$LATEST_VERSION" \
             --release-owner "$REPO_OWNER" \
             --release-repo "$REPO_NAME" \
@@ -95,6 +99,7 @@ jobs:
           add-paths: |
             custom_components/opnsense/manifest.json
             pyproject.toml
+            prek.toml
 
       - name: Close extra auto-generated PRs
         if: steps.versions.outputs.update_needed == 'true' && steps.cpr.outputs.pull-request-number != ''

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ A Discord server to discuss the integration is available. Click the Discord badg
 ## Table of Contents
 
 * [Installation](#installation)
-  * [Home Assistant Integration](#homeassistant-integration)
+  * [Home Assistant Integration](#home-assistant-integration)
     * [HACS Installation](#hacs-installation)
-    * [Manual Installation](#manual-installation)
 
 * [Configuration](#configuration)
+  * [OPNsense Device Entry](#opnsense-device-entry)
+  * [CARP VIP Entry](#carp-vip-entry)
+  * [Recommended CARP Topology](#recommended-carp-topology)
   * [OPNsense User](#opnsense-user)
     * [Granular Sync Options](#granular-sync-options)
   * [Basic Configuration](#basic-configuration)
@@ -45,6 +47,7 @@ A Discord server to discuss the integration is available. Click the Discord badg
   * [Sensor](#sensor)
   * [Switch](#switch)
   * [Device Tracker](#device-tracker)
+  * [CARP VIP Entities and Limitations](#carp-vip-entities-and-limitations)
 
 * [Actions](#actions-services)
 
@@ -89,6 +92,26 @@ Copy the contents of the custom_components folder to the Home Assistant config/c
 ## Configuration
 
 Configuration is managed entirely from the Home Assistant UI. Simply go to `Configuration -> Integrations -> Add Integration` and search for <ins>OPNsense</ins> in the search box. If it isn't in the list (well-known HA issue), do a 'hard-refresh' of the browser (ctrl-F5) then open the list again.
+
+### OPNsense Device Entry
+
+Choose **OPNsense device entry** for each physical node's own non-VIP IP address or hostname. This is the full integration: telemetry, interfaces, services, gateways, firmware, optional CARP data, actions, and switches follow the selected sync options. Existing entries remain OPNsense device entries automatically and require no migration.
+
+### CARP VIP Entry
+
+Choose **CARP VIP entry** for the shared CARP VIP IP address or hostname when you want read-only CARP visibility. A CARP VIP entry follows the active responder and exposes only the CARP entities described in [CARP VIP Entities and Limitations](#carp-vip-entities-and-limitations). Configure each physical node separately with an OPNsense device entry; the VIP entry does not replace node entries.
+
+### Recommended CARP Topology
+
+Use one OPNsense device entry per physical node and add the optional CARP VIP entry for the shared endpoint:
+
+```text
+Node A non-VIP IP/hostname       -> full OPNsense device entry
+Node B non-VIP IP/hostname       -> full OPNsense device entry
+Shared CARP VIP IP/hostname      -> optional read-only CARP VIP entry
+```
+
+Node entries are required for complete monitoring because a VIP endpoint cannot prove the health of a standby node.
 
 ### OPNsense User
 
@@ -148,7 +171,7 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 * Filesystem usage
 * Interface details (status, stats, pps, kbs, etc.) *[speeds are based on the `Scan Interval (seconds)` config option]*
 * Gateways details (status, delay, stddev, loss, address)
-* CARP Status (aggregate)
+* CARP VIP status (aggregate)
 * CARP Interface status
 * DHCP Leases
 * OpenVPN and Wireguard server and client stats
@@ -180,6 +203,18 @@ The selectable device list is built from the current OPNsense ARP table, so only
 
 See [Device Tracker Guide](docs/device_tracker.md) for setup details, ARP behavior, and troubleshooting.
 
+### CARP VIP Entities and Limitations
+
+A CARP VIP entry creates only these read-only entities:
+
+* **active responder:** the name of the node currently answering through the VIP;
+* **CARP VIP status:** aggregate CARP status reported by that active responder;
+* **CARP VIP state:** one state sensor for each virtual IP keyed by VHID and subnet.
+
+A CARP VIP entry does not expose node hardware telemetry, firmware/update entities, general interfaces, services, gateways, VPN, DHCP, firewall/NAT, SMART, disks, temperatures, device trackers, actions, or switches. The VIP cannot prove standby-node health; configure OPNsense device entries for each node when complete monitoring is required.
+
+The persistent CARP maintenance switch remains on physical-node entries. Enabling maintenance through the VIP can move the VIP; a later disable request could then reach the other node. Use the physical node's OPNsense device entry when changing maintenance mode.
+
 ## Actions *(Services)*
 
 * **opnsense.close_notice:** Close any open notices
@@ -202,7 +237,7 @@ See [Device Tracker Guide](docs/device_tracker.md) for setup details, ARP behavi
 
 ### Hardware Changes
 
-If you partially or fully change the <ins>OPNsense</ins> hardware, it will require a removal and reinstall of this integration. This is to ensure changed interfaces, services, gateways, etc. are accounted for and don't leave duplicate or non-functioning entities. 
+If you partially or fully change the <ins>OPNsense</ins> hardware, it will require a removal and reinstall of this integration. This is to ensure changed interfaces, services, gateways, etc. are accounted for and don't leave duplicate or non-functioning entities.
 
 [commits-shield]: https://img.shields.io/github/last-commit/travisghansen/hass-opnsense?style=for-the-badge
 [commits]: https://github.com/travisghansen/hass-opnsense/commits/main

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -14,14 +14,17 @@ from typing import Any
 from aiopnsense import OPNsenseClient
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
+    OPNsenseConnectionError,
     OPNsenseError,
     OPNsenseMissingDeviceUniqueID,
+    OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
 import awesomeversion
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -32,6 +35,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 
 from .const import (
+    CARP_PLATFORMS,
     CONF_DEVICE_TRACKER_ENABLED,
     CONF_DEVICE_TRACKER_SCAN_INTERVAL,
     CONF_DEVICE_UNIQUE_ID,
@@ -50,7 +54,13 @@ from .const import (
     VERSION,
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
-from .helpers import create_opnsense_client_from_config_entry, detach_shared_router_parent
+from .helpers import (
+    config_entry_identity,
+    create_opnsense_client_from_config_entry,
+    detach_shared_router_parent,
+    is_carp_entry,
+    is_usable_carp_vip,
+)
 from .migrate import (
     _is_firewall_sync_enabled,
     _migrate_1_to_2,
@@ -100,9 +110,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if getattr(entry.runtime_data, SHOULD_RELOAD, True):
         _LOGGER.info("[async_update_listener] Reloading")
 
-        uid_prefix: str | None = slugify(
-            str(entry.data.get(CONF_DEVICE_UNIQUE_ID) or entry.unique_id or "")
-        )
+        uid_prefix = slugify(config_entry_identity(entry))
         if not uid_prefix:
             _LOGGER.debug("[async_update_listener] Skipping entity cleanup; empty entry uid prefix")
             uid_prefix = None
@@ -255,6 +263,84 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a CARP integration entry with a runtime ID-less coordinator.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        entry: CARP config entry being set up.
+
+    Returns:
+        bool: ``True`` after the coordinator refresh and platform setup succeed.
+
+    Raises:
+        ConfigEntryNotReady: If the initial refresh returns no usable CARP VIPs.
+        OPNsenseError: If client validation or the initial refresh fails.
+    """
+    client: OPNsenseClient | None = None
+    setup_succeeded: bool = False
+    coordinator: OPNsenseDataUpdateCoordinator | None = None
+
+    try:
+        client = create_opnsense_client_from_config_entry(hass=hass, config_entry=entry)
+        try:
+            await client.validate(require_device_id=False)
+        except OPNsenseTimeoutError as err:
+            raise ConfigEntryNotReady("OPNsense validation timed out") from err
+        except OPNsenseConnectionError as err:
+            if type(err) is not OPNsenseConnectionError:
+                raise
+            raise ConfigEntryNotReady("OPNsense validation could not complete") from err
+
+        scan_interval: int = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        _LOGGER.info("Starting hass-opnsense %s", VERSION)
+
+        coordinator = OPNsenseDataUpdateCoordinator(
+            hass=hass,
+            name=f"{entry.title} state",
+            update_interval=timedelta(seconds=scan_interval),
+            client=client,
+            device_unique_id=None,
+            config_entry=entry,
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+
+        coordinator_data = coordinator.data
+        carp_state = coordinator_data.get("carp") if isinstance(coordinator_data, Mapping) else None
+        carp_interfaces = carp_state.get("interfaces") if isinstance(carp_state, Mapping) else None
+        if not isinstance(carp_interfaces, list) or not any(
+            is_usable_carp_vip(interface) for interface in carp_interfaces
+        ):
+            raise ConfigEntryNotReady("No usable CARP VIPs were returned during initial refresh")
+
+        platforms: list[Platform] = CARP_PLATFORMS.copy()
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][entry.entry_id] = client
+        entry.runtime_data = OPNsenseData(
+            coordinator=coordinator,
+            device_tracker_coordinator=None,
+            opnsense_client=client,
+            device_unique_id=None,
+            loaded_platforms=platforms,
+        )
+        remove_listener = entry.add_update_listener(_async_update_listener)
+        entry.async_on_unload(remove_listener)
+
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+        setup_succeeded = True
+        return True
+    finally:
+        if not setup_succeeded:
+            if coordinator is not None:
+                await coordinator.async_shutdown()
+            if DOMAIN in hass.data:
+                hass.data[DOMAIN].pop(entry.entry_id, None)
+            if client is not None:
+                await client.async_close()
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up OPNsense integration state for a config entry.
 
@@ -266,9 +352,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bool: `True` when setup and initial refresh succeed; otherwise `False`.
 
     Raises:
+        ConfigEntryNotReady: If transient connection validation fails and setup should be retried.
         OPNsenseError: Raised when validation cannot complete because of
             authentication, privilege, firmware, or transport failures.
     """
+    if is_carp_entry(entry):
+        return await _async_setup_carp_entry(hass, entry)
+
     config: Mapping[str, Any] = entry.data
     options: Mapping[str, Any] = entry.options
     # _LOGGER.debug("[async_setup_entry] entry: %s", entry.as_dict())
@@ -291,6 +381,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug(
                 "Client validation reported firmware issues; continuing to firmware probes"
             )
+        except OPNsenseTimeoutError as err:
+            raise ConfigEntryNotReady("OPNsense validation timed out") from err
+        except OPNsenseConnectionError as err:
+            if type(err) is not OPNsenseConnectionError:
+                raise
+            raise ConfigEntryNotReady("OPNsense validation could not complete") from err
+    except ConfigEntryNotReady:
+        if client is not None:
+            await client.async_close()
+        raise
     except OPNsenseError:
         if client is not None:
             await client.async_close()

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -110,7 +110,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if getattr(entry.runtime_data, SHOULD_RELOAD, True):
         _LOGGER.info("[async_update_listener] Reloading")
 
-        uid_prefix = slugify(config_entry_identity(entry))
+        uid_prefix: str | None = slugify(config_entry_identity(entry))
         if not uid_prefix:
             _LOGGER.debug("[async_update_listener] Skipping entity cleanup; empty entry uid prefix")
             uid_prefix = None

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -324,10 +324,8 @@ async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
             device_unique_id=None,
             loaded_platforms=platforms,
         )
-        remove_listener = entry.add_update_listener(_async_update_listener)
-        entry.async_on_unload(remove_listener)
-
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
         setup_succeeded = True
         return True

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -341,20 +341,19 @@ async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up OPNsense integration state for a config entry.
+    """Set up an OPNsense config entry and its runtime resources.
 
     Args:
         hass: Home Assistant instance.
         entry: Config entry containing OPNsense connection credentials and options.
 
     Returns:
-        bool: `True` when setup and initial refresh succeed; otherwise `False`.
+        bool: `True` when setup and initial refresh succeed. Returns `False` when
+            the router identity has changed or its firmware is unsupported.
 
     Raises:
-        TimeoutError: If client validation raises a raw timeout error.
-        ConfigEntryNotReady: If transient connection validation fails and setup should be retried.
-        OPNsenseError: Raised when validation cannot complete because of
-            authentication, privilege, firmware, or transport failures.
+        ConfigEntryNotReady: If a transient connection failure prevents setup.
+        OPNsenseError: If setup fails with a non-retryable OPNsense client error.
     """
     if is_carp_entry(entry):
         return await _async_setup_carp_entry(hass, entry)

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -115,7 +115,6 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             _LOGGER.debug("[async_update_listener] Skipping entity cleanup; empty entry uid prefix")
             uid_prefix = None
         sync_firewall_and_nat_enabled = _is_firewall_sync_enabled(entry)
-        config_device_id: str = entry.data[CONF_DEVICE_UNIQUE_ID]
         # _LOGGER.debug("[async_update_listener] uid_prefix: %s", uid_prefix)
         removal_prefixes: list[str] = []
         for item, prefix in GRANULAR_SYNC_PREFIX.items():
@@ -155,7 +154,8 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                         entity_registry.async_remove(ent.entity_id)
                         break
         dt_enabled = entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED)
-        if not dt_enabled:
+        if not dt_enabled and not is_carp_entry(entry):
+            config_device_id: str = entry.data[CONF_DEVICE_UNIQUE_ID]
             device_registry = dr.async_get(hass)
             devices = dr.async_entries_for_config_entry(
                 registry=device_registry, config_entry_id=entry.entry_id

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -387,15 +387,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if type(err) is not OPNsenseConnectionError:
                 raise
             raise ConfigEntryNotReady("OPNsense validation could not complete") from err
-    except ConfigEntryNotReady:
-        if client is not None:
-            await client.async_close()
-        raise
-    except TimeoutError:
-        if client is not None:
-            await client.async_close()
-        raise
-    except OPNsenseError:
+    except ConfigEntryNotReady, TimeoutError, OPNsenseError:
         if client is not None:
             await client.async_close()
         raise

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -333,6 +333,7 @@ async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
         return True
     finally:
         if not setup_succeeded:
+            entry.runtime_data = None
             if coordinator is not None:
                 await coordinator.async_shutdown()
             if DOMAIN in hass.data:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -351,6 +351,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bool: `True` when setup and initial refresh succeed; otherwise `False`.
 
     Raises:
+        TimeoutError: If client validation raises a raw timeout error.
         ConfigEntryNotReady: If transient connection validation fails and setup should be retried.
         OPNsenseError: Raised when validation cannot complete because of
             authentication, privilege, firmware, or transport failures.
@@ -387,6 +388,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise
             raise ConfigEntryNotReady("OPNsense validation could not complete") from err
     except ConfigEntryNotReady:
+        if client is not None:
+            await client.async_close()
+        raise
+    except TimeoutError:
         if client is not None:
             await client.async_close()
         raise

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -23,21 +23,9 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
-from .helpers import coerce_bool, dict_get
+from .helpers import coerce_bool, dict_get, get_smart_device_name
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-
-def _smart_device_slug(device_name: str) -> str:
-    """Return the entity key slug for a SMART device name.
-
-    Args:
-        device_name: SMART device name to normalize.
-
-    Returns:
-        The slugified device name, or ``unknown`` when slugification fails.
-    """
-    return slugify(device_name) or "unknown"
 
 
 def _build_interface_enabled_binary_sensor_description(
@@ -73,7 +61,7 @@ def _build_smart_status_binary_sensor_description(
         A binary sensor description for SMART health state.
     """
     return BinarySensorEntityDescription(
-        key=f"smart.{_smart_device_slug(device_name)}.status",
+        key=f"smart.{slugify(device_name) or 'unknown'}.status",
         name=f"SMART {device_name} Status",
         icon="mdi:harddisk",
         device_class=BinarySensorDeviceClass.PROBLEM,
@@ -160,10 +148,9 @@ async def _compile_smart_status_binary_sensors(
     for smart_device in smart_devices:
         if not isinstance(smart_device, Mapping):
             continue
-        device_name = smart_device.get("device")
-        if not isinstance(device_name, str) or not device_name.strip():
+        device_name = get_smart_device_name(smart_device)
+        if not device_name:
             continue
-        device_name = device_name.strip()
 
         entities.append(
             OPNsenseSmartStatusBinarySensor(
@@ -300,10 +287,10 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
         for candidate in smart_devices:
             if not isinstance(candidate, Mapping):
                 continue
-            device_name = candidate.get("device")
-            if not isinstance(device_name, str) or not device_name.strip():
+            device_name = get_smart_device_name(candidate)
+            if not device_name:
                 continue
-            if _smart_device_slug(device_name.strip()) == expected_device_slug:
+            if (slugify(device_name.strip()) or "unknown") == expected_device_slug:
                 smart_device = candidate
                 break
 
@@ -311,12 +298,9 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
             self._mark_unavailable()
             return
 
-        device_name = smart_device.get("device")
+        device_name = get_smart_device_name(smart_device)
         smart_info = state.get("smart_info")
-        normalized_device_name = device_name.strip() if isinstance(device_name, str) else ""
-        device_info = (
-            smart_info.get(normalized_device_name) if isinstance(smart_info, Mapping) else None
-        )
+        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
         if not isinstance(device_info, Mapping):
             device_info = {}
 

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -8,8 +8,10 @@ import ipaddress
 import logging
 import re
 from typing import Any
-from urllib.parse import ParseResult, quote_plus, urlparse
+from urllib.parse import quote_plus, urlparse
 
+import aiohttp
+from aiohttp import ClientError
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
@@ -41,6 +43,7 @@ from .const import (
     CONF_DEVICE_TRACKER_SCAN_INTERVAL,
     CONF_DEVICE_UNIQUE_ID,
     CONF_DEVICES,
+    CONF_ENTRY_TYPE,
     CONF_FIRMWARE_VERSION,
     CONF_GRANULAR_SYNC_OPTIONS,
     CONF_MANUAL_DEVICES,
@@ -52,15 +55,36 @@ from .const import (
     DEFAULT_SYNC_OPTION_VALUE,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    ENTRY_TYPE_CARP,
+    ENTRY_TYPE_DEVICE,
     GRANULAR_SYNC_ITEMS,
     OPNSENSE_MIN_FIRMWARE,
     TRACKED_MACS,
 )
-from .helpers import create_opnsense_client
+from .helpers import (
+    create_opnsense_client,
+    get_arp_ip,
+    get_arp_mac,
+    is_carp_entry,
+    is_usable_carp_vip,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 DeviceEntries = dict[str, str]
+
+
+class OPNsenseCarpNotConfiguredError(OPNsenseError):
+    """Raised when an endpoint has no usable CARP VIP rows."""
+
+
+class OPNsenseCarpResponderUnavailableError(OPNsenseError):
+    """Signal missing or invalid active CARP responder metadata.
+
+    This error distinguishes responder discovery failures from empty or invalid
+    CARP VIP inventories.
+    """
+
 
 CONF_DEVICE_TRACKING_MODE = "device_tracking_mode"
 DEVICE_TRACKING_MODE_DISABLED = "disabled"
@@ -222,20 +246,8 @@ def _build_selected_device_entries(selected_devices: Iterable[str]) -> DeviceEnt
         normalized = normalize_mac_address(str(device))
         if not normalized:
             continue
-        entries[normalized] = _format_selected_device_label(normalized)
+        entries[normalized] = f"Not currently detected [{normalized}]"
     return entries
-
-
-def _format_selected_device_label(mac: str) -> str:
-    """Format a fallback label for configured MACs not currently detected.
-
-    Args:
-        mac: MAC address to display.
-
-    Returns:
-        str: Human-readable fallback label.
-    """
-    return f"Not currently detected [{mac}]"
 
 
 def _format_detected_device_label(entry: Mapping[str, Any]) -> str:
@@ -247,9 +259,10 @@ def _format_detected_device_label(entry: Mapping[str, Any]) -> str:
     Returns:
         str: Human-readable device label for the options form.
     """
-    normalized_mac = normalize_mac_address(str(entry.get("mac", "")))
-    mac = normalized_mac or str(entry.get("mac", "")).lower().strip()
-    ip: str = str(entry.get("ip", "")).strip()
+    arp_mac = get_arp_mac(entry)
+    normalized_mac = normalize_mac_address(arp_mac)
+    mac = normalized_mac or arp_mac
+    ip: str = get_arp_ip(entry)
     hostname: str = str(entry.get("hostname", "")).strip("?").strip()
     manufacturer: str = str(entry.get("manufacturer", "")).strip()
 
@@ -335,6 +348,8 @@ async def validate_input(
     user_input: MutableMapping[str, Any],
     errors: dict[str, Any],
     expected_id: str | None = None,
+    *,
+    carp: bool = False,
 ) -> dict[str, Any]:
     """Validate user input and map failures to config-flow error keys.
 
@@ -343,14 +358,23 @@ async def validate_input(
         user_input: Input payload being validated for this flow step.
         errors: Mutable error mapping populated by this validator.
         expected_id: Expected device unique ID for reconfigure and options validation.
+        carp: Validate CARP VIP-specific client details instead of standard details.
 
     Returns:
         dict[str, Any]: Updated error mapping suitable for form rendering.
+
+    Raises:
+        OPNsenseError: If an OPNsense validation error cannot be mapped to a form error.
     """
     try:
-        await _validate_client_details(hass=hass, user_input=user_input, expected_id=expected_id)
-    except OPNsenseError as err:
-        validation_error = _get_validation_error_details(error=err, user_input=user_input)
+        if carp:
+            await _validate_carp_client_details(hass=hass, user_input=user_input)
+        else:
+            await _validate_client_details(
+                hass=hass, user_input=user_input, expected_id=expected_id
+            )
+    except (OPNsenseError, TimeoutError, ClientError) as err:
+        validation_error = _get_connection_error_details(error=err, user_input=user_input)
         if validation_error is None:
             raise
         error_key, log_message = validation_error
@@ -359,13 +383,13 @@ async def validate_input(
 
 
 def _get_validation_error_details(
-    error: OPNsenseError,
+    error: OPNsenseError | ClientError | TimeoutError,
     user_input: Mapping[str, Any],
 ) -> tuple[str, str] | None:
-    """Return config-flow error details for an aiopnsense validation exception.
+    """Return config-flow error details for a validation exception.
 
     Args:
-        error: aiopnsense exception raised while validating the input.
+        error: Validation exception raised while validating the input.
         user_input: User input containing optional secrets for log redaction.
 
     Returns:
@@ -382,10 +406,33 @@ def _get_validation_error_details(
             "unknown_firmware",
             "Unable to get OPNsense Firmware version",
         )
+    if isinstance(error, OPNsenseCarpResponderUnavailableError):
+        return (
+            "carp_responder_unavailable",
+            "Unable to determine the active CARP responder",
+        )
+    if isinstance(error, OPNsenseCarpNotConfiguredError):
+        return ("carp_not_configured", "No CARP VIPs were returned")
     if isinstance(error, OPNsenseMissingDeviceUniqueID):
         return (
             "missing_device_unique_id",
             f"Missing Device Unique ID Error. {type(error).__name__}: {error}",
+        )
+    if isinstance(error, TimeoutError):
+        return (
+            "connect_timeout",
+            cleanse_sensitive_data(
+                f"Connection TimeoutError. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
+        )
+    if isinstance(error, ClientError):
+        return (
+            "cannot_connect",
+            cleanse_sensitive_data(
+                f"ClientError. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
         )
     if isinstance(error, OPNsenseInvalidURL):
         return (
@@ -406,18 +453,58 @@ def _get_validation_error_details(
     return None
 
 
-async def _clean_and_parse_url(user_input: MutableMapping[str, Any]) -> None:
-    """Normalize and validate the configured OPNsense base URL.
+def _get_connection_error_details(
+    error: BaseException,
+    user_input: Mapping[str, Any],
+) -> tuple[str, str] | None:
+    """Map connection-level validation exceptions to config-flow error keys."""
 
-    Args:
-        user_input: Mutable form payload containing `CONF_URL`.
+    if isinstance(error, TimeoutError):
+        return (
+            "connect_timeout",
+            cleanse_sensitive_data(
+                f"Connection TimeoutError. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
+        )
 
-    Raises:
-        OPNsenseInvalidURL: URL is missing a host after normalization.
-    """
-    fix_url: str = user_input.get(CONF_URL, "").strip()
-    url_parts: ParseResult = urlparse(fix_url)
+    if isinstance(error, aiohttp.ClientResponseError) and error.status == 403:
+        return (
+            "privilege_missing",
+            cleanse_sensitive_data(
+                f"aiohttp Error. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
+        )
 
+    if isinstance(error, aiohttp.ClientSSLError):
+        return (
+            "cannot_connect_ssl",
+            cleanse_sensitive_data(
+                f"aiohttp SSL Error. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
+        )
+
+    if isinstance(error, aiohttp.ClientError):
+        return (
+            "cannot_connect",
+            cleanse_sensitive_data(
+                f"aiohttp Error. {type(error).__name__}: {error}",
+                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
+            ),
+        )
+
+    if isinstance(error, OPNsenseError):
+        return _get_validation_error_details(error=error, user_input=user_input)
+
+    return None
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize and validate an OPNsense base URL."""
+    fix_url = url.strip()
+    url_parts = urlparse(fix_url)
     if not url_parts.scheme and not url_parts.netloc:
         fix_url = "https://" + fix_url
         url_parts = urlparse(fix_url)
@@ -435,10 +522,17 @@ async def _clean_and_parse_url(user_input: MutableMapping[str, Any]) -> None:
         port = url_parts.port
     except ValueError as err:
         raise OPNsenseInvalidURL from err
-    if port:
+
+    default_port = {"http": 80, "https": 443}.get(url_parts.scheme)
+    if port and port != default_port:
         host = f"{host}:{port}"
 
-    user_input[CONF_URL] = f"{url_parts.scheme}://{host}"
+    return f"{url_parts.scheme}://{host}"
+
+
+async def _clean_and_parse_url(user_input: MutableMapping[str, Any]) -> None:
+    """Normalize and validate the configured OPNsense base URL."""
+    user_input[CONF_URL] = _normalize_url(user_input.get(CONF_URL, ""))
     _LOGGER.debug("[config_flow] Cleaned URL: %s", user_input[CONF_URL])
 
 
@@ -488,6 +582,59 @@ async def _validate_client_details(
 
         if not user_input.get(CONF_DEVICE_UNIQUE_ID):
             raise OPNsenseMissingDeviceUniqueID("OPNsense device unique ID is unavailable")
+    finally:
+        await client.async_close()
+
+
+async def _validate_carp_client_details(
+    hass: HomeAssistant,
+    user_input: MutableMapping[str, Any],
+) -> None:
+    """Validate and enrich a CARP VIP flow submission without a device-ID probe.
+
+    Args:
+        hass: Home Assistant instance used to create the OPNsense client.
+        user_input: Mutable flow payload updated with normalized and discovered values.
+
+    Raises:
+        OPNsenseError: If URL, client, responder, or CARP VIP validation fails.
+    """
+    await _clean_and_parse_url(user_input)
+
+    client = create_opnsense_client(
+        hass=hass,
+        url=user_input[CONF_URL],
+        username=user_input[CONF_USERNAME],
+        password=user_input[CONF_PASSWORD],
+        verify_ssl=user_input.get(CONF_VERIFY_SSL),
+        throw_errors=True,
+    )
+    try:
+        await client.validate(require_device_id=False)
+        firmware = await client.get_host_firmware_version()
+        user_input[CONF_FIRMWARE_VERSION] = firmware
+
+        system_info = await client.get_system_info()
+        if not isinstance(system_info, Mapping):
+            raise OPNsenseCarpResponderUnavailableError("CARP responder information is unavailable")
+        responder_name = system_info.get("name")
+        if not isinstance(responder_name, str) or not responder_name.strip():
+            raise OPNsenseCarpResponderUnavailableError("CARP responder name is unavailable")
+        responder_name = responder_name.strip()
+
+        carp = await client.get_carp()
+        carp_interfaces = carp.get("interfaces") if isinstance(carp, Mapping) else None
+        if not isinstance(carp_interfaces, list) or not any(
+            is_usable_carp_vip(interface) for interface in carp_interfaces
+        ):
+            raise OPNsenseCarpNotConfiguredError("No CARP VIPs were returned")
+
+        if not user_input.get(CONF_NAME):
+            user_input[CONF_NAME] = f"{responder_name} CARP VIP"
+
+        user_input[CONF_ENTRY_TYPE] = ENTRY_TYPE_CARP
+        user_input.pop(CONF_DEVICE_UNIQUE_ID, None)
+        user_input.pop(CONF_GRANULAR_SYNC_OPTIONS, None)
     finally:
         await client.async_close()
 
@@ -555,6 +702,82 @@ def _build_user_input_schema(
             }
         )
     return vol.Schema(schema_fields)
+
+
+def _build_carp_input_schema(
+    user_input: Mapping[str, Any] | None,
+    stored_values: Mapping[str, Any] | None = None,
+) -> vol.Schema:
+    """Build the CARP-only user input schema.
+
+    Args:
+        user_input: Values submitted for the current configuration or options flow step.
+        stored_values: Stored config-entry values used to prefill the form.
+
+    Returns:
+        vol.Schema: Form schema for a CARP flow connection step.
+    """
+    defaults = {
+        CONF_URL: "https://",
+        CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_NAME: "",
+        **(stored_values or {}),
+        **(user_input or {}),
+    }
+
+    return vol.Schema(
+        {
+            vol.Required(CONF_URL, default=defaults[CONF_URL]): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+            ),
+            vol.Optional(CONF_VERIFY_SSL, default=defaults[CONF_VERIFY_SSL]): bool,
+            vol.Required(CONF_USERNAME, default=defaults[CONF_USERNAME]): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+            ),
+            vol.Required(CONF_PASSWORD, default=defaults[CONF_PASSWORD]): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+            ),
+            vol.Optional(CONF_NAME, default=defaults[CONF_NAME]): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+            ),
+        }
+    )
+
+
+def _build_carp_options_schema(
+    user_input: Mapping[str, Any] | None,
+    stored_options: Mapping[str, Any] | None,
+) -> vol.Schema:
+    """Build the scan-interval-only options schema for a CARP VIP entry.
+
+    Args:
+        user_input: Values submitted for the current options-flow step.
+        stored_options: Existing config-entry options used to prefill the form.
+
+    Returns:
+        vol.Schema: Options schema containing the CARP scan interval selector.
+    """
+    defaults = {
+        CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+        **(stored_options or {}),
+        **(user_input or {}),
+    }
+    scan_interval = _normalize_int_option(defaults[CONF_SCAN_INTERVAL], 10, 300)
+
+    return vol.Schema(
+        {
+            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=10,
+                    max=300,
+                    step=1,
+                    unit_of_measurement="seconds",
+                )
+            )
+        }
+    )
 
 
 def _build_granular_sync_schema(
@@ -743,11 +966,12 @@ async def _get_dt_entries(
             ip_by_mac: dict[str, str] = {}
             # follow with all arp table entries
             for entry in arp_table:
-                normalized_mac = normalize_mac_address(str(entry.get("mac", "")))
-                mac: str = normalized_mac or str(entry.get("mac", "")).lower().strip()
+                arp_mac = get_arp_mac(entry)
+                normalized_mac = normalize_mac_address(arp_mac)
+                mac: str = normalized_mac or arp_mac
                 if len(mac) < 1:
                     continue
-                ip_by_mac[mac] = str(entry.get("ip", "")).strip()
+                ip_by_mac[mac] = get_arp_ip(entry)
                 label: str = _format_detected_device_label(entry)
                 entries[mac] = label
 
@@ -774,6 +998,32 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize transient config-flow storage."""
         self._config: dict[str, Any] = {}
 
+    def _async_abort_if_url_conflict(self, *, url: str, carp: bool) -> ConfigFlowResult | None:
+        """Abort when a device and CARP entry reuse the same URL.
+
+        Args:
+            url: Normalized OPNsense URL being configured.
+            carp: Whether the submitted entry is a CARP entry.
+
+        Returns:
+            ConfigFlowResult | None: Conflict abort result, if applicable.
+        """
+        for existing_entry in self.hass.config_entries.async_entries(DOMAIN):
+            if is_carp_entry(existing_entry) == carp:
+                continue
+            existing_url = existing_entry.data.get(CONF_URL)
+            if existing_url == url:
+                return self.async_abort(reason="carp_device_url_conflict")
+            if not isinstance(existing_url, str):
+                continue
+            try:
+                existing_url = _normalize_url(existing_url)
+            except OPNsenseInvalidURL, ValueError:
+                continue
+            if existing_url == url:
+                return self.async_abort(reason="carp_device_url_conflict")
+        return None
+
     # gets invoked without user input initially
     # when user submits has user_input
     async def async_step_user(
@@ -782,15 +1032,36 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial user config step.
 
         Args:
-            user_input: Submitted form payload, or `None` for first render.
+            user_input: Ignored initial menu payload.
 
         Returns:
-            ConfigFlowResult: Next flow step or created config entry.
+            ConfigFlowResult: Menu containing device and CARP setup choices.
+        """
+        return self.async_show_menu(step_id="user", menu_options=["device", "carp"])
+
+    async def async_step_device(
+        self, user_input: MutableMapping[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the device setup flow.
+
+        Args:
+            user_input: Submitted device connection and synchronization settings.
+
+        Returns:
+            ConfigFlowResult: Device form, granular-sync form, entry, or abort result.
         """
         errors: dict[str, Any] = {}
         if user_input is not None:
+            user_input[CONF_ENTRY_TYPE] = ENTRY_TYPE_DEVICE
             errors = await validate_input(hass=self.hass, user_input=user_input, errors=errors)
             if not errors:
+                abort = self._async_abort_if_url_conflict(
+                    url=user_input[CONF_URL],
+                    carp=False,
+                )
+                if abort:
+                    return abort
+
                 # https://developers.home-assistant.io/docs/config_entries_config_flow_handler#unique-ids
                 await self.async_set_unique_id(user_input.get(CONF_DEVICE_UNIQUE_ID))
                 self._abort_if_unique_id_configured()
@@ -809,8 +1080,58 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         firmware = user_input.get(CONF_FIRMWARE_VERSION, "Unknown")
 
         return self.async_show_form(
-            step_id="user",
+            step_id="device",
             data_schema=_build_user_input_schema(user_input=user_input),
+            errors=errors,
+            description_placeholders={
+                "firmware": firmware,
+                "min_firmware": OPNSENSE_MIN_FIRMWARE,
+            },
+        )
+
+    async def async_step_carp(
+        self, user_input: MutableMapping[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle CARP setup flow.
+
+        Args:
+            user_input: Submitted CARP VIP connection settings.
+
+        Returns:
+            ConfigFlowResult: CARP form, created entry, or duplicate/conflict abort result.
+        """
+        errors: dict[str, Any] = {}
+        if user_input is not None:
+            errors = await validate_input(
+                hass=self.hass,
+                user_input=user_input,
+                errors=errors,
+                carp=True,
+            )
+            if not errors:
+                abort = self._async_abort_if_url_conflict(
+                    url=user_input[CONF_URL],
+                    carp=True,
+                )
+                if abort:
+                    return abort
+
+                abort = self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
+                if abort:
+                    return abort
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data=user_input,
+                )
+
+        if not user_input:
+            user_input = {}
+        firmware = user_input.get(CONF_FIRMWARE_VERSION, "Unknown")
+
+        return self.async_show_form(
+            step_id="carp",
+            data_schema=_build_carp_input_schema(user_input=user_input),
             errors=errors,
             description_placeholders={
                 "firmware": firmware,
@@ -870,26 +1191,57 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._config.update(user_input)
-            errors = await validate_input(
-                hass=self.hass,
-                user_input=self._config,
-                errors=errors,
-                expected_id=self._config.get(CONF_DEVICE_UNIQUE_ID),
-            )
-
-            if not errors:
-                # https://developers.home-assistant.io/docs/config_entries_config_flow_handler#unique-ids
-                await self.async_set_unique_id(self._config.get(CONF_DEVICE_UNIQUE_ID))
-                self._abort_if_unique_id_mismatch()
-
-                # Keep this non-reloading helper paired with the config-entry
-                # update listener registered in async_setup_entry.
-                # async_update_reload_and_abort is deprecated for entries that
-                # also use add_update_listener.
-                return self.async_update_and_abort(
-                    entry=reconfigure_entry,
-                    data=self._config,
+            if is_carp_entry(reconfigure_entry):
+                errors = await validate_input(
+                    hass=self.hass,
+                    user_input=self._config,
+                    errors=errors,
+                    carp=True,
                 )
+                if not errors:
+                    if self._config[CONF_URL] != reconfigure_entry.data[CONF_URL]:
+                        abort = self._async_abort_if_url_conflict(
+                            url=self._config[CONF_URL],
+                            carp=True,
+                        )
+                        if abort:
+                            return abort
+                        abort = self._async_abort_entries_match({CONF_URL: self._config[CONF_URL]})
+                        if abort:
+                            return abort
+                    return self.async_update_and_abort(
+                        entry=reconfigure_entry,
+                        data=self._config,
+                    )
+            else:
+                errors = await validate_input(
+                    hass=self.hass,
+                    user_input=self._config,
+                    errors=errors,
+                    expected_id=self._config.get(CONF_DEVICE_UNIQUE_ID),
+                )
+
+                if not errors:
+                    if self._config[CONF_URL] != reconfigure_entry.data[CONF_URL]:
+                        abort = self._async_abort_if_url_conflict(
+                            url=self._config[CONF_URL],
+                            carp=False,
+                        )
+                        if abort:
+                            return abort
+
+                    # https://developers.home-assistant.io/docs/config_entries_config_flow_handler#unique-ids
+                    await self.async_set_unique_id(self._config.get(CONF_DEVICE_UNIQUE_ID))
+                    self._abort_if_unique_id_mismatch()
+
+                    # Keep this non-reloading helper paired with the config-entry
+                    # update listener registered in async_setup_entry.
+                    # async_update_reload_and_abort is deprecated for entries that
+                    # also use add_update_listener.
+                    return self.async_update_and_abort(
+                        entry=reconfigure_entry,
+                        data=self._config,
+                    )
 
         if not user_input:
             user_input = {}
@@ -897,8 +1249,12 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=_build_user_input_schema(
-                user_input=user_input, stored_values=self._config, reconf=True
+            data_schema=(
+                _build_carp_input_schema(user_input=user_input, stored_values=self._config)
+                if is_carp_entry(reconfigure_entry)
+                else _build_user_input_schema(
+                    user_input=user_input, stored_values=self._config, reconf=True
+                )
             ),
             errors=errors,
             description_placeholders={
@@ -916,7 +1272,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             ConfigFlowResult: Result from `async_step_user`.
         """
-        return await self.async_step_user(user_input)
+        return await self.async_step_device(user_input)
 
     @staticmethod
     @callback
@@ -966,6 +1322,36 @@ class OPNsenseOptionsFlow(OptionsFlow):
         errors: dict[str, Any] = {}
         self._config = dict(self.config_entry.data)
         self._options = dict(self.config_entry.options)
+
+        if is_carp_entry(self.config_entry):
+            if user_input is not None:
+                options = dict(self._options)
+                options[CONF_SCAN_INTERVAL] = _normalize_int_option(
+                    user_input.get(
+                        CONF_SCAN_INTERVAL,
+                        options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    ),
+                    10,
+                    300,
+                )
+                self._options = options
+                return self.async_create_entry(data=self._options)
+
+            if not user_input:
+                user_input = {}
+
+            return self.async_show_form(
+                step_id="init",
+                data_schema=_build_carp_options_schema(
+                    user_input=user_input,
+                    stored_options=self._options,
+                ),
+                errors=errors,
+                description_placeholders={
+                    "options_scope": "scan interval only for this CARP VIP entry",
+                },
+            )
+
         if user_input is not None:
             tracking_mode = _resolve_device_tracking_mode(self._options, user_input)
             self._options.update(
@@ -1000,6 +1386,9 @@ class OPNsenseOptionsFlow(OptionsFlow):
                 user_input=user_input, stored_config=self._config, stored_options=self._options
             ),
             errors=errors,
+            description_placeholders={
+                "options_scope": "all available integration and device-tracker options",
+            },
         )
 
     async def async_step_granular_sync(
@@ -1078,17 +1467,15 @@ class OPNsenseOptionsFlow(OptionsFlow):
             dt_entries: DeviceEntries = await _get_dt_entries(
                 hass=self.hass, config=self.config_entry.data, selected_devices=selected_devices
             )
-        except OPNsenseConnectionError as err:
-            validation_error = _get_validation_error_details(
-                error=err, user_input=self.config_entry.data
-            )
+        except (OPNsenseError, ClientError, TimeoutError) as err:
+            validation_error = _get_connection_error_details(error=err, user_input=self._config)
             if validation_error is None:
                 raise
             error_key, log_message = validation_error
             _LOGGER.warning("Failed to load device tracker entries: %s", log_message)
             errors["base"] = error_key
             dt_entries = {
-                mac: _format_selected_device_label(mac)
+                mac: f"Not currently detected [{mac}]"
                 for mac in _merge_selected_devices(selected_devices)
             }
 

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -1198,6 +1198,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                             return abort
                     return self.async_update_and_abort(
                         entry=reconfigure_entry,
+                        title=self._config[CONF_NAME],
                         data=self._config,
                     )
             else:

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -490,9 +490,6 @@ def _normalize_url(url: str) -> str:
     if "://" not in fix_url:
         fix_url = "https://" + fix_url
     url_parts = urlparse(fix_url)
-    if not url_parts.scheme and not url_parts.netloc:
-        fix_url = "https://" + fix_url
-        url_parts = urlparse(fix_url)
 
     if not url_parts.netloc:
         raise OPNsenseInvalidURL
@@ -515,7 +512,7 @@ def _normalize_url(url: str) -> str:
     return f"{url_parts.scheme}://{host}"
 
 
-async def _clean_and_parse_url(user_input: MutableMapping[str, Any]) -> None:
+def _clean_and_parse_url(user_input: MutableMapping[str, Any]) -> None:
     """Normalize and validate the configured OPNsense base URL."""
     user_input[CONF_URL] = _normalize_url(user_input.get(CONF_URL, ""))
     _LOGGER.debug("[config_flow] Cleaned URL: %s", user_input[CONF_URL])
@@ -538,7 +535,7 @@ async def _validate_client_details(
         OPNsenseBelowMinFirmware: Firmware is below the minimum supported version.
         OPNsenseMissingDeviceUniqueID: Backend did not return a device unique ID.
     """
-    await _clean_and_parse_url(user_input)
+    _clean_and_parse_url(user_input)
 
     client = create_opnsense_client(
         hass=hass,
@@ -584,7 +581,7 @@ async def _validate_carp_client_details(
     Raises:
         OPNsenseError: If URL, client, responder, or CARP VIP validation fails.
     """
-    await _clean_and_parse_url(user_input)
+    _clean_and_parse_url(user_input)
 
     client = create_opnsense_client(
         hass=hass,
@@ -1011,8 +1008,6 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="carp_device_url_conflict")
         return None
 
-    # gets invoked without user input initially
-    # when user submits has user_input
     async def async_step_user(
         self, user_input: MutableMapping[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -1248,13 +1243,13 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_import(self, user_input: MutableMapping[str, Any]) -> ConfigFlowResult:
-        """Handle YAML import by delegating to the user step.
+        """Handle YAML import by delegating to the device step.
 
         Args:
             user_input: Imported configuration payload.
 
         Returns:
-            ConfigFlowResult: Result from `async_step_user`.
+            ConfigFlowResult: Result returned from `async_step_device`.
         """
         return await self.async_step_device(user_input)
 

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -10,8 +10,6 @@ import re
 from typing import Any
 from urllib.parse import quote_plus, urlparse
 
-import aiohttp
-from aiohttp import ClientError
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
@@ -373,8 +371,8 @@ async def validate_input(
             await _validate_client_details(
                 hass=hass, user_input=user_input, expected_id=expected_id
             )
-    except (OPNsenseError, TimeoutError, ClientError) as err:
-        validation_error = _get_connection_error_details(error=err, user_input=user_input)
+    except OPNsenseError as err:
+        validation_error = _get_validation_error_details(error=err, user_input=user_input)
         if validation_error is None:
             raise
         error_key, log_message = validation_error
@@ -433,53 +431,6 @@ def _get_validation_error_details(
                     [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
                 ),
             )
-
-    return None
-
-
-def _get_connection_error_details(
-    error: BaseException,
-    user_input: Mapping[str, Any],
-) -> tuple[str, str] | None:
-    """Map connection-level validation exceptions to config-flow error keys."""
-    if isinstance(error, TimeoutError):
-        return (
-            "connect_timeout",
-            cleanse_sensitive_data(
-                f"Connection TimeoutError. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
-        )
-
-    if isinstance(error, aiohttp.ClientResponseError) and error.status == 403:
-        return (
-            "privilege_missing",
-            cleanse_sensitive_data(
-                f"aiohttp Error. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
-        )
-
-    if isinstance(error, aiohttp.ClientSSLError):
-        return (
-            "cannot_connect_ssl",
-            cleanse_sensitive_data(
-                f"aiohttp SSL Error. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
-        )
-
-    if isinstance(error, aiohttp.ClientError):
-        return (
-            "cannot_connect",
-            cleanse_sensitive_data(
-                f"aiohttp Error. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
-        )
-
-    if isinstance(error, OPNsenseError):
-        return _get_validation_error_details(error=error, user_input=user_input)
 
     return None
 
@@ -1446,8 +1397,8 @@ class OPNsenseOptionsFlow(OptionsFlow):
             dt_entries: DeviceEntries = await _get_dt_entries(
                 hass=self.hass, config=self.config_entry.data, selected_devices=selected_devices
             )
-        except (OPNsenseError, ClientError, TimeoutError) as err:
-            validation_error = _get_connection_error_details(error=err, user_input=self._config)
+        except OPNsenseError as err:
+            validation_error = _get_validation_error_details(error=err, user_input=self._config)
             if validation_error is None:
                 raise
             error_key, log_message = validation_error

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -933,30 +933,35 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize transient config-flow storage."""
         self._config: dict[str, Any] = {}
 
-    def _async_abort_if_url_conflict(self, *, url: str, carp: bool) -> ConfigFlowResult | None:
-        """Abort when a device and CARP entry reuse the same URL.
+    def _async_abort_if_url_conflict(
+        self, *, url: str, carp: bool, exclude_entry_id: str | None = None
+    ) -> ConfigFlowResult | None:
+        """Abort when another entry reuses the same normalized URL.
 
         Args:
             url: Normalized OPNsense URL being configured.
             carp: Whether the submitted entry is a CARP entry.
+            exclude_entry_id: Config entry to exclude during reconfiguration.
 
         Returns:
             ConfigFlowResult | None: Conflict abort result, if applicable.
         """
         for existing_entry in self.hass.config_entries.async_entries(DOMAIN):
-            if is_carp_entry(existing_entry) == carp:
+            if existing_entry.entry_id == exclude_entry_id:
                 continue
             existing_url = existing_entry.data.get(CONF_URL)
-            if existing_url == url:
-                return self.async_abort(reason="carp_device_url_conflict")
             if not isinstance(existing_url, str):
                 continue
             try:
                 existing_url = _normalize_url(existing_url)
             except OPNsenseInvalidURL, ValueError:
                 continue
-            if existing_url == url:
+            if existing_url != url:
+                continue
+            if is_carp_entry(existing_entry) != carp:
                 return self.async_abort(reason="carp_device_url_conflict")
+            if carp:
+                return self.async_abort(reason="already_configured")
         return None
 
     async def async_step_user(
@@ -1134,6 +1139,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                         abort = self._async_abort_if_url_conflict(
                             url=self._config[CONF_URL],
                             carp=True,
+                            exclude_entry_id=reconfigure_entry.entry_id,
                         )
                         if abort:
                             return abort
@@ -1156,6 +1162,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                         abort = self._async_abort_if_url_conflict(
                             url=self._config[CONF_URL],
                             carp=False,
+                            exclude_entry_id=reconfigure_entry.entry_id,
                         )
                         if abort:
                             return abort

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -1103,9 +1103,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                 if abort:
                     return abort
 
-                abort = self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
-                if abort:
-                    return abort
+                self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
 
                 return self.async_create_entry(
                     title=user_input[CONF_NAME],
@@ -1193,9 +1191,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                         )
                         if abort:
                             return abort
-                        abort = self._async_abort_entries_match({CONF_URL: self._config[CONF_URL]})
-                        if abort:
-                            return abort
+                        self._async_abort_entries_match({CONF_URL: self._config[CONF_URL]})
                     return self.async_update_and_abort(
                         entry=reconfigure_entry,
                         title=self._config[CONF_NAME],

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -458,7 +458,6 @@ def _get_connection_error_details(
     user_input: Mapping[str, Any],
 ) -> tuple[str, str] | None:
     """Map connection-level validation exceptions to config-flow error keys."""
-
     if isinstance(error, TimeoutError):
         return (
             "connect_timeout",

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -487,6 +487,8 @@ def _get_connection_error_details(
 def _normalize_url(url: str) -> str:
     """Normalize and validate an OPNsense base URL."""
     fix_url = url.strip()
+    if "://" not in fix_url:
+        fix_url = "https://" + fix_url
     url_parts = urlparse(fix_url)
     if not url_parts.scheme and not url_parts.netloc:
         fix_url = "https://" + fix_url
@@ -949,6 +951,8 @@ async def _get_dt_entries(
             ip_by_mac: dict[str, str] = {}
             # follow with all arp table entries
             for entry in arp_table:
+                if not isinstance(entry, Mapping):
+                    continue
                 arp_mac = get_arp_mac(entry)
                 normalized_mac = normalize_mac_address(arp_mac)
                 mac: str = normalized_mac or arp_mac

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -383,7 +383,7 @@ async def validate_input(
 
 
 def _get_validation_error_details(
-    error: OPNsenseError | ClientError | TimeoutError,
+    error: OPNsenseError,
     user_input: Mapping[str, Any],
 ) -> tuple[str, str] | None:
     """Return config-flow error details for a validation exception.
@@ -417,22 +417,6 @@ def _get_validation_error_details(
         return (
             "missing_device_unique_id",
             f"Missing Device Unique ID Error. {type(error).__name__}: {error}",
-        )
-    if isinstance(error, TimeoutError):
-        return (
-            "connect_timeout",
-            cleanse_sensitive_data(
-                f"Connection TimeoutError. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
-        )
-    if isinstance(error, ClientError):
-        return (
-            "cannot_connect",
-            cleanse_sensitive_data(
-                f"ClientError. {type(error).__name__}: {error}",
-                [user_input.get(CONF_USERNAME), user_input.get(CONF_PASSWORD)],
-            ),
         )
     if isinstance(error, OPNsenseInvalidURL):
         return (

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -40,7 +40,11 @@ CONF_DEVICE_TRACKER_CONSIDER_HOME = "device_tracker_consider_home"
 DEFAULT_DEVICE_TRACKER_CONSIDER_HOME = 0
 
 CONF_DEVICE_UNIQUE_ID = "device_unique_id"
+CONF_ENTRY_TYPE = "entry_type"
+ENTRY_TYPE_DEVICE = "device"
+ENTRY_TYPE_CARP = "carp"
 CONF_FIRMWARE_VERSION = "firmware_version"
+CARP_PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 CONF_SYNC_TELEMETRY = "sync_telemetry"
 CONF_SYNC_VNSTAT = "sync_vnstat"

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -32,7 +32,7 @@ from .const import (
     DEFAULT_SYNC_OPTION_VALUE,
     DOMAIN,
 )
-from .helpers import dict_get
+from .helpers import dict_get, get_smart_device_name, is_carp_entry
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -56,7 +56,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         client: OPNsenseClient,
         name: str,
         update_interval: timedelta,
-        device_unique_id: str,
+        device_unique_id: str | None,
         config_entry: ConfigEntry,
         device_tracker_coordinator: bool = False,
     ) -> None:
@@ -84,7 +84,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         self._state: dict[str, Any] = {}
         self._device_tracker_coordinator: bool = device_tracker_coordinator
         self._mismatched_count = 0
-        self._device_unique_id: str = device_unique_id
+        self._device_unique_id: str | None = device_unique_id
         self._updating: bool = False
         super().__init__(
             hass=hass,
@@ -141,12 +141,11 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                         for smart_device in smart_devices:
                             if not isinstance(smart_device, Mapping):
                                 continue
-                            device_name = smart_device.get("device")
-                            if not isinstance(device_name, str) or not device_name.strip():
+                            device_name = get_smart_device_name(smart_device)
+                            if not device_name:
                                 continue
-                            normalized_device_name = device_name.strip()
-                            smart_info[normalized_device_name] = await method(
-                                device=normalized_device_name,
+                            smart_info[device_name] = await method(
+                                device=device_name,
                                 info_type=cat.get("info_type", "A"),
                             )
                     state[cat.get("state_key")] = smart_info
@@ -175,6 +174,12 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         if not self.config_entry:
             _LOGGER.error("Coordinator build_categories failed. No config entry found.")
             return []
+        if is_carp_entry(self.config_entry):
+            return [
+                {"function": "get_system_info", "state_key": "system_info"},
+                {"function": "get_carp", "state_key": "carp"},
+            ]
+
         config: Mapping[str, Any] = self.config_entry.data
         categories: list[dict[str, str]] = [
             {"function": "get_device_unique_id", "state_key": "device_unique_id"},
@@ -254,6 +259,12 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         Returns:
             bool: `True` when IDs match; otherwise `False` after mismatch handling.
         """
+        if (
+            self._device_unique_id is None
+            and self.config_entry
+            and is_carp_entry(self.config_entry)
+        ):
+            return True
         if self._state.get("device_unique_id") is None:
             _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -36,9 +36,30 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseBaseEntity
-from .helpers import detach_shared_router_parent, dict_get
+from .helpers import (
+    detach_shared_router_parent,
+    dict_get,
+    get_arp_ip,
+    get_arp_mac,
+    normalize_arp_mac,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def _normalize_mac_for_device_tracker(mac_address: str) -> str:
+    """Normalize a user-facing or payload MAC with canonical fallback.
+
+    Args:
+        mac_address: A raw MAC-like input.
+
+    Returns:
+        Canonical MAC when possible, otherwise permissive lower-case normalized value.
+    """
+    normalized_mac = normalize_mac_address(mac_address)
+    if normalized_mac is not None:
+        return normalized_mac
+    return normalize_arp_mac(mac_address)
 
 
 def _device_data_from_arp_entry(
@@ -60,24 +81,11 @@ def _device_data_from_arp_entry(
     if hostname is not None:
         device["hostname"] = hostname
 
-    manufacturer = _non_empty_string(arp_entry.get("manufacturer"))
-    if manufacturer is not None:
+    manufacturer = arp_entry.get("manufacturer")
+    if isinstance(manufacturer, str) and manufacturer:
         device["manufacturer"] = manufacturer
 
     return device
-
-
-def _mac_matches(mac_a: object, mac_b: object) -> bool:
-    """Compare MAC addresses case-insensitively and normalize known formats."""
-    if not isinstance(mac_a, str) or not isinstance(mac_b, str):
-        return False
-
-    mac_a_normalized = normalize_mac_address(mac_a)
-    mac_b_normalized = normalize_mac_address(mac_b)
-    if mac_a_normalized is not None and mac_b_normalized is not None:
-        return mac_a_normalized == mac_b_normalized
-
-    return mac_a.lower() == mac_b.lower()
 
 
 def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str, Any]:
@@ -91,10 +99,12 @@ def _device_from_arp_entry(mac_address: str, arp_entries: list[Any]) -> dict[str
         A device dictionary for the matching ARP entry, or a MAC-only fallback.
     """
     device: dict[str, Any] = {"mac": mac_address}
+    normalized_mac = _normalize_mac_for_device_tracker(mac_address)
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
             continue
-        if not _mac_matches(mac_address, arp_entry.get("mac")):
+        arp_mac = get_arp_mac(arp_entry)
+        if not arp_mac or _normalize_mac_for_device_tracker(arp_mac) != normalized_mac:
             continue
         device.update(_device_data_from_arp_entry(mac_address, arp_entry))
         break
@@ -116,29 +126,16 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
             continue
-        mac_address = arp_entry.get("mac")
-        if not isinstance(mac_address, str):
+        mac_address = get_arp_mac(arp_entry)
+        if not mac_address:
             continue
-        normalized_mac = normalize_mac_address(mac_address)
-        mac = normalized_mac or mac_address.lower().strip()
-        if not mac or mac in mac_addresses:
+        normalized_mac = _normalize_mac_for_device_tracker(mac_address)
+        if not normalized_mac or normalized_mac in mac_addresses:
             continue
-        mac_addresses.append(mac)
-        devices.append(_device_data_from_arp_entry(mac, arp_entry))
+        mac_addresses.append(normalized_mac)
+        devices.append(_device_data_from_arp_entry(normalized_mac, arp_entry))
 
     return devices, mac_addresses
-
-
-def _non_empty_string(value: object) -> str | None:
-    """Return a non-empty string value, if available.
-
-    Args:
-        value: Candidate value to inspect.
-
-    Returns:
-        The input string when it is non-empty, otherwise ``None``.
-    """
-    return value if isinstance(value, str) and value else None
 
 
 def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
@@ -215,15 +212,15 @@ def _compile_tracked_devices(
     if not config_entry.options.get(CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED):
         return [], [], False
 
-    configured_mac_addresses = []
+    configured_mac_addresses: list[str] = []
     for mac_address in config_entry.options.get(CONF_DEVICES, []):
         if not isinstance(mac_address, str):
             continue
-        normalized_mac = normalize_mac_address(mac_address)
-        normalized_mac = normalized_mac or mac_address.lower().strip()
+        normalized_mac = _normalize_mac_for_device_tracker(mac_address)
         if not normalized_mac or normalized_mac in configured_mac_addresses:
             continue
         configured_mac_addresses.append(normalized_mac)
+
     if configured_mac_addresses:
         _LOGGER.debug(
             "[device_tracker async_setup_entry] configured_mac_addresses: %s",
@@ -375,7 +372,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         config_entry: ConfigEntry,
         coordinator: OPNsenseDataUpdateCoordinator,
         enabled_default: bool,
-        mac: str | None,
+        mac: str,
         mac_vendor: str | None,
         hostname: str | None,
     ) -> None:
@@ -385,7 +382,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             config_entry: Config entry owning the entity.
             coordinator: Shared OPNsense data coordinator.
             enabled_default: Whether the entity is enabled by default.
-            mac: MAC address tracked by the entity, or ``None`` when unavailable.
+            mac: MAC address tracked by the entity.
             mac_vendor: Vendor name reported for the MAC address.
             hostname: Hostname reported by OPNsense.
         """
@@ -433,7 +430,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
 
     @property
     def unique_id(self) -> str | None:
-        """Return the unique id.
+        """Return a stable object-id hint when linking to an existing device.
 
         Returns:
             The Home Assistant entity unique ID.
@@ -483,12 +480,17 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         for arp_entry in arp_table:
             if not isinstance(arp_entry, MutableMapping):
                 continue
-            if _mac_matches(self._attr_mac_address, arp_entry.get("mac")):
+            arp_mac = get_arp_mac(arp_entry)
+            if (
+                isinstance(self._attr_mac_address, str)
+                and self._attr_mac_address.lower() == arp_mac
+            ):
                 entry = arp_entry
                 break
         if not entry:
             entry = {}
-        self._attr_ip_address = _non_empty_string(entry.get("ip"))
+        ip_address = get_arp_ip(entry)
+        self._attr_ip_address = ip_address if isinstance(ip_address, str) and ip_address else None
 
         if self._attr_ip_address:
             self._last_known_ip = self._attr_ip_address

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -9,9 +9,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
-from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN, OPNSENSE_CLIENT
+from .const import DOMAIN, OPNSENSE_CLIENT
 from .coordinator import OPNsenseDataUpdateCoordinator
-from .helpers import dict_get
+from .helpers import config_entry_identity, dict_get
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -85,7 +85,9 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         """
         self.config_entry: ConfigEntry = config_entry
         self.coordinator: OPNsenseDataUpdateCoordinator = coordinator
-        self._device_unique_id: str = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+        # Keep the existing attribute name for compatibility; this is now the
+        # identity prefix for both device and CARP config entry modes.
+        self._device_unique_id: str = config_entry_identity(config_entry)
         if unique_id_suffix:
             self._attr_unique_id: str = slugify(f"{self._device_unique_id}_{unique_id_suffix}")
         if name_suffix:

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -15,11 +15,27 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 from homeassistant.util import slugify
 
-from .const import CONF_DEVICE_UNIQUE_ID, DEFAULT_VERIFY_SSL, DOMAIN
+from .const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_ENTRY_TYPE,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    ENTRY_TYPE_CARP,
+    ENTRY_TYPE_DEVICE,
+)
 
 
 def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = None) -> Any | None:
-    """Parse the path to get the desired value out of the data."""
+    """Parse a dotted path to get a value from nested mapping or list data.
+
+    Args:
+        data: Mutable mapping containing the value to retrieve.
+        path: Case-insensitive dotted path, including numeric list indexes.
+        default: Value returned when any path segment is unavailable.
+
+    Returns:
+        Any | None: Value found at the path, or ``default`` when absent.
+    """
     path_list: list = re.split(r"\.", path, flags=re.IGNORECASE)
     result: Any | None = data
 
@@ -35,16 +51,46 @@ def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = No
     return result
 
 
+def normalize_arp_mac(mac: object) -> str:
+    """Normalize a MAC address from an ARP payload."""
+
+    if not isinstance(mac, str):
+        return ""
+    return mac.strip().lower().replace("-", ":")
+
+
+def get_arp_mac(entry: Mapping[str, Any]) -> str:
+    """Return a normalized MAC address from an ARP payload."""
+
+    mac: object = entry.get("mac")
+    if not isinstance(mac, str):
+        mac = entry.get("mac-address")
+    return normalize_arp_mac(mac)
+
+
+def get_arp_ip(entry: Mapping[str, Any]) -> str:
+    """Return an IP address from an ARP payload."""
+
+    ip: object = entry.get("ip")
+    if not isinstance(ip, str):
+        ip = entry.get("ip-address")
+    return ip.strip() if isinstance(ip, str) else ""
+
+
+def get_smart_device_name(smart_device: Mapping[str, Any]) -> str:
+    """Return a SMART device identifier, preferring ``device`` over ``ident``."""
+
+    device_name = smart_device.get("device")
+    if not isinstance(device_name, str) or not device_name.strip():
+        device_name = smart_device.get("ident")
+    if not isinstance(device_name, str):
+        return ""
+    return device_name.strip()
+
+
 def firewall_rule_id_from_payload(rule_key: object, rule: object) -> str | None:
-    """Get a firewall rule ID from an aiopnsense rule payload.
+    """Get a firewall rule ID from an aiopnsense rule payload."""
 
-    Args:
-        rule_key: Mapping key for the rule in the firewall rules payload.
-        rule: Firewall rule payload.
-
-    Returns:
-        str | None: The rule UUID, falling back to the mapping key when usable.
-    """
     if not isinstance(rule, Mapping):
         return None
 
@@ -110,7 +156,14 @@ def firewall_nat_switch_unique_ids_from_payload(
 
 
 def is_private_ip(url: str) -> bool:
-    """Check if the address in the given URL is a private IP address."""
+    """Check whether the host address in a URL is private.
+
+    Args:
+        url: URL whose hostname should be inspected.
+
+    Returns:
+        bool: ``True`` when the URL hostname is a private IP address.
+    """
     parsed_url = urlparse(url)
     addr = parsed_url.hostname
     if not addr:
@@ -287,6 +340,52 @@ def detach_shared_router_parent(
         remove_config_entry_id=shared_config_entry_id,
     )
     return is_device_from_router, None
+
+
+def is_carp_entry(config_entry: ConfigEntry) -> bool:
+    """Return whether a config entry represents a CARP virtual endpoint.
+
+    Args:
+        config_entry: Config entry to classify.
+
+    Returns:
+        bool: ``True`` when the entry type is CARP.
+    """
+    return config_entry.data.get(CONF_ENTRY_TYPE, ENTRY_TYPE_DEVICE) == ENTRY_TYPE_CARP
+
+
+def config_entry_identity(config_entry: ConfigEntry) -> str:
+    """Return the stable Home Assistant identity prefix for a config entry.
+
+    Args:
+        config_entry: Config entry whose device or entry identity is needed.
+
+    Returns:
+        str: Device unique ID for normal entries, otherwise the entry ID.
+    """
+    device_id = config_entry.data.get(CONF_DEVICE_UNIQUE_ID)
+    return device_id if isinstance(device_id, str) and device_id else config_entry.entry_id
+
+
+def is_usable_carp_vip(value: object) -> bool:
+    """Return whether a CARP row has a usable VHID and subnet identity.
+
+    Args:
+        value: Raw CARP VIP row returned by the OPNsense API.
+
+    Returns:
+        bool: ``True`` when normalized VHID and subnet values are non-empty.
+    """
+    if not isinstance(value, Mapping):
+        return False
+
+    vhid = value.get("vhid")
+    if isinstance(vhid, bool) or not isinstance(vhid, (int, str)):
+        return False
+    normalized_vhid = str(vhid).strip()
+    subnet = value.get("subnet")
+    normalized_subnet = subnet.strip() if isinstance(subnet, str) else ""
+    return bool(normalized_vhid and normalized_subnet)
 
 
 def coerce_bool(value: Any) -> bool | None:

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -53,7 +53,6 @@ def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = No
 
 def normalize_arp_mac(mac: object) -> str:
     """Normalize a MAC address from an ARP payload."""
-
     if not isinstance(mac, str):
         return ""
     return mac.strip().lower().replace("-", ":")
@@ -61,7 +60,6 @@ def normalize_arp_mac(mac: object) -> str:
 
 def get_arp_mac(entry: Mapping[str, Any]) -> str:
     """Return a normalized MAC address from an ARP payload."""
-
     mac: object = entry.get("mac")
     if not isinstance(mac, str):
         mac = entry.get("mac-address")
@@ -70,7 +68,6 @@ def get_arp_mac(entry: Mapping[str, Any]) -> str:
 
 def get_arp_ip(entry: Mapping[str, Any]) -> str:
     """Return an IP address from an ARP payload."""
-
     ip: object = entry.get("ip")
     if not isinstance(ip, str):
         ip = entry.get("ip-address")
@@ -79,7 +76,6 @@ def get_arp_ip(entry: Mapping[str, Any]) -> str:
 
 def get_smart_device_name(smart_device: Mapping[str, Any]) -> str:
     """Return a SMART device identifier, preferring ``device`` over ``ident``."""
-
     device_name = smart_device.get("device")
     if not isinstance(device_name, str) or not device_name.strip():
         device_name = smart_device.get("ident")
@@ -90,7 +86,6 @@ def get_smart_device_name(smart_device: Mapping[str, Any]) -> str:
 
 def firewall_rule_id_from_payload(rule_key: object, rule: object) -> str | None:
     """Get a firewall rule ID from an aiopnsense rule payload."""
-
     if not isinstance(rule, Mapping):
         return None
 

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -30,7 +30,8 @@ def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = No
 
     Args:
         data: Mutable mapping containing the value to retrieve.
-        path: Case-insensitive dotted path, including numeric list indexes.
+        path: Dotted path through nested mappings and lists. Numeric segments are
+            converted to integer indexes or keys.
         default: Value returned when any path segment is unavailable.
 
     Returns:
@@ -61,7 +62,7 @@ def normalize_arp_mac(mac: object) -> str:
 def get_arp_mac(entry: Mapping[str, Any]) -> str:
     """Return a normalized MAC address from an ARP payload."""
     mac: object = entry.get("mac")
-    if not isinstance(mac, str):
+    if not isinstance(mac, str) or not mac.strip():
         mac = entry.get("mac-address")
     return normalize_arp_mac(mac)
 
@@ -69,7 +70,7 @@ def get_arp_mac(entry: Mapping[str, Any]) -> str:
 def get_arp_ip(entry: Mapping[str, Any]) -> str:
     """Return an IP address from an ARP payload."""
     ip: object = entry.get("ip")
-    if not isinstance(ip, str):
+    if not isinstance(ip, str) or not ip.strip():
         ip = entry.get("ip-address")
     return ip.strip() if isinstance(ip, str) else ""
 
@@ -363,13 +364,14 @@ def config_entry_identity(config_entry: ConfigEntry) -> str:
 
 
 def is_usable_carp_vip(value: object) -> bool:
-    """Return whether a CARP row has a usable VHID and subnet identity.
+    """Return whether a CARP row has a valid VHID and usable subnet identity.
 
     Args:
         value: Raw CARP VIP row returned by the OPNsense API.
 
     Returns:
-        bool: ``True`` when normalized VHID and subnet values are non-empty.
+        bool: ``True`` when the VHID is numeric and within the CARP range 1 through
+            255, and the normalized subnet is non-empty.
     """
     if not isinstance(value, Mapping):
         return False
@@ -380,7 +382,9 @@ def is_usable_carp_vip(value: object) -> bool:
     normalized_vhid = str(vhid).strip()
     subnet = value.get("subnet")
     normalized_subnet = subnet.strip() if isinstance(subnet, str) else ""
-    return bool(normalized_vhid and normalized_subnet)
+    return bool(
+        normalized_vhid.isdecimal() and 1 <= int(normalized_vhid) <= 255 and normalized_subnet
+    )
 
 
 def coerce_bool(value: Any) -> bool | None:

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -41,9 +41,17 @@ def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = No
     result: Any | None = data
 
     for key in path_list:
+        if isinstance(result, list):
+            if not key.isdecimal():
+                return default
+            index = int(key)
+            if index >= len(result):
+                return default
+            result = result[index]
+            continue
         if key.isnumeric():
             key = int(key)
-        if isinstance(result, MutableMapping | list) and key in result:
+        if isinstance(result, MutableMapping) and key in result:
             result = result[key]
         else:
             result = default

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -359,8 +359,13 @@ def config_entry_identity(config_entry: ConfigEntry) -> str:
     Returns:
         str: Device unique ID for normal entries, otherwise the entry ID.
     """
+    if is_carp_entry(config_entry):
+        return config_entry.entry_id
+
     device_id = config_entry.data.get(CONF_DEVICE_UNIQUE_ID)
-    return device_id if isinstance(device_id, str) and device_id else config_entry.entry_id
+    if isinstance(device_id, str) and (device_id := device_id.strip()):
+        return device_id
+    return config_entry.entry_id
 
 
 def is_usable_carp_vip(value: object) -> bool:

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable, Mapping, MutableMapping
 import inspect
+import ipaddress
 import logging
 import re
 from typing import Any, Final
@@ -45,7 +46,7 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
-from .helpers import coerce_bool, dict_get
+from .helpers import coerce_bool, dict_get, get_smart_device_name, is_carp_entry
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -75,6 +76,11 @@ _VPN_TRAFFIC_PROPERTIES: tuple[str, ...] = (
 _VPN_SERVER_PROPERTIES: tuple[str, ...] = ("status", "connected_clients")
 _VPN_WIREGUARD_CLIENT_PROPERTIES: tuple[str, ...] = ("connected_servers",)
 _ICON_MEMORY: Final[str] = "mdi:memory"
+_CARP_STATUS_ICONS: Final[Mapping[str, str]] = {
+    "MASTER": "mdi:check-network",
+    "BACKUP": "mdi:backup-restore",
+}
+
 
 STATIC_TELEMETRY_SENSORS: Final[tuple[SensorEntityDescription, ...]] = (
     # pfstate
@@ -305,6 +311,7 @@ def _create_sensor[SensorT: OPNsenseSensor](
         coordinator: Coordinator providing the OPNsense data for the entity.
         entity_description: Metadata describing the sensor entity.
 
+
     Returns:
         SensorT: Instantiated sensor entity.
     """
@@ -331,6 +338,7 @@ def _create_sensors[SensorT: OPNsenseSensor](
 
     Returns:
         list[SensorT]: Instantiated sensor entities in description order.
+
     """
     return [
         _create_sensor(entity_cls, config_entry, coordinator, entity_description)
@@ -444,6 +452,7 @@ def _build_vnstat_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the vnStat sensor entity.
+
     """
     return SensorEntityDescription(
         key=f"vnstat.{interface_name}.{metric_name}",
@@ -474,6 +483,7 @@ def _build_speedtest_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the speedtest sensor entity.
+
     """
     return SensorEntityDescription(
         key=key,
@@ -494,9 +504,10 @@ def _build_smart_sensor_description(device_name: str) -> SensorEntityDescription
 
     Returns:
         SensorEntityDescription: Description for the SMART temperature sensor.
+
     """
     return SensorEntityDescription(
-        key=f"smart.{_smart_device_slug(device_name)}.temperature",
+        key=f"smart.{slugify(device_name) or 'unknown'}.temperature",
         name=f"SMART {device_name} Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -516,6 +527,7 @@ def _build_filesystem_sensor_description(filesystem: Mapping[str, Any]) -> Senso
 
     Returns:
         SensorEntityDescription: Description for the filesystem usage sensor.
+
     """
     mountpoint = filesystem["mountpoint"]
     filesystem_slug = slugify_filesystem_mountpoint(mountpoint)
@@ -545,6 +557,7 @@ def _build_interface_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the interface sensor.
+
     """
     state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
     native_unit_of_measurement = None
@@ -613,6 +626,7 @@ def _build_gateway_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the gateway sensor.
+
     """
     native_unit_of_measurement = None
     device_class: SensorDeviceClass | None = None
@@ -655,6 +669,7 @@ def _build_temperature_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the temperature sensor.
+
     """
     return SensorEntityDescription(
         key=f"telemetry.temps.{temp_device}",
@@ -681,6 +696,7 @@ def _build_dhcp_leases_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the interface lease sensor.
+
     """
     return SensorEntityDescription(
         key=f"dhcp_leases.{interface}",
@@ -698,6 +714,7 @@ def _build_dhcp_leases_total_sensor_description() -> SensorEntityDescription:
 
     Returns:
         SensorEntityDescription: Description for the aggregate lease sensor.
+
     """
     return SensorEntityDescription(
         key="dhcp_leases.all",
@@ -728,6 +745,7 @@ def _build_vpn_sensor_description(
 
     Returns:
         SensorEntityDescription: Description for the VPN sensor entity.
+
     """
     state_class: SensorStateClass | None = None
     native_unit_of_measurement: UnitOfDataRate | UnitOfInformation | None = None
@@ -788,6 +806,9 @@ async def _compile_static_telemetry_sensors(
     Args:
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
+
+    Returns:
+        list: Compiled static telemetry sensor entities.
     """
     return _create_sensors(
         OPNsenseStaticKeySensor,
@@ -806,6 +827,9 @@ async def _compile_static_certificate_sensors(
     Args:
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
+
+    Returns:
+        list: Compiled static certificate sensor entities.
     """
     return _create_sensors(
         OPNsenseStaticKeySensor,
@@ -820,7 +844,16 @@ async def _compile_vnstat_sensors(
     coordinator: OPNsenseDataUpdateCoordinator,
     state: MutableMapping[str, Any],
 ) -> list:
-    """Compile per-interface vnStat sensors."""
+    """Compile per-interface vnStat sensors.
+
+    Args:
+        config_entry: Config entry owning the sensors.
+        coordinator: Data update coordinator supplying state.
+        state: Coordinator state snapshot containing vnStat interfaces.
+
+    Returns:
+        list: Compiled vnStat sensor entities.
+    """
     if not isinstance(state, MutableMapping):
         return []
     vnstat_interfaces = dict_get(state, "vnstat.interfaces", {}) or {}
@@ -878,7 +911,16 @@ async def _compile_speedtest_sensors(
     coordinator: OPNsenseDataUpdateCoordinator,
     state: MutableMapping[str, Any],
 ) -> list:
-    """Compile speedtest sensors from normalized coordinator state."""
+    """Compile speedtest sensors from normalized coordinator state.
+
+    Args:
+        config_entry: Config entry owning the sensors.
+        coordinator: Data update coordinator supplying state.
+        state: Coordinator state snapshot containing speedtest instances.
+
+    Returns:
+        list: Compiled speedtest sensor entities.
+    """
     if not isinstance(state, MutableMapping):
         return []
     speedtest = state.get("speedtest")
@@ -934,19 +976,6 @@ async def _compile_speedtest_sensors(
     )
 
 
-def _smart_device_slug(device_name: str) -> str:
-    """Return the entity key slug for a SMART device name.
-
-    Args:
-        device_name: SMART device name, such as ``nvme0`` or ``ada0``.
-
-    Returns:
-        str: Slug suitable for a SMART sensor entity description key.
-    """
-    device_slug = slugify(device_name)
-    return device_slug or "unknown"
-
-
 async def _compile_smart_sensors(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -973,11 +1002,9 @@ async def _compile_smart_sensors(
     for smart_device in smart_devices:
         if not isinstance(smart_device, Mapping):
             continue
-        device_name = smart_device.get("device")
-        if not isinstance(device_name, str) or not device_name.strip():
+        device_name = get_smart_device_name(smart_device)
+        if not device_name:
             continue
-        device_name = device_name.strip()
-
         entities.append(
             _create_sensor(
                 OPNsenseSmartSensor,
@@ -1000,6 +1027,9 @@ async def _compile_filesystem_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains filesystem telemetry data.
+
+    Returns:
+        list: Compiled filesystem sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1031,6 +1061,9 @@ async def _compile_carp_interface_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains CARP interface status data.
+
+    Returns:
+        list: Compiled CARP interface sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1119,6 +1152,127 @@ def _parse_carp_interface_sensor_key(key: str) -> tuple[str, str] | None:
     return (interface_slug, subnet_slug)
 
 
+def _normalize_carp_value(value: Any) -> str:
+    """Normalize a CARP identifier or subnet value for matching.
+
+    Args:
+        value: Raw CARP value, which may be a number or string.
+
+    Returns:
+        str: Trimmed value, or an empty string when it cannot be normalized.
+    """
+    if value is None:
+        return ""
+    try:
+        return str(value).strip()
+    except AttributeError, RuntimeError, TypeError, ValueError:
+        return ""
+
+
+def _normalize_carp_vip_subnet(subnet: str) -> str:
+    """Return a stable CARP subnet identity for entity matching and key generation.
+
+    Args:
+        subnet: CARP subnet or address value to normalize.
+
+    Returns:
+        str: Slugified IP identity, or the normalized raw subnet when parsing fails.
+    """
+    raw_subnet = subnet.strip()
+    if not raw_subnet:
+        return ""
+    try:
+        return slugify(str(ipaddress.ip_interface(raw_subnet).ip))
+    except ValueError, TypeError:
+        return slugify(raw_subnet)
+
+
+def _build_carp_vip_sensor_key(vhid: str, subnet: str) -> str:
+    """Build a node-independent CARP VIP key from synchronized values.
+
+    Args:
+        vhid: CARP virtual host ID.
+        subnet: CARP virtual IP or subnet value.
+
+    Returns:
+        str: Stable CARP VIP sensor key.
+    """
+    return f"carp.vip.{slugify(vhid.strip())}.{_normalize_carp_vip_subnet(subnet)}"
+
+
+def _parse_carp_vip_sensor_key(key: str) -> tuple[str, str] | None:
+    """Parse a CARP VIP key into its VHID and subnet slugs.
+
+    Args:
+        key: Sensor description key to parse.
+
+    Returns:
+        tuple[str, str] | None: VHID and subnet slugs when the key is valid.
+    """
+    key_parts = key.split(".")
+    if len(key_parts) != 4 or key_parts[:2] != ["carp", "vip"]:
+        return None
+    vhid_slug, subnet_slug = (part.strip() for part in key_parts[2:])
+    if not vhid_slug or not subnet_slug:
+        return None
+    return vhid_slug, subnet_slug
+
+
+async def _compile_carp_vip_sensors(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+) -> list:
+    """Compile stable, read-only CARP VIP sensors.
+
+    Args:
+        config_entry: CARP config entry being exercised by the helper or test.
+        coordinator: Data update coordinator that caches CARP state.
+        state: Coordinator state snapshot that contains CARP interface rows.
+
+    Returns:
+        list: CARP VIP sensors disabled by default.
+    """
+    if not isinstance(state, MutableMapping):
+        return []
+    carp_interfaces = dict_get(state, "carp.interfaces", []) or []
+    if not isinstance(carp_interfaces, list):
+        return []
+
+    entities: list[OPNsenseCarpVipSensor] = []
+    seen_keys: set[str] = set()
+    for interface in carp_interfaces:
+        if not isinstance(interface, Mapping):
+            continue
+        vhid = _normalize_carp_value(interface.get("vhid"))
+        subnet = _normalize_carp_value(interface.get("subnet"))
+        if not vhid or not subnet:
+            continue
+        key = _build_carp_vip_sensor_key(vhid, subnet)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        entities.append(
+            _create_sensor(
+                OPNsenseCarpVipSensor,
+                config_entry,
+                coordinator,
+                SensorEntityDescription(
+                    key=key,
+                    name=f"CARP VIP {subnet} (VHID {vhid})",
+                    translation_key="carp_vip",
+                    translation_placeholders={"subnet": subnet, "vhid": vhid},
+                    native_unit_of_measurement=None,
+                    device_class=None,
+                    icon="mdi:ip-network",
+                    state_class=None,
+                    entity_registry_enabled_default=False,
+                ),
+            )
+        )
+    return entities
+
+
 async def _compile_carp_status_sensor(
     config_entry: ConfigEntry,
     coordinator: OPNsenseDataUpdateCoordinator,
@@ -1130,6 +1284,9 @@ async def _compile_carp_status_sensor(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains CARP summary status data.
+
+    Returns:
+        list: Compiled aggregate CARP status sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1141,6 +1298,7 @@ async def _compile_carp_status_sensor(
             SensorEntityDescription(
                 key="carp.status_summary",
                 name="CARP Status",
+                translation_key="carp_status_summary",
                 native_unit_of_measurement=None,
                 device_class=None,
                 icon="mdi:gauge",
@@ -1162,6 +1320,9 @@ async def _compile_interface_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains network interface statistics.
+
+    Returns:
+        list: Compiled interface sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1198,6 +1359,9 @@ async def _compile_gateway_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains gateway latency, loss, and status data.
+
+    Returns:
+        list: Compiled gateway sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1237,6 +1401,9 @@ async def _compile_temperature_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains hardware temperature telemetry.
+
+    Returns:
+        list: Compiled temperature sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1271,6 +1438,9 @@ async def _compile_dhcp_leases_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains DHCP lease counts per interface.
+
+    Returns:
+        list: Compiled DHCP lease sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1318,6 +1488,9 @@ async def _compile_vpn_sensors(
         config_entry: Config entry being exercised by the helper or test.
         coordinator: Data update coordinator that caches OPNsense state for entities.
         state: Coordinator state snapshot that contains OpenVPN and WireGuard metrics.
+
+    Returns:
+        list: Compiled VPN sensor entities.
     """
     if not isinstance(state, MutableMapping):
         return []
@@ -1367,15 +1540,40 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the OPNsense sensors."""
+    """Set up the OPNsense sensors.
+
+    Args:
+        hass: Home Assistant instance receiving the entities.
+        config_entry: Config entry whose sensors are being set up.
+        async_add_entities: Callback used to register compiled entities.
+    """
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
     state: dict[str, Any] = coordinator.data
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in sensor async_setup_entry")
         return
     config: Mapping[str, Any] = config_entry.data
-
     entities: list = []
+
+    if is_carp_entry(config_entry):
+        entities = [
+            _create_sensor(
+                OPNsenseCarpActiveResponderSensor,
+                config_entry,
+                coordinator,
+                SensorEntityDescription(
+                    key="carp.active_responder",
+                    name="Active CARP Responder",
+                    translation_key="carp_active_responder",
+                    icon="mdi:server-network",
+                    entity_registry_enabled_default=True,
+                ),
+            )
+        ]
+        entities.extend(await _compile_carp_status_sensor(config_entry, coordinator, state))
+        entities.extend(await _compile_carp_vip_sensors(config_entry, coordinator, state))
+        async_add_entities(entities)
+        return
 
     if config.get(CONF_SYNC_TELEMETRY, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_telemetry_sensors(config_entry, coordinator))
@@ -1406,7 +1604,14 @@ async def async_setup_entry(
 
 
 def slugify_filesystem_mountpoint(mountpoint: str) -> str:
-    """Slugify the mountpoint."""
+    """Slugify a filesystem mountpoint for use in an entity key.
+
+    Args:
+        mountpoint: Filesystem mountpoint to normalize.
+
+    Returns:
+        str: Stable mountpoint slug.
+    """
     if not mountpoint:
         return ""
     if mountpoint == "/":
@@ -1415,7 +1620,14 @@ def slugify_filesystem_mountpoint(mountpoint: str) -> str:
 
 
 def normalize_filesystem_mountpoint(mountpoint: str) -> str:
-    """Normalize the mountpoint."""
+    """Normalize a filesystem mountpoint for display.
+
+    Args:
+        mountpoint: Filesystem mountpoint to normalize.
+
+    Returns:
+        str: Display-friendly mountpoint.
+    """
     if not mountpoint:
         return ""
     if mountpoint == "/":
@@ -1433,9 +1645,18 @@ class OPNsenseSensor(OPNsenseEntity, SensorEntity):
         entity_description: SensorEntityDescription,
         unique_id_suffix: str | None = None,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the sensor.
+
+        Args:
+            config_entry: Config entry owning the sensor.
+            coordinator: Data update coordinator supplying sensor state.
+            entity_description: Description of the sensor entity.
+        """
         name_suffix: str | None = (
-            entity_description.name if isinstance(entity_description.name, str) else None
+            entity_description.name
+            if isinstance(entity_description.name, str)
+            and entity_description.translation_key is None
+            else None
         )
         if unique_id_suffix is None:
             unique_id_suffix = (
@@ -1615,10 +1836,10 @@ class OPNsenseSmartSensor(OPNsenseSensor):
         for candidate in smart_devices:
             if not isinstance(candidate, Mapping):
                 continue
-            device_name = candidate.get("device")
-            if not isinstance(device_name, str) or not device_name.strip():
+            device_name = get_smart_device_name(candidate)
+            if not device_name:
                 continue
-            if _smart_device_slug(device_name.strip()) == expected_device_slug:
+            if (slugify(device_name.strip()) or "unknown") == expected_device_slug:
                 smart_device = candidate
                 break
 
@@ -1626,12 +1847,9 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             self._mark_unavailable()
             return
 
-        device_name = smart_device.get("device")
+        device_name = get_smart_device_name(smart_device)
         smart_info = state.get("smart_info")
-        normalized_device_name = device_name.strip() if isinstance(device_name, str) else ""
-        device_info = (
-            smart_info.get(normalized_device_name) if isinstance(smart_info, Mapping) else None
-        )
+        device_info = smart_info.get(device_name) if isinstance(smart_info, Mapping) else None
         if not isinstance(device_info, Mapping):
             self._mark_unavailable()
             return
@@ -1769,7 +1987,11 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the sensor."""
+        """Return the icon for the sensor.
+
+        Returns:
+            str | None: Icon identifier, or the inherited icon.
+        """
         key_parts = self.entity_description.key.rsplit(".", 1)
         if len(key_parts) != 2:
             return super().icon
@@ -1777,6 +1999,28 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
         if prop_name == "status" and self.native_value != "up":
             return "mdi:close-network-outline"
         return super().icon
+
+
+class OPNsenseCarpActiveResponderSensor(OPNsenseSensor):
+    """Class for the active OPNsense node observed by a CARP endpoint."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator updates for the active CARP responder."""
+        system_info = self._mapping_at("system_info")
+        if system_info is None:
+            self._mark_unavailable(clear_attributes=True)
+            return
+
+        responder_name = system_info.get("name")
+        if not isinstance(responder_name, str) or not responder_name.strip():
+            self._mark_unavailable(clear_attributes=True)
+            return
+
+        self._available = True
+        self._attr_native_value = responder_name.strip()
+        self._attr_extra_state_attributes = {}
+        self.async_write_ha_state()
 
 
 class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
@@ -1846,15 +2090,14 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the sensor."""
-        if not self.native_value or not isinstance(self.native_value, str):
+        """Return the icon for the sensor.
+
+        Returns:
+            str | None: Icon identifier, or the inherited icon.
+        """
+        if not isinstance(self.native_value, str):
             return "mdi:close-network-outline"
-        status = self.native_value.upper()
-        if status == "MASTER":
-            return "mdi:check-network"
-        if status == "BACKUP":
-            return "mdi:backup-restore"
-        return "mdi:close-network-outline"
+        return _CARP_STATUS_ICONS.get(self.native_value.upper(), "mdi:close-network-outline")
 
 
 class OPNsenseCarpStatusSensor(OPNsenseSensor):
@@ -1896,7 +2139,11 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the sensor."""
+        """Return the icon for the sensor.
+
+        Returns:
+            str | None: Icon identifier, or the inherited icon.
+        """
         state_value = str(self.native_value).lower().strip().replace(" ", "_")
         if state_value == "healthy":
             return "mdi:check-network"
@@ -1905,6 +2152,73 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
         if state_value in {"degraded", "disabled"}:
             return "mdi:close-network-outline"
         return super().icon
+
+
+class OPNsenseCarpVipSensor(OPNsenseSensor):
+    """Class for an individual read-only CARP virtual IP sensor."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator updates for a CARP virtual IP."""
+        key_data = _parse_carp_vip_sensor_key(self.entity_description.key)
+        carp_interfaces = self._list_at("carp.interfaces")
+        if key_data is None or carp_interfaces is None:
+            self._mark_unavailable()
+            return
+
+        expected_vhid_slug, expected_subnet_slug = key_data
+        carp_vip: dict[str, Any] = {}
+        for interface in carp_interfaces:
+            if not isinstance(interface, Mapping):
+                continue
+            vhid = _normalize_carp_value(interface.get("vhid"))
+            subnet = _normalize_carp_value(interface.get("subnet"))
+            if not vhid or not subnet:
+                continue
+            if (
+                slugify(vhid) != expected_vhid_slug
+                or _normalize_carp_vip_subnet(subnet) != expected_subnet_slug
+            ):
+                continue
+            carp_vip = dict(interface)
+            break
+
+        if not carp_vip:
+            self._mark_unavailable()
+            return
+
+        status = carp_vip.get("status")
+        if status is None:
+            self._mark_unavailable()
+            return
+
+        self._available = True
+        self._attr_native_value = status
+        self._attr_extra_state_attributes = {}
+        for attr in (
+            "interface",
+            "vhid",
+            "advskew",
+            "advbase",
+            "subnet_bits",
+            "subnet",
+            "descr",
+            "mode",
+        ):
+            if attr in carp_vip:
+                self._attr_extra_state_attributes[attr] = carp_vip[attr]
+        self.async_write_ha_state()
+
+    @property
+    def icon(self) -> str | None:
+        """Return an icon based on the current CARP VIP status.
+
+        Returns:
+            str | None: Icon identifier for the current CARP VIP status.
+        """
+        if not isinstance(self.native_value, str):
+            return "mdi:close-network-outline"
+        return _CARP_STATUS_ICONS.get(self.native_value.upper(), "mdi:close-network-outline")
 
 
 class OPNsenseGatewaySensor(OPNsenseSensor):
@@ -1919,6 +2233,7 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
         Returns:
             dict[str, Any]: Matching gateway payload, or an empty dictionary when
                 no matching gateway is available.
+
         """
         gateways = self._mapping_at("gateways")
         if gateways is None:
@@ -1974,7 +2289,11 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the sensor."""
+        """Return the icon for the sensor.
+
+        Returns:
+            str | None: Icon identifier, or the inherited icon.
+        """
         key_parts = self.entity_description.key.rsplit(".", 1)
         if len(key_parts) != 2:
             return super().icon
@@ -2116,7 +2435,11 @@ class OPNsenseVPNSensor(OPNsenseSensor):
 
     @property
     def icon(self) -> str | None:
-        """Return the icon for the sensor."""
+        """Return the icon for the sensor.
+
+        Returns:
+            str | None: Icon identifier, or the inherited icon.
+        """
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 4:
             return super().icon
@@ -2174,6 +2497,7 @@ def _count_active_dhcp_leases(leases: Iterable[Any]) -> int | None:
     Returns:
         int | None: Number of rows with a non-empty ``address``, or ``None`` when
             any row is not a mutable mapping.
+
     """
     lease_count = 0
     for lease in leases:

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1298,7 +1298,7 @@ async def _compile_carp_status_sensor(
             SensorEntityDescription(
                 key="carp.status_summary",
                 name="CARP Status",
-                translation_key="carp_status_summary",
+                translation_key=("carp_status_summary" if is_carp_entry(config_entry) else None),
                 native_unit_of_measurement=None,
                 device_class=None,
                 icon="mdi:gauge",
@@ -2164,7 +2164,7 @@ class OPNsenseCarpVipSensor(OPNsenseSensor):
         key_data = _parse_carp_vip_sensor_key(self.entity_description.key)
         carp_interfaces = self._list_at("carp.interfaces")
         if key_data is None or carp_interfaces is None:
-            self._mark_unavailable()
+            self._mark_unavailable(clear_attributes=True)
             return
 
         expected_vhid_slug, expected_subnet_slug = key_data
@@ -2185,12 +2185,12 @@ class OPNsenseCarpVipSensor(OPNsenseSensor):
             break
 
         if not carp_vip:
-            self._mark_unavailable()
+            self._mark_unavailable(clear_attributes=True)
             return
 
         status = carp_vip.get("status")
         if status is None:
-            self._mark_unavailable()
+            self._mark_unavailable(clear_attributes=True)
             return
 
         self._available = True

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -620,8 +620,8 @@ def _build_gateway_sensor_description(
     """Build a gateway sensor description.
 
     Args:
-        gateway_key: OPNsense gateway key used in the entity key.
-        gateway_name: User-facing gateway name used in the entity name.
+        gateway_key: Stable gateway identifier used in the entity key.
+        gateway_name: Human-readable gateway name used in the entity label.
         prop_name: Gateway property represented by the sensor.
 
     Returns:
@@ -1651,6 +1651,7 @@ class OPNsenseSensor(OPNsenseEntity, SensorEntity):
             config_entry: Config entry owning the sensor.
             coordinator: Data update coordinator supplying sensor state.
             entity_description: Description of the sensor entity.
+            unique_id_suffix: Optional stable suffix for the entity unique ID.
         """
         name_suffix: str | None = (
             entity_description.name

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -76,6 +76,16 @@ _VPN_TRAFFIC_PROPERTIES: tuple[str, ...] = (
 _VPN_SERVER_PROPERTIES: tuple[str, ...] = ("status", "connected_clients")
 _VPN_WIREGUARD_CLIENT_PROPERTIES: tuple[str, ...] = ("connected_servers",)
 _ICON_MEMORY: Final[str] = "mdi:memory"
+_CARP_INTERFACE_ATTRIBUTES: Final[tuple[str, ...]] = (
+    "interface",
+    "vhid",
+    "advskew",
+    "advbase",
+    "subnet_bits",
+    "subnet",
+    "descr",
+    "mode",
+)
 _CARP_STATUS_ICONS: Final[Mapping[str, str]] = {
     "MASTER": "mdi:check-network",
     "BACKUP": "mdi:backup-restore",
@@ -2075,16 +2085,7 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             return
         self._available = True
         self._attr_extra_state_attributes = {}
-        for attr in (
-            "interface",
-            "vhid",
-            "advskew",
-            "advbase",
-            "subnet_bits",
-            "subnet",
-            "descr",
-            "mode",
-        ):
+        for attr in _CARP_INTERFACE_ATTRIBUTES:
             if attr in carp_interface:
                 self._attr_extra_state_attributes[attr] = carp_interface[attr]
         self.async_write_ha_state()
@@ -2196,16 +2197,7 @@ class OPNsenseCarpVipSensor(OPNsenseSensor):
         self._available = True
         self._attr_native_value = status
         self._attr_extra_state_attributes = {}
-        for attr in (
-            "interface",
-            "vhid",
-            "advskew",
-            "advbase",
-            "subnet_bits",
-            "subnet",
-            "descr",
-            "mode",
-        ):
+        for attr in _CARP_INTERFACE_ATTRIBUTES:
             if attr in carp_vip:
                 self._attr_extra_state_attributes[attr] = carp_vip[attr]
         self.async_write_ha_state()

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -32,6 +32,7 @@ from .const import (
     SERVICE_SYSTEM_REBOOT,
     SERVICE_TOGGLE_ALIAS,
 )
+from .helpers import is_carp_entry
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 _VNSTAT_PERIODS: tuple[str, ...] = ("hourly", "daily", "monthly", "yearly")
@@ -160,7 +161,11 @@ def _register_service(
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
-    """Create the OPNsense HA Services/Actions."""
+    """Create the OPNsense HA Services/Actions.
+
+    Args:
+        hass: Home Assistant instance receiving the service registrations.
+    """
     _register_service(
         hass,
         SERVICE_CLOSE_NOTICE,
@@ -294,6 +299,9 @@ async def _get_clients(
 
     Raises:
         ServiceValidationError: If explicit target selectors do not resolve to configured clients.
+
+    Returns:
+        list[OPNsenseServiceClient]: Clients selected by the request.
     """
     if (
         DOMAIN not in hass.data
@@ -303,9 +311,21 @@ async def _get_clients(
         if opndevice_id or opnentity_id:
             raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
         return []
-    first_entry_id = next(iter(hass.data[DOMAIN]))
-    if len(hass.data[DOMAIN]) == 1 and not opndevice_id and not opnentity_id:
-        return [hass.data[DOMAIN][first_entry_id]]
+
+    service_clients: dict[str, OPNsenseServiceClient] = {}
+    for entry_id, client in hass.data[DOMAIN].items():
+        config_entry = hass.config_entries.async_get_entry(entry_id)
+        if config_entry is None or is_carp_entry(config_entry):
+            continue
+        service_clients[entry_id] = client
+
+    if not service_clients:
+        if opndevice_id or opnentity_id:
+            raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
+        return []
+    first_entry_id = next(iter(service_clients))
+    if len(service_clients) == 1 and not opndevice_id and not opnentity_id:
+        return [service_clients[first_entry_id]]
 
     entry_ids = _resolve_target_entry_ids(hass, opndevice_id, opnentity_id)
 
@@ -313,7 +333,7 @@ async def _get_clients(
         raise _service_validation_error(_TRANSLATION_KEY_NO_TARGET_CLIENTS)
 
     clients: list[OPNsenseServiceClient] = []
-    for entry_id, opnsense_client in hass.data[DOMAIN].items():
+    for entry_id, opnsense_client in service_clients.items():
         if not entry_ids or entry_id in entry_ids:
             clients.append(opnsense_client)
     if (opndevice_id or opnentity_id) and not clients:
@@ -794,6 +814,9 @@ async def _service_generate_vouchers(hass: HomeAssistant, call: ServiceCall) -> 
     Raises:
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
+
+    Returns:
+        ServiceResponse: Generated voucher values grouped under ``vouchers``.
     """
     clients = await _get_target_clients(hass, call)
     voucher_list = await _collect_voucher_results(clients, dict(call.data))
@@ -815,6 +838,9 @@ async def _service_kill_states(hass: HomeAssistant, call: ServiceCall) -> Servic
     Raises:
         ServiceValidationError: If the service call payload is missing a valid target or
         required value.
+
+    Returns:
+        ServiceResponse: Dropped-state results grouped under ``dropped_states``.
     """
     clients = await _get_target_clients(hass, call)
     response_list = await _collect_kill_state_results(clients, call.data["ip_addr"])

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -822,15 +822,7 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             coordinator=coordinator,
             entity_description=entity_description,
         )
-        self._rule_id: str = self._opnsense_get_rule_id()
-
-    def _opnsense_get_rule_id(self) -> str:
-        """Get the rule ID from the entity description.
-
-        Returns:
-            str: The rule ID.
-        """
-        return self.entity_description.key.split(".")[-1]
+        self._rule_id: str = self.entity_description.key.split(".")[-1]
 
     def _opnsense_get_rule(self) -> MutableMapping[str, Any] | None:
         """Get the firewall rule data from the coordinator.
@@ -950,15 +942,7 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             entity_description=entity_description,
         )
         self._rule_id: str = self._opnsense_get_rule_id()
-        self._nat_rule_type: str = self._get_nat_rule_type()
-
-    def _get_nat_rule_type(self) -> str:
-        """Get the NAT rule type from the entity description.
-
-        Returns:
-            str: The NAT rule type.
-        """
-        return self.entity_description.key.split(".")[2]
+        self._nat_rule_type: str = self.entity_description.key.split(".")[2]
 
     def _opnsense_get_rule_id(self) -> str:
         """Get the rule ID from the entity description.
@@ -1122,23 +1106,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             entity_description=entity_description,
         )
         self._service: MutableMapping[str, Any] | None = None
-        self._prop_name: str = self._opnsense_get_property_name()
-
-    def _opnsense_get_property_name(self) -> str:
-        """Get the property name from the entity description.
-
-        Returns:
-            str: The property name.
-        """
-        return self.entity_description.key.split(".")[2]
-
-    def _opnsense_get_service_id(self) -> str:
-        """Get the service ID from the entity description.
-
-        Returns:
-            str: The service ID.
-        """
-        return self.entity_description.key.split(".")[1]
+        self._prop_name: str = self.entity_description.key.split(".")[2]
 
     def _opnsense_get_service(self) -> MutableMapping[str, Any] | None:
         """Get the service data from the coordinator.
@@ -1149,7 +1117,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         state = self._coordinator_mapping()
         if state is None:
             return None
-        service_id: str = self._opnsense_get_service_id()
+        service_id: str = self.entity_description.key.split(".")[1]
         services = state.get("services")
         if not isinstance(services, list):
             return None

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -38,7 +38,10 @@
           "verify_ssl": "Verify SSL certificate",
           "granular_sync_options": "Enable Granular Sync Options"
         },
-        "title": "Connect to the OPNsense firewall / router"
+        "title": "Connect to the OPNsense firewall / router",
+        "data_description": {
+          "url": "Use the actual OPNsense device URL. Do not use a CARP virtual URL."
+        }
       },
       "carp": {
         "description": "CARP VIP entries are read-only. Configure each physical node with its own management address in a separate OPNsense device entry.",

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -3,6 +3,7 @@
   "config": {
     "abort": {
       "already_configured": "Device is already configured",
+      "carp_device_url_conflict": "A CARP entry and a device entry cannot use the same URL. Use the actual firewall IP address or hostname for the device entry and the CARP VIP IP address or hostname for the CARP entry.",
       "reconfigure_successful": "OPNsense integration reconfigured"
     },
     "error": {
@@ -16,10 +17,19 @@
       "url_redirect": "Incorrect URL (redirect)",
       "missing_device_unique_id": "Unable to get MAC addresses from OPNsense to use as Device Unique ID",
       "below_min_firmware": "OPNsense Firmware of {firmware} is below the minimum supported version of {min_firmware}",
+      "carp_not_configured": "No CARP VIP interfaces are configured on the selected OPNsense host",
+      "carp_responder_unavailable": "Unable to determine the active CARP responder from the selected OPNsense host",
       "unknown_firmware": "Unable to get OPNsense Firmware version"
     },
     "step": {
       "user": {
+        "title": "Add a hass-opnsense instance",
+        "menu_options": {
+          "device": "OPNsense device entry",
+          "carp": "CARP VIP entry"
+        }
+      },
+      "device": {
         "data": {
           "url": "URL",
           "username": "API Key",
@@ -29,6 +39,20 @@
           "granular_sync_options": "Enable Granular Sync Options"
         },
         "title": "Connect to the OPNsense firewall / router"
+      },
+      "carp": {
+        "description": "CARP VIP entries are read-only. Configure each physical node with its own management address in a separate OPNsense device entry.",
+        "data": {
+          "url": "URL",
+          "username": "API Key",
+          "password": "API Secret",
+          "name": "CARP VIP display name",
+          "verify_ssl": "Verify SSL certificate"
+        },
+        "title": "Connect to the OPNsense CARP VIP entry",
+        "data_description": {
+          "url": "Use the CARP virtual URL; individual physical nodes must also be configured separately via their management addresses."
+        }
       },
       "granular_sync": {
         "data": {
@@ -75,8 +99,10 @@
           "device_tracker_consider_home": "Device Tracker Consider Home",
           "granular_sync_options": "Enable Granular Sync Options"
         },
+        "description": "This screen exposes {options_scope}.",
         "data_description": {
-          "device_tracking_mode": "For `Track only selected devices`, a next step lets you pick devices from recent ARP detections and add MAC addresses manually"
+          "device_tracking_mode": "For `Track only selected devices`, a next step lets you pick devices from recent ARP detections and add MAC addresses manually",
+          "scan_interval": "Scan interval controls how often this entry polls its source."
         }
       },
       "granular_sync": {
@@ -109,6 +135,19 @@
           "devices": "Only recently detected devices appear here. Previously selected devices that are not currently detected stay available in the list.",
           "manual_devices": "Enter MAC addresses separated by commas or new lines. Invalid MAC addresses are ignored. Example: 00:00:00:00:00:00"
         }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "carp_active_responder": {
+        "name": "Active responder"
+      },
+      "carp_status_summary": {
+        "name": "CARP VIP status"
+      },
+      "carp_vip": {
+        "name": "CARP VIP {subnet} (VHID {vhid})"
       }
     }
   },

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -79,7 +79,7 @@
       },
       "reconfigure": {
         "data": {
-          "name": "CARP VIP display name",
+          "name": "Display name",
           "url": "URL",
           "username": "API Key",
           "password": "API Secret",

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -76,6 +76,7 @@
       },
       "reconfigure": {
         "data": {
+          "name": "CARP VIP display name",
           "url": "URL",
           "username": "API Key",
           "password": "API Secret",

--- a/prek.toml
+++ b/prek.toml
@@ -49,6 +49,7 @@ id = "mypy"
 language_version = "python3.14"
 args = ["--config-file=pyproject.toml"]
 additional_dependencies = [
+  "aiopnsense==1.1.3",
   "aiohttp",
   "awesomeversion",
   "homeassistant-stubs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.14"
 dynamic = ["version"]
 
 [build-system]
-requires = ["setuptools>=62.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -42,7 +42,6 @@ lint = [
 pytest = [
     { include-group = "ha" },
     "aiohttp",
-    "aiopnsense",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
@@ -63,10 +62,6 @@ namespace_packages = true
 pretty = true
 show_error_codes = true
 warn_unused_configs = true
-
-[[tool.mypy.overrides]]
-module = ["aiopnsense.*"]
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["pytest_homeassistant_custom_component.*"]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -240,6 +240,41 @@ async def test_async_setup_entry_creates_smart_status_problem_binary_sensors(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_creates_smart_status_binary_sensors_from_ident_only_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART status entities should be compiled when rows provide `ident` only."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_NOTICES: False,
+            CONF_SYNC_SMART: True,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "smart": [{"ident": "SERIAL-ONLY", "state": {"smart_status": {"passed": False}}}],
+        "smart_info": {"SERIAL-ONLY": {"smart_status": {"passed": False}}},
+    }
+    setattr(entry.runtime_data, COORDINATOR, coord)
+    created: list = []
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Add entities."""
+        created.extend(ents)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    smart_entities = [
+        entity for entity in created if isinstance(entity, OPNsenseSmartStatusBinarySensor)
+    ]
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.serial_only.status",
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("coord_data", [None, {"smart": {}}])
 async def test_compile_smart_status_binary_sensors_skips_invalid_state(
     coord_data: Any, make_config_entry: Callable[..., MockConfigEntry]
@@ -366,6 +401,24 @@ def test_smart_status_binary_sensor_parses_supported_status_shapes(
     assert sensor.available is True
     assert sensor.is_on is expected_is_on
     assert sensor.extra_state_attributes == {"device": "nvme0"}
+
+
+def test_smart_status_binary_sensor_uses_ident_when_device_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART status binary sensors should match rows using `ident` when `device` is absent."""
+    sensor = _build_smart_status_binary_sensor(
+        make_config_entry,
+        {
+            "smart": [{"ident": "SERIAL-ONLY", "state": {"smart_status": {"passed": False}}}],
+            "smart_info": {"SERIAL-ONLY": {"smart_status": {"passed": False}}},
+        },
+        "smart.serial_only.status",
+    )
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.is_on is True
 
 
 def test_smart_status_binary_sensor_strips_device_name_before_smart_info_lookup(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 from aiohttp import ClientError, ClientResponseError, ClientSSLError, ServerTimeoutError
 from aiopnsense import exceptions as aiopnsense_exceptions
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import AbortFlow
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
@@ -900,15 +901,13 @@ async def test_async_step_carp_aborts_on_duplicate_url(
 
     flow = cf_mod.OPNsenseConfigFlow()
     flow.hass = MagicMock()
-    object.__setattr__(
-        flow,
-        "_async_abort_entries_match",
-        lambda _match: {"type": "abort", "reason": "already_configured"},
-    )
+    abort_match = MagicMock(side_effect=AbortFlow("already_configured"))
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
 
-    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+    with pytest.raises(AbortFlow, match="already_configured"):
+        await flow.async_step_carp(user_input=_make_basic_carp_input())
 
-    assert result == {"type": "abort", "reason": "already_configured"}
+    abort_match.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -2235,22 +2234,21 @@ async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
     )
     monkeypatch.setattr(cf_mod, "validate_input", validate)
     object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
-    duplicate_abort = {"type": "abort", "reason": "already_configured"}
-    abort_match = MagicMock(return_value=duplicate_abort)
+    abort_match = MagicMock(side_effect=AbortFlow("already_configured"))
     object.__setattr__(flow, "_async_abort_entries_match", abort_match)
     update_and_abort = MagicMock()
     object.__setattr__(flow, "async_update_and_abort", update_and_abort)
 
-    result = await flow.async_step_reconfigure(
-        user_input={
-            cf_mod.CONF_URL: "https://carp-router.example/",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
-        }
-    )
+    with pytest.raises(AbortFlow, match="already_configured"):
+        await flow.async_step_reconfigure(
+            user_input={
+                cf_mod.CONF_URL: "https://carp-router.example/",
+                cf_mod.CONF_USERNAME: "admin",
+                cf_mod.CONF_PASSWORD: "secret",
+                cf_mod.CONF_VERIFY_SSL: True,
+            }
+        )
 
-    assert result == duplicate_abort
     abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
     update_and_abort.assert_not_called()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -522,6 +522,48 @@ async def test_async_step_carp_aborts_on_device_url_conflict(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stored_url", "normalized_url"),
+    [
+        ("https://router.example:443", "https://router.example"),
+        ("http://router.example:80", "http://router.example"),
+    ],
+)
+async def test_async_step_carp_aborts_on_legacy_default_port_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    stored_url: str,
+    normalized_url: str,
+) -> None:
+    """CARP setup should reject canonical duplicates stored with default ports."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: stored_url,
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_USERNAME: "carp-user",
+            cf_mod.CONF_PASSWORD: "carp-pass",
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    abort_match = MagicMock()
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    user_input = _make_basic_carp_input()
+    user_input[cf_mod.CONF_URL] = normalized_url
+
+    result = await flow.async_step_carp(user_input=user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    abort_match.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_async_step_device_allows_same_url_for_non_carp_entry(
     monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -2025,6 +2067,120 @@ async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
 
     abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
     update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stored_url", "normalized_url"),
+    [
+        ("https://router.example:443", "https://router.example"),
+        ("http://router.example:80", "http://router.example"),
+    ],
+)
+async def test_reconfigure_carp_aborts_on_legacy_default_port_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    stored_url: str,
+    normalized_url: str,
+) -> None:
+    """CARP reconfigure should reject another canonical legacy URL duplicate."""
+    config_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={
+            cf_mod.CONF_URL: "https://old.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_NAME: "Router CARP VIP",
+        },
+        options={},
+    )
+    duplicate_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: stored_url,
+            cf_mod.CONF_USERNAME: "other-user",
+            cf_mod.CONF_PASSWORD: "other-password",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[config_entry, duplicate_entry])
+    monkeypatch.setattr(cf_mod, "validate_input", AsyncMock(return_value={}))
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    abort_match = MagicMock()
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    update_and_abort = MagicMock()
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_NAME: "Router CARP VIP",
+            cf_mod.CONF_URL: normalized_url,
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    abort_match.assert_not_called()
+    update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stored_url", "normalized_url"),
+    [
+        ("https://router.example:443", "https://router.example"),
+        ("http://router.example:80", "http://router.example"),
+    ],
+)
+async def test_reconfigure_carp_ignores_own_legacy_default_port_url(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    stored_url: str,
+    normalized_url: str,
+) -> None:
+    """CARP reconfigure should not treat its canonical legacy URL as a duplicate."""
+    config_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={
+            cf_mod.CONF_URL: stored_url,
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_NAME: "Router CARP VIP",
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
+    monkeypatch.setattr(cf_mod, "validate_input", AsyncMock(return_value={}))
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    abort_match = MagicMock()
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    update_and_abort = MagicMock(return_value={"type": "abort", "reason": "reconfigure_successful"})
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_NAME: "Router CARP VIP",
+            cf_mod.CONF_URL: normalized_url,
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
+    abort_match.assert_called_once_with({cf_mod.CONF_URL: normalized_url})
+    update_and_abort.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2032,6 +2032,7 @@ async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
 
     result = await flow.async_step_reconfigure(
         user_input={
+            cf_mod.CONF_NAME: "Renamed CARP VIP",
             cf_mod.CONF_URL: "https://carp-router.example",
             cf_mod.CONF_USERNAME: "admin",
             cf_mod.CONF_PASSWORD: "secret",
@@ -2046,6 +2047,19 @@ async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
     assert validate_call.kwargs["carp"] is True
     assert "expected_id" not in validate_call.kwargs
     set_unique_id.assert_not_awaited()
+    update_and_abort.assert_called_once_with(
+        entry=config_entry,
+        title="Renamed CARP VIP",
+        data={
+            cf_mod.CONF_URL: "https://carp-router.example",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_FIRMWARE_VERSION: "26.1.11",
+            cf_mod.CONF_NAME: "Renamed CARP VIP",
+            cf_mod.CONF_VERIFY_SSL: True,
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -2153,6 +2167,7 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
             cf_mod.CONF_USERNAME: "u",
             cf_mod.CONF_PASSWORD: "p",
             cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
@@ -2184,12 +2199,14 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
     abort_match.assert_not_called()
     update_and_abort.assert_called_once_with(
         entry=config_entry,
+        title="Router CARP VIP",
         data={
             cf_mod.CONF_URL: "https://carp-router.example",
             cf_mod.CONF_USERNAME: "admin",
             cf_mod.CONF_PASSWORD: "secret",
             cf_mod.CONF_VERIFY_SSL: True,
             cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_NAME: "Router CARP VIP",
         },
     )
 
@@ -2250,6 +2267,7 @@ async def test_reconfigure_carp_preserves_self_url_when_no_duplicate(
             cf_mod.CONF_USERNAME: "u",
             cf_mod.CONF_PASSWORD: "p",
             cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_NAME: "Router CARP VIP",
         },
         options={},
     )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -285,6 +285,28 @@ def test_url_conflict_matches_persisted_default_ports(
     assert result["reason"] == "carp_device_url_conflict"
 
 
+def test_url_conflict_skips_invalid_stored_urls_and_continues_scanning() -> None:
+    """Ignore unusable stored URLs and continue until a normalized match is found."""
+    entries = [
+        MagicMock(entry_id="non-string", data={cf_mod.CONF_URL: 123}),
+        MagicMock(entry_id="malformed", data={cf_mod.CONF_URL: "https://"}),
+        MagicMock(entry_id="mismatch", data={cf_mod.CONF_URL: "other.example"}),
+        MagicMock(
+            entry_id="match",
+            data={cf_mod.CONF_URL: "https://router.example", CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
+        ),
+    ]
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries.async_entries.return_value = entries
+
+    result = flow._async_abort_if_url_conflict(url="https://router.example", carp=False)
+
+    assert result is not None
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("exception_factory", "expected"),
@@ -627,6 +649,35 @@ async def test_async_step_carp_validates_without_device_id_and_sets_entry_type(
     assert result["data"].get(cf_mod.CONF_GRANULAR_SYNC_OPTIONS) is None
     client.validate.assert_awaited_once_with(require_device_id=False)
     client.get_device_unique_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_without_input_shows_empty_form() -> None:
+    """Opening CARP setup without input should show the initial empty form."""
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_carp(None)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "carp"
+    assert result["errors"] == {}
+    assert result["description_placeholders"]["firmware"] == "Unknown"
+
+
+@pytest.mark.asyncio
+async def test_async_step_import_delegates_to_device_step() -> None:
+    """YAML import should delegate its payload unchanged to the device step."""
+    flow = cf_mod.OPNsenseConfigFlow()
+    user_input = _make_basic_device_input()
+    expected: dict[str, Any] = {"type": "abort", "reason": "test"}
+    device_step = AsyncMock(return_value=expected)
+    object.__setattr__(flow, "async_step_device", device_step)
+
+    result = await flow.async_step_import(user_input)
+
+    assert result == expected
+    device_step.assert_awaited_once_with(user_input)
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -398,6 +398,7 @@ async def test_validate_input_maps_raw_aiohttp_ssl_error(
 
     assert res["base"] == "cannot_connect_ssl"
 
+
 @pytest.mark.parametrize(
     (
         "failing_attribute",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -229,6 +229,26 @@ async def test_clean_and_parse_url_success_and_failure() -> None:
 @pytest.mark.parametrize(
     ("input_url", "expected_url"),
     [
+        ("router.example:8443", "https://router.example:8443"),
+        ("router.example:443", "https://router.example"),
+        ("https://router.example:443", "https://router.example"),
+    ],
+)
+async def test_clean_and_parse_url_with_and_without_scheme(
+    input_url: str, expected_url: str
+) -> None:
+    """Normalize URLs that omit a scheme and retain canonical default-port behavior."""
+    user_input = {cf_mod.CONF_URL: input_url}
+
+    await cf_mod._clean_and_parse_url(user_input)
+
+    assert user_input[cf_mod.CONF_URL] == expected_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("input_url", "expected_url"),
+    [
         ("https://router.example:443", "https://router.example"),
         ("http://router.example:80", "http://router.example"),
         ("https://router.example:8443", "https://router.example:8443"),
@@ -1078,6 +1098,37 @@ async def test_get_dt_entries_supports_raw_arp_keys(
     )
 
     assert res == {"aa:bb:cc:00:00:01": "10.0.0.10 [aa:bb:cc:00:00:01]"}
+
+
+@pytest.mark.asyncio
+async def test_get_dt_entries_skips_non_mapping_arp_rows(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """Non-mapping ARP rows should be ignored instead of raising mapping errors."""
+    client_cls = fake_client()
+
+    async def _get_arp_table(self: Any, resolve_hostnames: bool = True) -> Any:
+        return [
+            "invalid row",
+            {"mac": "aa:bb:cc:00:00:02", "hostname": "hostb", "ip": "10.0.0.10"},
+            None,
+        ]
+
+    client_cls.get_arp_table = _get_arp_table
+    patch_opnsense_client(monkeypatch, cf_mod, client_cls)
+
+    res = await cf_mod._get_dt_entries(
+        hass=MagicMock(),
+        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        selected_devices=["AA-BB-CC-DD-EE-FF"],
+    )
+
+    assert list(res.keys()) == [
+        "aa:bb:cc:dd:ee:ff",
+        "aa:bb:cc:00:00:02",
+    ]
+    assert res["aa:bb:cc:dd:ee:ff"] == "Not currently detected [aa:bb:cc:dd:ee:ff]"
+    assert res["aa:bb:cc:00:00:02"] == "hostb [10.0.0.10 | aa:bb:cc:00:00:02]"
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -198,35 +198,33 @@ def test_device_entry_sort_key_numeric_ip_sorting() -> None:
     assert subnet_key_2 < subnet_key_10
 
 
-@pytest.mark.asyncio
-async def test_clean_and_parse_url_success_and_failure() -> None:
+def test_clean_and_parse_url_success_and_failure() -> None:
     """Clean and parse URL, fix missing scheme and handle invalid URL."""
     ui = {cf_mod.CONF_URL: "router.example"}
-    await cf_mod._clean_and_parse_url(ui)
+    cf_mod._clean_and_parse_url(ui)
     assert ui[cf_mod.CONF_URL] == "https://router.example"
 
     auth_ui = {cf_mod.CONF_URL: "https://user:pass@router.example:8443"}
-    await cf_mod._clean_and_parse_url(auth_ui)
+    cf_mod._clean_and_parse_url(auth_ui)
     assert auth_ui[cf_mod.CONF_URL] == "https://router.example:8443"
 
     ipv6_ui = {cf_mod.CONF_URL: "https://user:pass@[2001:db8::1]:8443"}
-    await cf_mod._clean_and_parse_url(ipv6_ui)
+    cf_mod._clean_and_parse_url(ipv6_ui)
     assert ipv6_ui[cf_mod.CONF_URL] == "https://[2001:db8::1]:8443"
 
     invalid_port_ui = {cf_mod.CONF_URL: "https://router.example:abc"}
     with pytest.raises(cf_mod.OPNsenseInvalidURL):
-        await cf_mod._clean_and_parse_url(invalid_port_ui)
+        cf_mod._clean_and_parse_url(invalid_port_ui)
 
     # invalid netloc -> raise OPNsenseInvalidURL
     with pytest.raises(cf_mod.OPNsenseInvalidURL):
-        await cf_mod._clean_and_parse_url({cf_mod.CONF_URL: ""})
+        cf_mod._clean_and_parse_url({cf_mod.CONF_URL: ""})
 
     missing_host_ui = {cf_mod.CONF_URL: "https://:8443"}
     with pytest.raises(cf_mod.OPNsenseInvalidURL):
-        await cf_mod._clean_and_parse_url(missing_host_ui)
+        cf_mod._clean_and_parse_url(missing_host_ui)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("input_url", "expected_url"),
     [
@@ -235,18 +233,15 @@ async def test_clean_and_parse_url_success_and_failure() -> None:
         ("https://router.example:443", "https://router.example"),
     ],
 )
-async def test_clean_and_parse_url_with_and_without_scheme(
-    input_url: str, expected_url: str
-) -> None:
+def test_clean_and_parse_url_with_and_without_scheme(input_url: str, expected_url: str) -> None:
     """Normalize URLs that omit a scheme and retain canonical default-port behavior."""
     user_input = {cf_mod.CONF_URL: input_url}
 
-    await cf_mod._clean_and_parse_url(user_input)
+    cf_mod._clean_and_parse_url(user_input)
 
     assert user_input[cf_mod.CONF_URL] == expected_url
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("input_url", "expected_url"),
     [
@@ -256,13 +251,11 @@ async def test_clean_and_parse_url_with_and_without_scheme(
         ("http://router.example:8080", "http://router.example:8080"),
     ],
 )
-async def test_clean_and_parse_url_canonicalizes_default_ports(
-    input_url: str, expected_url: str
-) -> None:
+def test_clean_and_parse_url_canonicalizes_default_ports(input_url: str, expected_url: str) -> None:
     """Normalize default HTTP ports while preserving non-default ports."""
     user_input = {cf_mod.CONF_URL: input_url}
 
-    await cf_mod._clean_and_parse_url(user_input)
+    cf_mod._clean_and_parse_url(user_input)
 
     assert user_input[cf_mod.CONF_URL] == expected_url
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -765,7 +765,8 @@ async def test_async_step_carp_rejects_malformed_or_blank_vip_rows(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "form"
-    assert result["errors"]["base"] == "carp_responder_unavailable"
+    assert result["errors"]["base"] == "carp_not_configured"
+    client.get_device_unique_id.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -814,8 +815,7 @@ async def test_async_step_carp_rejects_missing_or_blank_responder_name(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "form"
-    assert result["errors"]["base"] == "carp_not_configured"
-    client.get_device_unique_id.assert_not_awaited()
+    assert result["errors"]["base"] == "carp_responder_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
-from aiohttp import ClientError, ClientResponseError, ClientSSLError, ServerTimeoutError
 from aiopnsense import exceptions as aiopnsense_exceptions
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import AbortFlow
@@ -288,48 +287,26 @@ def test_url_conflict_matches_persisted_default_ports(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("exc_key", "expected"),
+    ("exception_factory", "expected"),
     [
-        ("below_min", "below_min_firmware"),
-        ("unknown_fw", "unknown_firmware"),
-        ("missing_id", "missing_device_unique_id"),
-        ("invalid_url", "invalid_url_format"),
-        ("ssl", "cannot_connect_ssl"),
-        ("invalid_auth", "invalid_auth"),
-        ("privilege_missing", "privilege_missing"),
-        ("timeout", "connect_timeout"),
-        ("connection", "cannot_connect"),
-        ("aiohttp_client_error", "cannot_connect"),
+        (aiopnsense_exceptions.OPNsenseBelowMinFirmware, "below_min_firmware"),
+        (aiopnsense_exceptions.OPNsenseUnknownFirmware, "unknown_firmware"),
+        (aiopnsense_exceptions.OPNsenseMissingDeviceUniqueID, "missing_device_unique_id"),
+        (aiopnsense_exceptions.OPNsenseInvalidURL, "invalid_url_format"),
+        (aiopnsense_exceptions.OPNsenseSSLError, "cannot_connect_ssl"),
+        (aiopnsense_exceptions.OPNsenseInvalidAuth, "invalid_auth"),
+        (aiopnsense_exceptions.OPNsensePrivilegeMissing, "privilege_missing"),
+        (aiopnsense_exceptions.OPNsenseTimeoutError, "connect_timeout"),
+        (aiopnsense_exceptions.OPNsenseConnectionError, "cannot_connect"),
     ],
 )
 async def test_validate_input_exception_mapping(
-    monkeypatch: pytest.MonkeyPatch, exc_key: Any, expected: Any
+    monkeypatch: pytest.MonkeyPatch,
+    exception_factory: type[aiopnsense_exceptions.OPNsenseError],
+    expected: str,
 ) -> None:
-    """Ensure validate_input maps various exceptions to the expected error code."""
-    # Build exception object lazily to avoid constructor issues at collection time
-    exc: BaseException
-    if exc_key == "below_min":
-        exc = aiopnsense_exceptions.OPNsenseBelowMinFirmware()
-    elif exc_key == "unknown_fw":
-        exc = aiopnsense_exceptions.OPNsenseUnknownFirmware()
-    elif exc_key == "missing_id":
-        exc = aiopnsense_exceptions.OPNsenseMissingDeviceUniqueID("x")
-    elif exc_key == "invalid_url":
-        exc = cf_mod.OPNsenseInvalidURL("u")
-    elif exc_key == "ssl":
-        exc = aiopnsense_exceptions.OPNsenseSSLError("ssl error")
-    elif exc_key == "invalid_auth":
-        exc = aiopnsense_exceptions.OPNsenseInvalidAuth("auth error")
-    elif exc_key == "privilege_missing":
-        exc = aiopnsense_exceptions.OPNsensePrivilegeMissing("privilege error")
-    elif exc_key == "timeout":
-        exc = aiopnsense_exceptions.OPNsenseTimeoutError("t")
-    elif exc_key == "connection":
-        exc = aiopnsense_exceptions.OPNsenseConnectionError("boom")
-    elif exc_key == "aiohttp_client_error":
-        exc = ClientError("boom")
-    else:
-        exc = OSError("unknown")
+    """Ensure validate_input maps public aiopnsense exceptions to form errors."""
+    exc = exception_factory("boom")
 
     async def _raiser(*args, **kwargs) -> Never:
         """Raise the prepared exception so input error mapping can be validated.
@@ -347,98 +324,6 @@ async def test_validate_input_exception_mapping(
     errors: dict[str, str] = {}
     res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
     assert res.get("base") == expected
-
-
-@pytest.mark.asyncio
-async def test_validate_input_maps_raw_aiohttp_forbidden_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Aiohttp 403 responses should map to privilege_missing."""
-
-    async def _raise(*args: object, **kwargs: object) -> Never:
-        """Raise a fake 403 response error to exercise privilege mapping."""
-        error = ClientResponseError(
-            request_info=MagicMock(real_url="https://x"),
-            history=(),
-            status=403,
-            message="forbidden",
-            headers=MagicMock(),
-        )
-        raise error
-
-    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
-    errors: dict[str, str] = {}
-    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
-
-    assert res["base"] == "privilege_missing"
-
-
-@pytest.mark.asyncio
-async def test_validate_input_maps_raw_aiohttp_ssl_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Aiohttp SSL errors should map to cannot_connect_ssl."""
-
-    async def _raise(*args: object, **kwargs: object) -> Never:
-        """Raise a raw aiohttp SSL error to exercise ssl mapping."""
-        error = ClientSSLError(MagicMock(host="x", port=443, ssl=True), OSError("ssl"))
-        raise error
-
-    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
-    errors: dict[str, str] = {}
-    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
-
-    assert res["base"] == "cannot_connect_ssl"
-
-
-@pytest.mark.parametrize(
-    (
-        "failing_attribute",
-        "carp",
-    ),
-    [
-        ("get_system_info", False),
-        ("get_device_unique_id", False),
-        ("get_carp", True),
-    ],
-)
-async def test_validate_input_maps_aiohttp_client_error_from_enrichment_calls(
-    monkeypatch: pytest.MonkeyPatch,
-    failing_attribute: str,
-    carp: bool,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Raw aiohttp errors from enrichment calls should map to cannot_connect."""
-    username = "admin"
-    password = "supersecret"
-    client = _CarpFlowClient()
-    setattr(
-        client,
-        failing_attribute,
-        AsyncMock(side_effect=ClientError(f"timeout user={username} pass={password}")),
-    )
-    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
-
-    user_input = _make_basic_carp_input() if carp else _make_basic_device_input()
-    user_input.update(
-        {
-            cf_mod.CONF_USERNAME: username,
-            cf_mod.CONF_PASSWORD: password,
-        }
-    )
-
-    with caplog.at_level("ERROR"):
-        result = await cf_mod.validate_input(
-            hass=MagicMock(),
-            user_input=user_input,
-            errors={},
-            carp=carp,
-        )
-
-    assert result["base"] == "cannot_connect"
-    assert "[redacted]" in caplog.text
-    assert username not in caplog.text
-    assert password not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -481,32 +366,6 @@ async def test_validate_input_timeout_uses_connect_timeout_error(
         raise aiopnsense_exceptions.OPNsenseTimeoutError(
             f"timed out for user={username} pass={password}"
         )
-
-    monkeypatch.setattr(cf_mod, "_validate_client_details", _raiser)
-    with caplog.at_level("ERROR"):
-        result = await cf_mod.validate_input(
-            hass=MagicMock(),
-            user_input={cf_mod.CONF_USERNAME: username, cf_mod.CONF_PASSWORD: password},
-            errors={},
-        )
-
-    assert result.get("base") == "connect_timeout"
-    assert "[redacted]" in caplog.text
-    assert username not in caplog.text
-    assert password not in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_validate_input_timeout_subclass_of_client_error_still_maps_connect_timeout(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Timeout subclasses that also appear as ClientError map to connect_timeout."""
-    username = "admin"
-    password = "supersecret"
-
-    async def _raiser(*args: object, **kwargs: object) -> Never:
-        """Raise an exception that is both TimeoutError and ClientError."""
-        raise ServerTimeoutError(f"timeout user={username} pass={password}")
 
     monkeypatch.setattr(cf_mod, "_validate_client_details", _raiser)
     with caplog.at_level("ERROR"):
@@ -1667,8 +1526,6 @@ async def test_device_tracker_shows_form_when_no_user_input(
         (cf_mod.OPNsenseSSLError, "cannot_connect_ssl"),
         (aiopnsense_exceptions.OPNsensePrivilegeMissing, "privilege_missing"),
         (aiopnsense_exceptions.OPNsenseTimeoutError, "connect_timeout"),
-        (ServerTimeoutError, "connect_timeout"),
-        (ClientError, "cannot_connect"),
     ],
     ids=[
         "cannot_connect",
@@ -1676,8 +1533,6 @@ async def test_device_tracker_shows_form_when_no_user_input(
         "ssl",
         "privilege_missing",
         "timeout",
-        "server_timeout",
-        "aiohttp",
     ],
 )
 @pytest.mark.asyncio
@@ -1716,58 +1571,6 @@ async def test_device_tracker_handles_arp_lookup_failure(
     assert res["errors"]["base"] == expected_base_error
     validated = res["data_schema"]({})
     assert validated[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
-
-
-@pytest.mark.asyncio
-async def test_device_tracker_handles_builtin_timeout_lookup_failure(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Builtin TimeoutError from ARP lookup should map to connect_timeout."""
-    cfg = make_config_entry(
-        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
-        options={cf_mod.CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
-    )
-    flow = _make_options_flow(cfg)
-    flow._config = dict(cfg.data)
-    flow._options = dict(cfg.options)
-
-    async def _raise(*args, **kwargs) -> Never:
-        raise TimeoutError("timed out")
-
-    monkeypatch.setattr(cf_mod, "_get_dt_entries", _raise)
-
-    res = await flow.async_step_device_tracker(user_input=None)
-    assert res["type"] == "form"
-    assert res["errors"]["base"] == "connect_timeout"
-    validated = res["data_schema"]({})
-    assert validated[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
-
-
-@pytest.mark.asyncio
-async def test_device_tracker_handles_opnsense_timeout_error(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """OPNsense timeouts should keep picker rendering with the saved MAC fallback."""
-    cfg = make_config_entry(
-        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
-        options={cf_mod.CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
-    )
-    flow = _make_options_flow(cfg)
-    flow._config = dict(cfg.data)
-    flow._options = dict(cfg.options)
-
-    async def _raise_timeout(*args: object, **kwargs: object) -> Never:
-        """Raise an OPNsense timeout to exercise connect_timeout mapping."""
-        raise aiopnsense_exceptions.OPNsenseTimeoutError("request timed out")
-
-    monkeypatch.setattr(cf_mod, "_get_dt_entries", _raise_timeout)
-    res_timeout = await flow.async_step_device_tracker(user_input=None)
-    assert res_timeout["type"] == "form"
-    assert res_timeout["errors"]["base"] == "connect_timeout"
-    validated_timeout = res_timeout["data_schema"]({})
-    assert validated_timeout[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
+from aiohttp import ClientError, ClientResponseError, ClientSSLError, ServerTimeoutError
 from aiopnsense import exceptions as aiopnsense_exceptions
 from homeassistant.core import HomeAssistant
 import pytest
@@ -16,9 +17,12 @@ import voluptuous as vol
 
 import custom_components.opnsense.config_flow as config_flow_mod
 from custom_components.opnsense.const import (
+    CONF_ENTRY_TYPE,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_SYNC_SMART,
     CONF_SYNC_TELEMETRY,
+    ENTRY_TYPE_CARP,
+    ENTRY_TYPE_DEVICE,
 )
 from tests.utilities import patch_opnsense_client
 
@@ -36,6 +40,79 @@ def _make_options_flow(config_entry: Any) -> Any:
     flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=config_entry)
     flow.handler = config_entry.entry_id
     return flow
+
+
+class _CarpFlowClient:
+    """Fake client for CARP config-flow validation and setup tests."""
+
+    def __init__(
+        self,
+        *,
+        firmware_version: str = "26.1.11",
+        system_name: str = "fw-a.example",
+        carp_interfaces: list[dict[str, str]] | None = None,
+        validate_error: BaseException | None = None,
+    ) -> None:
+        """Initialize fake client responses for config-flow tests.
+
+        Args:
+            firmware_version: Firmware version returned by the fake client.
+            system_name: System name returned by the fake client.
+            carp_interfaces: CARP interface rows returned by the fake client.
+            validate_error: Optional validation exception raised by the fake client.
+        """
+        self.firmware_version = firmware_version
+        self.system_name = system_name
+        self.carp_interfaces = (
+            carp_interfaces
+            if carp_interfaces is not None
+            else [
+                {
+                    "interface": "lan",
+                    "subnet": "192.0.2.1",
+                    "vhid": "1",
+                    "status": "MASTER",
+                }
+            ]
+        )
+        self.validate = AsyncMock()
+        if validate_error is not None:
+            self.validate.side_effect = validate_error
+        self.async_close = AsyncMock()
+        self.get_device_unique_id = AsyncMock(return_value="dev-id")
+
+    async def get_host_firmware_version(self) -> str:
+        """Return fake firmware version."""
+        return self.firmware_version
+
+    async def get_system_info(self) -> dict[str, str]:
+        """Return fake responder metadata."""
+        return {"name": self.system_name}
+
+    async def get_carp(self) -> dict[str, Any]:
+        """Return CARP endpoint payload."""
+        return {"interfaces": self.carp_interfaces}
+
+
+def _make_basic_device_input() -> dict[str, Any]:
+    """Build a minimal device-flow input payload."""
+    return {
+        "url": "https://router.example",
+        "username": "user",
+        "password": "pass",
+        "verify_ssl": True,
+        "granular_sync_options": False,
+    }
+
+
+def _make_basic_carp_input() -> dict[str, Any]:
+    """Build a minimal CARP-flow input payload."""
+    return {
+        "url": "https://router.example",
+        "username": "user",
+        "password": "pass",
+        "verify_ssl": True,
+    }
 
 
 def test_mac_and_ip_and_cleanse() -> None:
@@ -150,6 +227,58 @@ async def test_clean_and_parse_url_success_and_failure() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("input_url", "expected_url"),
+    [
+        ("https://router.example:443", "https://router.example"),
+        ("http://router.example:80", "http://router.example"),
+        ("https://router.example:8443", "https://router.example:8443"),
+        ("http://router.example:8080", "http://router.example:8080"),
+    ],
+)
+async def test_clean_and_parse_url_canonicalizes_default_ports(
+    input_url: str, expected_url: str
+) -> None:
+    """Normalize default HTTP ports while preserving non-default ports."""
+    user_input = {cf_mod.CONF_URL: input_url}
+
+    await cf_mod._clean_and_parse_url(user_input)
+
+    assert user_input[cf_mod.CONF_URL] == expected_url
+
+
+@pytest.mark.parametrize(
+    ("stored_url", "normalized_url"),
+    [
+        ("https://router.example:443", "https://router.example"),
+        ("http://router.example:80", "http://router.example"),
+    ],
+)
+def test_url_conflict_matches_persisted_default_ports(
+    make_config_entry: Callable[..., MockConfigEntry], stored_url: str, normalized_url: str
+) -> None:
+    """Opposite-kind URL conflicts should match legacy explicit default ports."""
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: stored_url,
+            cf_mod.CONF_USERNAME: "carp-user",
+            cf_mod.CONF_PASSWORD: "carp-pass",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+
+    result = flow._async_abort_if_url_conflict(url=normalized_url, carp=False)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("exc_key", "expected"),
     [
         ("below_min", "below_min_firmware"),
@@ -161,6 +290,7 @@ async def test_clean_and_parse_url_success_and_failure() -> None:
         ("privilege_missing", "privilege_missing"),
         ("timeout", "connect_timeout"),
         ("connection", "cannot_connect"),
+        ("aiohttp_client_error", "cannot_connect"),
     ],
 )
 async def test_validate_input_exception_mapping(
@@ -187,6 +317,8 @@ async def test_validate_input_exception_mapping(
         exc = aiopnsense_exceptions.OPNsenseTimeoutError("t")
     elif exc_key == "connection":
         exc = aiopnsense_exceptions.OPNsenseConnectionError("boom")
+    elif exc_key == "aiohttp_client_error":
+        exc = ClientError("boom")
     else:
         exc = OSError("unknown")
 
@@ -206,6 +338,114 @@ async def test_validate_input_exception_mapping(
     errors: dict[str, str] = {}
     res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
     assert res.get("base") == expected
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_raw_aiohttp_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aiohttp ClientError should map to cannot_connect without aborting the flow."""
+
+    async def _raise(*args: object, **kwargs: object) -> Never:
+        """Raise a raw aiohttp ClientError to exercise transport mapping."""
+        raise ClientError("client request failed")
+
+    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
+    errors: dict[str, str] = {}
+    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
+
+    assert res["base"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_raw_aiohttp_forbidden_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aiohttp 403 responses should map to privilege_missing."""
+
+    async def _raise(*args: object, **kwargs: object) -> Never:
+        """Raise a fake 403 response error to exercise privilege mapping."""
+        error = ClientResponseError(
+            request_info=MagicMock(real_url="https://x"),
+            history=(),
+            status=403,
+            message="forbidden",
+            headers=MagicMock(),
+        )
+        raise error
+
+    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
+    errors: dict[str, str] = {}
+    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
+
+    assert res["base"] == "privilege_missing"
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_raw_aiohttp_ssl_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aiohttp SSL errors should map to cannot_connect_ssl."""
+
+    async def _raise(*args: object, **kwargs: object) -> Never:
+        """Raise a raw aiohttp SSL error to exercise ssl mapping."""
+        error = ClientSSLError(MagicMock(host="x", port=443, ssl=True), OSError("ssl"))
+        raise error
+
+    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
+    errors: dict[str, str] = {}
+    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
+
+    assert res["base"] == "cannot_connect_ssl"
+
+@pytest.mark.parametrize(
+    (
+        "failing_attribute",
+        "carp",
+    ),
+    [
+        ("get_system_info", False),
+        ("get_device_unique_id", False),
+        ("get_carp", True),
+    ],
+)
+async def test_validate_input_maps_aiohttp_client_error_from_enrichment_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_attribute: str,
+    carp: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Raw aiohttp errors from enrichment calls should map to cannot_connect."""
+    username = "admin"
+    password = "supersecret"
+    client = _CarpFlowClient()
+    setattr(
+        client,
+        failing_attribute,
+        AsyncMock(side_effect=ClientError(f"timeout user={username} pass={password}")),
+    )
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    user_input = _make_basic_carp_input() if carp else _make_basic_device_input()
+    user_input.update(
+        {
+            cf_mod.CONF_USERNAME: username,
+            cf_mod.CONF_PASSWORD: password,
+        }
+    )
+
+    with caplog.at_level("ERROR"):
+        result = await cf_mod.validate_input(
+            hass=MagicMock(),
+            user_input=user_input,
+            errors={},
+            carp=carp,
+        )
+
+    assert result["base"] == "cannot_connect"
+    assert "[redacted]" in caplog.text
+    assert username not in caplog.text
+    assert password not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -263,12 +503,452 @@ async def test_validate_input_timeout_uses_connect_timeout_error(
     assert password not in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_validate_input_timeout_subclass_of_client_error_still_maps_connect_timeout(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Timeout subclasses that also appear as ClientError map to connect_timeout."""
+    username = "admin"
+    password = "supersecret"
+
+    async def _raiser(*args: object, **kwargs: object) -> Never:
+        """Raise an exception that is both TimeoutError and ClientError."""
+        raise ServerTimeoutError(f"timeout user={username} pass={password}")
+
+    monkeypatch.setattr(cf_mod, "_validate_client_details", _raiser)
+    with caplog.at_level("ERROR"):
+        result = await cf_mod.validate_input(
+            hass=MagicMock(),
+            user_input={cf_mod.CONF_USERNAME: username, cf_mod.CONF_PASSWORD: password},
+            errors={},
+        )
+
+    assert result.get("base") == "connect_timeout"
+    assert "[redacted]" in caplog.text
+    assert username not in caplog.text
+    assert password not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_step_user_shows_menu() -> None:
+    """Initial config flow step should present a menu with two entry types."""
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_user()
+
+    assert result["type"] == "menu"
+    assert result["step_id"] == "user"
+    assert result["menu_options"] == ["device", "carp"]
+
+
+@pytest.mark.asyncio
+async def test_async_step_device_creates_entry_and_sets_entry_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Device flow should continue to set a hardware-backed entry type."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    object.__setattr__(
+        flow,
+        "async_set_unique_id",
+        AsyncMock(),
+    )
+    object.__setattr__(flow, "_abort_if_unique_id_configured", lambda: None)
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    result = await flow.async_step_device(user_input=_make_basic_device_input())
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_DEVICE
+    assert result["data"][cf_mod.CONF_DEVICE_UNIQUE_ID] == "dev-id"
+    assert not result["data"][cf_mod.CONF_GRANULAR_SYNC_OPTIONS]
+
+
+@pytest.mark.asyncio
+async def test_async_step_device_routes_to_granular_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Device flow must still forward granular-sync-enabled submissions."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    object.__setattr__(
+        flow,
+        "async_set_unique_id",
+        AsyncMock(),
+    )
+    object.__setattr__(flow, "_abort_if_unique_id_configured", lambda: None)
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    ui = _make_basic_device_input()
+    ui[cf_mod.CONF_GRANULAR_SYNC_OPTIONS] = True
+    result = await flow.async_step_device(user_input=ui)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "granular_sync"
+
+
+@pytest.mark.asyncio
+async def test_async_step_device_aborts_on_duplicate_carp_url(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Device flow should reject a normalized URL already used by a CARP entry."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://router.example",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_USERNAME: "carp-user",
+            cf_mod.CONF_PASSWORD: "carp-pass",
+        },
+        options={},
+    )
+    assert existing_entry.data[cf_mod.CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    set_unique_id = AsyncMock()
+    abort_if_configured = MagicMock()
+    object.__setattr__(flow, "async_set_unique_id", set_unique_id)
+    object.__setattr__(flow, "_abort_if_unique_id_configured", abort_if_configured)
+
+    user_input = _make_basic_device_input()
+    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    result = await flow.async_step_device(user_input=user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    set_unique_id.assert_not_awaited()
+    abort_if_configured.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_aborts_on_device_url_conflict(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP flow should reject a URL already used by a device entry."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://router.example",
+            cf_mod.CONF_USERNAME: "device-user",
+            cf_mod.CONF_PASSWORD: "device-pass",
+        },
+        options={},
+    )
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    abort_match = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+
+    user_input = _make_basic_carp_input()
+    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    result = await flow.async_step_carp(user_input=user_input)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    abort_match.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_step_device_allows_same_url_for_non_carp_entry(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Device flow should not block URL duplicates when matching entry is not CARP."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://router.example",
+            cf_mod.CONF_USERNAME: "device-user",
+            cf_mod.CONF_PASSWORD: "device-pass",
+        },
+        options={},
+    )
+    assert existing_entry.data.get(cf_mod.CONF_ENTRY_TYPE, ENTRY_TYPE_DEVICE) == ENTRY_TYPE_DEVICE
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    set_unique_id = AsyncMock()
+    abort_if_configured = MagicMock()
+
+    object.__setattr__(
+        flow,
+        "async_set_unique_id",
+        set_unique_id,
+    )
+    object.__setattr__(flow, "_abort_if_unique_id_configured", abort_if_configured)
+
+    user_input = _make_basic_device_input()
+    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    result = await flow.async_step_device(user_input=user_input)
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_DEVICE
+    assert result["data"][cf_mod.CONF_URL] == "https://router.example"
+    set_unique_id.assert_awaited_once_with("dev-id")
+    abort_if_configured.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_validates_without_device_id_and_sets_entry_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CARP flow should validate with device-id disabled and skip granular sync fields."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
+    assert result["data"][cf_mod.CONF_FIRMWARE_VERSION] == client.firmware_version
+    assert result["data"][cf_mod.CONF_NAME] == f"{client.system_name} CARP VIP"
+    assert result["data"].get(cf_mod.CONF_DEVICE_UNIQUE_ID) is None
+    assert result["data"].get(cf_mod.CONF_GRANULAR_SYNC_OPTIONS) is None
+    client.validate.assert_awaited_once_with(require_device_id=False)
+    client.get_device_unique_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interfaces",
+    [
+        None,
+        (),
+        "not-a-list",
+        [],
+        [{}],
+        ["not-a-mapping"],
+        [{"vhid": "", "subnet": "192.0.2.1"}],
+        [{"vhid": "1", "subnet": ""}],
+        [{"vhid": "  ", "subnet": "  "}],
+    ],
+)
+async def test_async_step_carp_rejects_malformed_or_blank_vip_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    interfaces: Any,
+) -> None:
+    """CARP validation should require a mapping row with usable VHID and subnet."""
+    client = _CarpFlowClient()
+    object.__setattr__(client, "get_carp", AsyncMock(return_value={"interfaces": interfaces}))
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "carp_responder_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interface",
+    [
+        {"vhid": 1, "subnet": "192.0.2.1"},
+        {"vhid": " 2 ", "subnet": " 192.0.2.2 "},
+    ],
+)
+async def test_async_step_carp_accepts_vip_identity_without_physical_interface(
+    monkeypatch: pytest.MonkeyPatch,
+    interface: dict[str, Any],
+) -> None:
+    """CARP validation should accept integer/string VHIDs without interface names."""
+    client = _CarpFlowClient()
+    object.__setattr__(client, "get_carp", AsyncMock(return_value={"interfaces": [interface]}))
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result["type"] == "create_entry"
+    assert result["data"][cf_mod.CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "system_info",
+    [None, {}, {"name": None}, {"name": ""}, {"name": "  "}, {"name": 123}, []],
+)
+async def test_async_step_carp_rejects_missing_or_blank_responder_name(
+    monkeypatch: pytest.MonkeyPatch,
+    system_info: Any,
+) -> None:
+    """CARP validation should require a usable responder name from system info."""
+    client = _CarpFlowClient()
+    object.__setattr__(client, "get_system_info", AsyncMock(return_value=system_info))
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "carp_not_configured"
+    client.get_device_unique_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_custom_name_does_not_waive_responder_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A custom entry name should not bypass required responder metadata."""
+    client = _CarpFlowClient()
+    object.__setattr__(client, "get_system_info", AsyncMock(return_value={"name": "  "}))
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    user_input = _make_basic_carp_input()
+    user_input[cf_mod.CONF_NAME] = "Custom CARP"
+
+    result = await flow.async_step_carp(user_input=user_input)
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "carp_responder_unavailable"
+
+
+def test_validation_error_details_maps_carp_responder_unavailable() -> None:
+    """Responder validation errors should use their dedicated form error key."""
+    result = cf_mod._get_validation_error_details(
+        cf_mod.OPNsenseCarpResponderUnavailableError("missing responder"),
+        _make_basic_carp_input(),
+    )
+
+    assert result is not None
+    assert result[0] == "carp_responder_unavailable"
+    assert result[1] == "Unable to determine the active CARP responder"
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_rejects_below_min_firmware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Below-minimum firmware in CARP mode should map to below_min_firmware."""
+    client = _CarpFlowClient(
+        firmware_version="0.1.0",
+        validate_error=aiopnsense_exceptions.OPNsenseBelowMinFirmware("too old"),
+    )
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "below_min_firmware"
+
+
+@pytest.mark.asyncio
+async def test_async_step_carp_aborts_on_duplicate_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CARP flow should use abort-by-URL dedupe for existing entries."""
+    client = _CarpFlowClient()
+    patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
+
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    object.__setattr__(
+        flow,
+        "_async_abort_entries_match",
+        lambda _match: {"type": "abort", "reason": "already_configured"},
+    )
+
+    result = await flow.async_step_carp(user_input=_make_basic_carp_input())
+
+    assert result == {"type": "abort", "reason": "already_configured"}
+
+
+@pytest.mark.asyncio
+async def test_validate_input_can_map_carp_not_configured_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """validate_input should map CARP payload errors to base key carp_not_configured."""
+
+    async def _raise(*_args: object, **_kwargs: object) -> Never:
+        """Raise the CARP validation error requested by the test."""
+        raise cf_mod.OPNsenseCarpNotConfiguredError("No CARP VIPs were returned")
+
+    monkeypatch.setattr(cf_mod, "_validate_carp_client_details", _raise)
+    errors: dict[str, str] = {}
+    result = await cf_mod.validate_input(
+        hass=MagicMock(),
+        user_input=_make_basic_carp_input(),
+        errors=errors,
+        carp=True,
+    )
+    assert result["base"] == "carp_not_configured"
+
+
 def test_record_validation_error_sets_base(caplog: pytest.LogCaptureFixture) -> None:
     """_record_validation_error should log the message and set errors['base']."""
     errors: dict[str, str] = {}
     cf_mod._record_validation_error(errors=errors, key="test_key", message="an msg")
     assert errors.get("base") == "test_key"
     assert "an msg" in caplog.text
+
+
+def test_build_carp_input_schema_defaults_and_rejects_unknown_fields() -> None:
+    """CARP schema should apply defaults and ignore unrelated field keys."""
+    schema = cf_mod._build_carp_input_schema(
+        user_input=None,
+        stored_values={
+            cf_mod.CONF_URL: "https://stored.example",
+            cf_mod.CONF_VERIFY_SSL: False,
+            cf_mod.CONF_USERNAME: "stored-user",
+            cf_mod.CONF_PASSWORD: "stored-pass",
+            cf_mod.CONF_NAME: "Stored Router",
+        },
+    )
+    values = schema({})
+    assert values[cf_mod.CONF_URL] == "https://stored.example"
+    assert values[cf_mod.CONF_VERIFY_SSL] is False
+    assert values[cf_mod.CONF_USERNAME] == "stored-user"
+    assert values[cf_mod.CONF_PASSWORD] == "stored-pass"
+    assert values[cf_mod.CONF_NAME] == "Stored Router"
+    with pytest.raises(vol.Invalid):
+        schema({cf_mod.CONF_GRANULAR_SYNC_OPTIONS: True})
+
+
+def test_build_carp_options_schema_exposes_scan_interval_only() -> None:
+    """CARP options schema should only contain scan interval."""
+    schema = cf_mod._build_carp_options_schema(user_input=None, stored_options=None)
+    values = schema({})
+    assert values == {cf_mod.CONF_SCAN_INTERVAL: cf_mod.DEFAULT_SCAN_INTERVAL}
+
+    with pytest.raises(vol.Invalid):
+        schema({cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_ALL})
 
 
 @pytest.mark.asyncio
@@ -378,10 +1058,34 @@ async def test_get_dt_entries_preserves_missing_selected_devices(
 
 
 @pytest.mark.asyncio
+async def test_get_dt_entries_supports_raw_arp_keys(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """_get_dt_entries should parse raw aiopnsense 1.1.1 ARP keys."""
+    client_cls = fake_client()
+
+    async def _get_arp_table(self: Any, resolve_hostnames: bool = True) -> Any:
+        return [{"mac-address": "AA-BB-CC-00-00-01", "ip-address": "10.0.0.10"}]
+
+    client_cls.get_arp_table = _get_arp_table
+    patch_opnsense_client(monkeypatch, cf_mod, client_cls)
+
+    res = await cf_mod._get_dt_entries(
+        hass=MagicMock(),
+        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        selected_devices=[],
+    )
+
+    assert res == {"aa:bb:cc:00:00:01": "10.0.0.10 [aa:bb:cc:00:00:01]"}
+
+
+@pytest.mark.asyncio
 async def test_get_dt_entries_closes_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_get_dt_entries should always close the temporary client."""
+    """_get_dt_entries should close the client and request propagated errors."""
 
     class _Client:
+        """Fake client that records closure for device-tracker entry tests."""
+
         last_instance = None
 
         def __init__(self, *args, **kwargs) -> None:
@@ -392,6 +1096,7 @@ async def test_get_dt_entries_closes_client(monkeypatch: pytest.MonkeyPatch) -> 
                 **kwargs: Unused keyword constructor args from factory helper.
             """
             type(self).last_instance = self
+            self.throw_errors = kwargs.get("throw_errors")
             self.async_close = AsyncMock()
 
         async def get_arp_table(self, resolve_hostnames: bool = True) -> Any:
@@ -413,6 +1118,7 @@ async def test_get_dt_entries_closes_client(monkeypatch: pytest.MonkeyPatch) -> 
         selected_devices=[],
     )
     assert _Client.last_instance is not None
+    assert _Client.last_instance.throw_errors is True
     _Client.last_instance.async_close.assert_awaited_once()
 
 
@@ -421,6 +1127,8 @@ async def test_validate_client_details_closes_client(monkeypatch: pytest.MonkeyP
     """_validate_client_details should always close the temporary client."""
 
     class _Client:
+        """Fake client that records closure for validation cleanup tests."""
+
         last_instance = None
 
         def __init__(self, *args, **kwargs) -> None:
@@ -487,6 +1195,8 @@ async def test_validate_client_details_raises_when_device_id_missing(
     """_validate_client_details should reject clients that return no device id."""
 
     class _Client:
+        """Fake client that returns no device ID for validation tests."""
+
         last_instance = None
 
         def __init__(self, *args: object, **kwargs: object) -> None:
@@ -724,6 +1434,67 @@ def test_async_get_options_flow_returns_options_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_options_flow_init_for_carp_entry_only_allows_scan_interval(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP options init should render scan interval form and skip device-tracker fields."""
+    cfg = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://x",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={cf_mod.CONF_SCAN_INTERVAL: 45},
+    )
+    flow = _make_options_flow(cfg)
+    flow._config = dict(cfg.data)
+    flow._options = dict(cfg.options)
+
+    res = await flow.async_step_init()
+
+    assert res["type"] == "form"
+    assert res["step_id"] == "init"
+    assert res["description_placeholders"]["options_scope"] == (
+        "scan interval only for this CARP VIP entry"
+    )
+    data = res["data_schema"]({})
+    assert data == {cf_mod.CONF_SCAN_INTERVAL: 45}
+
+
+@pytest.mark.asyncio
+async def test_options_flow_init_for_carp_entry_saves_scan_interval(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Submitting CARP options should normalize scan interval and preserve unrelated options."""
+    cfg = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://x",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={
+            cf_mod.CONF_SCAN_INTERVAL: 60,
+            cf_mod.CONF_DEVICE_TRACKER_ENABLED: False,
+            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+        },
+    )
+    flow = _make_options_flow(cfg)
+    flow._config = dict(cfg.data)
+    flow._options = dict(cfg.options)
+
+    res = await flow.async_step_init(user_input={cf_mod.CONF_SCAN_INTERVAL: 120})
+
+    assert res["type"] == "create_entry"
+    assert flow._options == {
+        cf_mod.CONF_SCAN_INTERVAL: 120,
+        cf_mod.CONF_DEVICE_TRACKER_ENABLED: False,
+        cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+    }
+
+
+@pytest.mark.asyncio
 async def test_options_flow_init_with_user_triggers_update() -> None:
     """Submitting user input to async_step_init should update entry and create entry."""
     cfg = MagicMock()
@@ -744,6 +1515,28 @@ async def test_options_flow_init_with_user_triggers_update() -> None:
     assert res["type"] == "create_entry"
     assert flow._options.get(cf_mod.CONF_SCAN_INTERVAL) == 30
     assert isinstance(flow._options.get(cf_mod.CONF_SCAN_INTERVAL), int)
+
+
+@pytest.mark.asyncio
+async def test_options_flow_init_for_device_shows_resolved_description_scope(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Device options form render should include normal options-scope description placeholders."""
+    cfg = make_config_entry(
+        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        options={},
+    )
+    flow = _make_options_flow(cfg)
+    flow._config = dict(cfg.data)
+    flow._options = dict(cfg.options)
+
+    res = await flow.async_step_init()
+
+    assert res["type"] == "form"
+    assert res["step_id"] == "init"
+    assert res["description_placeholders"] == {
+        "options_scope": "all available integration and device-tracker options"
+    }
 
 
 @pytest.mark.asyncio
@@ -844,13 +1637,36 @@ async def test_device_tracker_shows_form_when_no_user_input(
     assert cf_mod.CONF_DEVICES in validated
 
 
+@pytest.mark.parametrize(
+    ("exception_factory", "expected_base_error"),
+    [
+        (aiopnsense_exceptions.OPNsenseConnectionError, "cannot_connect"),
+        (aiopnsense_exceptions.OPNsenseInvalidAuth, "invalid_auth"),
+        (cf_mod.OPNsenseSSLError, "cannot_connect_ssl"),
+        (aiopnsense_exceptions.OPNsensePrivilegeMissing, "privilege_missing"),
+        (aiopnsense_exceptions.OPNsenseTimeoutError, "connect_timeout"),
+        (ServerTimeoutError, "connect_timeout"),
+        (ClientError, "cannot_connect"),
+    ],
+    ids=[
+        "cannot_connect",
+        "invalid_auth",
+        "ssl",
+        "privilege_missing",
+        "timeout",
+        "server_timeout",
+        "aiohttp",
+    ],
+)
 @pytest.mark.asyncio
 async def test_device_tracker_handles_arp_lookup_failure(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
+    exception_factory: type[BaseException],
+    expected_base_error: str,
 ) -> None:
     """ARP lookup failures should not abort device tracker form rendering."""
-    exc = aiopnsense_exceptions.OPNsenseConnectionError("boom")
+    exc = exception_factory("boom")
     cfg = make_config_entry(
         data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
         options={cf_mod.CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
@@ -875,7 +1691,33 @@ async def test_device_tracker_handles_arp_lookup_failure(
 
     res = await flow.async_step_device_tracker(user_input=None)
     assert res["type"] == "form"
-    assert res["errors"]["base"] == "cannot_connect"
+    assert res["errors"]["base"] == expected_base_error
+    validated = res["data_schema"]({})
+    assert validated[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
+
+
+@pytest.mark.asyncio
+async def test_device_tracker_handles_builtin_timeout_lookup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Builtin TimeoutError from ARP lookup should map to connect_timeout."""
+    cfg = make_config_entry(
+        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        options={cf_mod.CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
+    )
+    flow = _make_options_flow(cfg)
+    flow._config = dict(cfg.data)
+    flow._options = dict(cfg.options)
+
+    async def _raise(*args, **kwargs) -> Never:
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(cf_mod, "_get_dt_entries", _raise)
+
+    res = await flow.async_step_device_tracker(user_input=None)
+    assert res["type"] == "form"
+    assert res["errors"]["base"] == "connect_timeout"
     validated = res["data_schema"]({})
     assert validated[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
 
@@ -1052,6 +1894,339 @@ async def test_reconfigure_updates_entry_when_validation_succeeds(
             cf_mod.CONF_DEVICE_UNIQUE_ID: "device-1",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_device_aborts_on_carp_url_conflict(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Device reconfigure should reject a changed URL used by a CARP entry."""
+    config_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://old.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_DEVICE_UNIQUE_ID: "device-1",
+        },
+        options={},
+        unique_id="device-1",
+    )
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://router.example:443",
+            cf_mod.CONF_USERNAME: "carp-user",
+            cf_mod.CONF_PASSWORD: "carp-pass",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    validate = AsyncMock(return_value={})
+    set_unique_id = AsyncMock()
+    update_and_abort = MagicMock()
+
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    object.__setattr__(flow, "async_set_unique_id", set_unique_id)
+    object.__setattr__(flow, "_abort_if_unique_id_mismatch", lambda: None)
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://router.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+    validate.assert_awaited_once()
+    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    set_unique_id.assert_not_awaited()
+    update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure should validate with CARP mode and skip unique-id checks."""
+    config_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://x",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            cf_mod.CONF_FIRMWARE_VERSION: "26.1.11",
+            cf_mod.CONF_NAME: "Router CARP VIP",
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    validate = AsyncMock(return_value={})
+    set_unique_id = AsyncMock()
+    update_and_abort = MagicMock(return_value={"type": "abort", "reason": "reconfigure_successful"})
+
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    object.__setattr__(flow, "async_set_unique_id", set_unique_id)
+    object.__setattr__(flow, "_abort_if_unique_id_mismatch", lambda: None)
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://carp-router.example",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
+    validate.assert_awaited_once()
+    validate_call = validate.await_args
+    assert validate_call is not None
+    assert validate_call.kwargs["carp"] is True
+    assert "expected_id" not in validate_call.kwargs
+    set_unique_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_aborts_on_device_url_conflict(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure should reject a changed URL used by a device entry."""
+    config_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://old-carp.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    existing_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "http://router.example:80",
+            cf_mod.CONF_USERNAME: "device-user",
+            cf_mod.CONF_PASSWORD: "device-pass",
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    validate = AsyncMock(return_value={})
+    abort_match = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+    update_and_abort = MagicMock()
+
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "http://router.example",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "carp_device_url_conflict"
+    validate.assert_awaited_once()
+    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    abort_match.assert_not_called()
+    update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_returns_form_on_validation_error(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure validation errors should return form and not update."""
+    config_entry = make_config_entry(
+        data={
+            cf_mod.CONF_URL: "https://x",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    validate = AsyncMock(return_value={"base": "invalid_host"})
+    abort_match = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+    update_and_abort = MagicMock()
+
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://router.example",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "invalid_host"}
+    abort_match.assert_not_called()
+    update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure should skip URL duplicate checks when the URL is unchanged."""
+    config_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={
+            cf_mod.CONF_URL: "https://carp-router.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    validate = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["user_input"].update(
+            {cf_mod.CONF_URL: "https://carp-router.example"}
+        )
+    )
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    abort_match = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    update_and_abort = MagicMock(return_value={"type": "abort", "reason": "reconfigure_successful"})
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://carp-router.example/",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
+    validate.assert_awaited_once()
+    abort_match.assert_not_called()
+    update_and_abort.assert_called_once_with(
+        entry=config_entry,
+        data={
+            cf_mod.CONF_URL: "https://carp-router.example",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure should reject a normalized URL used by another entry."""
+    config_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={
+            cf_mod.CONF_URL: "https://old.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    validate = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["user_input"].update(
+            {cf_mod.CONF_URL: "https://carp-router.example"}
+        )
+    )
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    duplicate_abort = {"type": "abort", "reason": "already_configured"}
+    abort_match = MagicMock(return_value=duplicate_abort)
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    update_and_abort = MagicMock()
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://carp-router.example/",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result == duplicate_abort
+    abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
+    update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_carp_preserves_self_url_when_no_duplicate(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """CARP reconfigure should keep its own normalized URL when no other entry matches."""
+    config_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={
+            cf_mod.CONF_URL: "https://old.example",
+            cf_mod.CONF_USERNAME: "u",
+            cf_mod.CONF_PASSWORD: "p",
+            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    flow = cf_mod.OPNsenseConfigFlow()
+    flow.hass = MagicMock()
+    validate = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["user_input"].update(
+            {cf_mod.CONF_URL: "https://carp-router.example"}
+        )
+    )
+    monkeypatch.setattr(cf_mod, "validate_input", validate)
+    object.__setattr__(flow, "_get_reconfigure_entry", lambda: config_entry)
+    abort_match = MagicMock(return_value=None)
+    object.__setattr__(flow, "_async_abort_entries_match", abort_match)
+    update_and_abort = MagicMock(return_value={"type": "abort", "reason": "reconfigure_successful"})
+    object.__setattr__(flow, "async_update_and_abort", update_and_abort)
+
+    result = await flow.async_step_reconfigure(
+        user_input={
+            cf_mod.CONF_URL: "https://carp-router.example/",
+            cf_mod.CONF_USERNAME: "admin",
+            cf_mod.CONF_PASSWORD: "secret",
+            cf_mod.CONF_VERIFY_SSL: True,
+        }
+    )
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
+    abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
+    update_and_abort.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -228,31 +228,26 @@ def test_clean_and_parse_url_success_and_failure() -> None:
 @pytest.mark.parametrize(
     ("input_url", "expected_url"),
     [
-        ("router.example:8443", "https://router.example:8443"),
-        ("router.example:443", "https://router.example"),
-        ("https://router.example:443", "https://router.example"),
+        pytest.param(
+            "router.example:8443", "https://router.example:8443", id="no-scheme-custom-port"
+        ),
+        pytest.param("router.example:443", "https://router.example", id="no-scheme-default-port"),
+        pytest.param(
+            "https://router.example:443", "https://router.example", id="https-default-port"
+        ),
+        pytest.param("http://router.example:80", "http://router.example", id="http-default-port"),
+        pytest.param(
+            "https://router.example:8443",
+            "https://router.example:8443",
+            id="https-custom-port",
+        ),
+        pytest.param(
+            "http://router.example:8080", "http://router.example:8080", id="http-custom-port"
+        ),
     ],
 )
-def test_clean_and_parse_url_with_and_without_scheme(input_url: str, expected_url: str) -> None:
-    """Normalize URLs that omit a scheme and retain canonical default-port behavior."""
-    user_input = {cf_mod.CONF_URL: input_url}
-
-    cf_mod._clean_and_parse_url(user_input)
-
-    assert user_input[cf_mod.CONF_URL] == expected_url
-
-
-@pytest.mark.parametrize(
-    ("input_url", "expected_url"),
-    [
-        ("https://router.example:443", "https://router.example"),
-        ("http://router.example:80", "http://router.example"),
-        ("https://router.example:8443", "https://router.example:8443"),
-        ("http://router.example:8080", "http://router.example:8080"),
-    ],
-)
-def test_clean_and_parse_url_canonicalizes_default_ports(input_url: str, expected_url: str) -> None:
-    """Normalize default HTTP ports while preserving non-default ports."""
+def test_clean_and_parse_url_normalizes_scheme_and_ports(input_url: str, expected_url: str) -> None:
+    """Normalize URL schemes and ports into their canonical form."""
     user_input = {cf_mod.CONF_URL: input_url}
 
     cf_mod._clean_and_parse_url(user_input)
@@ -352,23 +347,6 @@ async def test_validate_input_exception_mapping(
     errors: dict[str, str] = {}
     res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
     assert res.get("base") == expected
-
-
-@pytest.mark.asyncio
-async def test_validate_input_maps_raw_aiohttp_client_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Aiohttp ClientError should map to cannot_connect without aborting the flow."""
-
-    async def _raise(*args: object, **kwargs: object) -> Never:
-        """Raise a raw aiohttp ClientError to exercise transport mapping."""
-        raise ClientError("client request failed")
-
-    monkeypatch.setattr(cf_mod, "_validate_client_details", _raise)
-    errors: dict[str, str] = {}
-    res = await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors=errors)
-
-    assert res["base"] == "cannot_connect"
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -21,6 +21,7 @@ from custom_components.opnsense import coordinator as coordinator_module
 from custom_components.opnsense.const import (
     ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
+    CONF_ENTRY_TYPE,
     CONF_FIRMWARE_VERSION,
     CONF_SYNC_CARP,
     CONF_SYNC_CERTIFICATES,
@@ -37,6 +38,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_UNBOUND,
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
+    ENTRY_TYPE_CARP,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 
@@ -155,6 +157,46 @@ async def test_get_states_fetches_smart_info_for_each_smart_device(
     assert client.get_smart_info.await_args_list == [
         call(device="nvme0", info_type="A"),
         call(device="ada0", info_type="A"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_states_uses_smart_ident_when_device_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART detail lookups should fall back to `ident` when `device` is missing."""
+    client = MagicMock()
+    client.get_smart = AsyncMock(
+        return_value=[
+            {"ident": "serial-1", "state": {"smart_status": {"passed": True}}},
+            {"device": "nvme0", "state": {"smart_status": {"passed": True}}},
+        ]
+    )
+    client.get_smart_info = AsyncMock(return_value={"temperature": {"current": 37}})
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
+    coordinator = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    state = await coordinator._get_states(
+        [
+            {"function": "get_smart", "state_key": "smart"},
+            {"function": "get_smart_info", "state_key": "smart_info"},
+        ]
+    )
+
+    assert state["smart_info"] == {
+        "serial-1": {"temperature": {"current": 37}},
+        "nvme0": {"temperature": {"current": 37}},
+    }
+    assert client.get_smart_info.await_args_list == [
+        call(device="serial-1", info_type="A"),
+        call(device="nvme0", info_type="A"),
     ]
 
 
@@ -330,6 +372,46 @@ async def test_get_states_uses_single_carp_call(
     client.get_carp.assert_awaited_once()
     assert state["carp"]["interfaces"][0]["status"] == "MASTER"
     assert state["carp"]["status_summary"]["state"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_build_categories_for_carp_entries_only_include_system_info_and_carp(
+    make_config_entry: Callable[..., MockConfigEntry], fake_client: Any
+) -> None:
+    """CARP entries should only request system info and CARP state."""
+    entry = make_config_entry(
+        {
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_SYNC_INTERFACES: True,
+            CONF_SYNC_TELEMETRY: True,
+        }
+    )
+    client = fake_client()()
+    object.__setattr__(
+        client,
+        "get_device_unique_id",
+        AsyncMock(return_value="should_not_be_called"),
+    )
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id=None,
+        config_entry=entry,
+    )
+
+    assert coord._build_categories() == [
+        {"function": "get_system_info", "state_key": "system_info"},
+        {"function": "get_carp", "state_key": "carp"},
+    ]
+    coord._state = {
+        "system_info": {"name": "fw"},
+        "carp": {"interfaces": [], "status_summary": {"state": "healthy"}},
+    }
+
+    assert await coord._check_device_unique_id() is True
+    client.get_device_unique_id.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -130,6 +130,26 @@ def test_compile_tracked_devices_normalizes_and_deduplicates_configured_macs(
     ]
 
 
+def test_device_from_arp_entry_uses_raw_arp_keys() -> None:
+    """Raw aiopnsense ARP keys should be discovered alongside normalized keys."""
+    device = dt_mod._device_from_arp_entry(
+        "aa:bb:cc",
+        [{"mac-address": "AA-BB-CC"}, {"mac": "11:22:33"}],
+    )
+
+    assert device == {"mac": "aa:bb:cc"}
+
+
+def test_devices_from_arp_entries_reads_raw_mac_ip_keys() -> None:
+    """Raw ARP key names should be consumed when scanning configured devices."""
+    devices, mac_addresses = dt_mod._devices_from_arp_entries(
+        [{"mac-address": "AA-BB-CC", "ip-address": "10.0.0.2", "hostname": "raw"}],
+    )
+
+    assert mac_addresses == ["aa:bb:cc"]
+    assert devices == [{"mac": "aa:bb:cc", "hostname": "raw"}]
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_configured_devices(
     monkeypatch: pytest.MonkeyPatch,
@@ -351,26 +371,6 @@ def test_handle_coordinator_update_entry_present(
     assert attributes.get("type") == "arp"
     assert ent.icon == "mdi:lan-connect"
     assert ent.source_type == dt_mod.SourceType.ROUTER
-
-
-def test_scanner_entity_uses_attr_backed_home_assistant_properties() -> None:
-    """Scanner entity should rely on Home Assistant attr-backed properties."""
-    locally_defined_properties = {
-        name
-        for name, value in vars(dt_mod.OPNsenseScannerEntity).items()
-        if isinstance(value, property)
-    }
-
-    assert "unique_id" in locally_defined_properties
-    assert "device_info" in locally_defined_properties
-    assert "entity_registry_enabled_default" in locally_defined_properties
-    assert "is_connected" in locally_defined_properties
-    assert {
-        "hostname",
-        "ip_address",
-        "mac_address",
-        "source_type",
-    }.isdisjoint(locally_defined_properties)
 
 
 def test_entity_registry_enabled_default_uses_existing_mac_device(
@@ -660,6 +660,28 @@ def test_handle_coordinator_update_matches_mac_case_insensitively(
     assert ent.available is True
 
 
+def test_handle_coordinator_update_reads_raw_arp_ip_key(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Tracker update should still read `ip-address` when `ip` is absent."""
+    coordinator.data = {
+        "arp_table": [
+            {"mac-address": "AA:BB:CC", "ip-address": "10.0.0.12", "intf_description": "lan"}
+        ],
+        "update_time": 0,
+    }
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data=coordinator.data,
+    )
+    object.__setattr__(ent, "async_write_ha_state", MagicMock())
+
+    ent._handle_coordinator_update()
+
+    assert ent.ip_address == "10.0.0.12"
+
+
 def test_update_arp_extra_state_attributes_clears_stale_values() -> None:
     """Stale ARP extra state attributes are removed when absent in current entry."""
     attributes: dict[str, Any] = {
@@ -900,52 +922,23 @@ async def test_restore_last_state_restores_tz_aware_connected_time(
 
 
 @pytest.mark.asyncio
-async def test_restore_last_state_ignores_naive_iso_connected_time(
+@pytest.mark.parametrize(
+    "connected_time",
+    [
+        pytest.param("2026-06-22T12:30:05", id="naive-iso"),
+        pytest.param("not-a-date", id="unparsable"),
+        pytest.param(1, id="non-datetime"),
+    ],
+)
+async def test_restore_last_state_ignores_invalid_connected_time(
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Naive ISO timestamps should be ignored during state restore."""
-    ent = _make_scanner_entity(coordinator, make_config_entry)
-    last_state = MagicMock()
-    last_state.attributes = {"last_known_connected_time": "2026-06-22T12:30:05"}
-    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
-
-    await ent._restore_last_state()
-
-    assert ent._last_known_connected_time is None
-    attrs = ent.extra_state_attributes
-    assert attrs is not None
-    assert "last_known_connected_time" not in attrs
-
-
-@pytest.mark.asyncio
-async def test_restore_last_state_ignores_unparseable_connected_time(
-    coordinator: MagicMock,
-    make_config_entry: Callable[..., MockConfigEntry],
+    connected_time: str | int,
 ) -> None:
     """Restoring state should ignore invalid saved connection timestamps."""
     ent = _make_scanner_entity(coordinator, make_config_entry)
     last_state = MagicMock()
-    last_state.attributes = {"last_known_connected_time": "not-a-date"}
-    object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
-
-    await ent._restore_last_state()
-
-    assert ent._last_known_connected_time is None
-    attrs = ent.extra_state_attributes
-    assert attrs is not None
-    assert "last_known_connected_time" not in attrs
-
-
-@pytest.mark.asyncio
-async def test_restore_last_state_ignores_non_datetime_connected_time(
-    coordinator: MagicMock,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Restoring state should ignore non-string and non-datetime timestamps."""
-    ent = _make_scanner_entity(coordinator, make_config_entry)
-    last_state = MagicMock()
-    last_state.attributes = {"last_known_connected_time": 1}
+    last_state.attributes = {"last_known_connected_time": connected_time}
     object.__setattr__(ent, "async_get_last_state", AsyncMock(return_value=last_state))
 
     await ent._restore_last_state()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -31,7 +31,7 @@ def _make_scanner_entity(
     *,
     coordinator_data: object | None = None,
     enabled_default: bool = False,
-    mac: str | None = "aa:bb:cc",
+    mac: str = "aa:bb:cc",
 ) -> OPNsenseScannerEntity:
     """Create a scanner entity with coordinator runtime data wired in.
 
@@ -466,8 +466,9 @@ def test_entity_registry_enabled_default_without_mac_stays_disabled(
         coordinator=coordinator,
         make_config_entry=make_config_entry,
         coordinator_data={"arp_table": []},
-        mac=None,
     )
+
+    object.__setattr__(ent, "_attr_mac_address", None)
 
     assert ent.entity_registry_enabled_default is False
     device_info = ent.device_info

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,9 +6,15 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_ENTRY_TYPE,
+    DOMAIN,
+    ENTRY_TYPE_CARP,
+)
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.entity import OPNsenseBaseEntity, OPNsenseEntity
+from custom_components.opnsense.helpers import config_entry_identity
 
 
 def test_payload_display_name_uses_scalar_fallback() -> None:
@@ -20,6 +26,7 @@ class _BadStrValue:
     """Value object that raises when converted to a string."""
 
     def __str__(self) -> str:
+        """Raise when the display-name helper converts this value to text."""
         raise ValueError("string conversion failure")
 
 
@@ -41,20 +48,55 @@ class _FaultyPayload(Mapping[str, object]):
     """Payload whose get() raises for a target field."""
 
     def __init__(self, values: dict[str, object]) -> None:
+        """Store payload values used by mapping protocol tests.
+
+        Args:
+            values: Values returned by the mapping methods.
+        """
         self._values = values
 
     def get(self, key: str, default: object | None = None) -> object | None:
+        """Return a value or raise for the deliberately broken key.
+
+        Args:
+            key: Mapping key to read.
+            default: Value returned when the key is absent.
+
+        Returns:
+            object | None: Stored value or the supplied default.
+
+        Raises:
+            ValueError: If ``key`` is the simulated broken field.
+        """
         if key == "broken_get":
             raise ValueError("payload get failed")
         return self._values.get(key, default)
 
     def __getitem__(self, key: str) -> object:
+        """Return the stored value for a required mapping key.
+
+        Args:
+            key: Mapping key to read.
+
+        Returns:
+            object: Stored mapping value.
+        """
         return self._values[key]
 
     def __iter__(self) -> Iterator[str]:
+        """Iterate over stored mapping keys.
+
+        Returns:
+            Iterator[str]: Iterator over the payload keys.
+        """
         return iter(self._values)
 
     def __len__(self) -> int:
+        """Return the number of stored mapping values.
+
+        Returns:
+            int: Number of payload values.
+        """
         return len(self._values)
 
 
@@ -95,6 +137,18 @@ def test_init_sets_unique_and_name_suffixes(
     assert ent.unique_id == "dev_123_suf"
     assert ent.has_entity_name is True
     assert ent.name == "Name"
+
+    carp_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
+        title="CARP VIP",
+    )
+    carp_ent = OPNsenseBaseEntity(
+        config_entry=carp_entry, coordinator=dummy_coordinator, unique_id_suffix="test"
+    )
+    assert config_entry_identity(carp_entry) == "carp-entry"
+    assert carp_ent._device_unique_id == "carp-entry"
+    assert carp_ent.unique_id == "carp_entry_test"
 
 
 def test_available_property_toggle(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -386,10 +386,23 @@ def test_entry_type_and_identity_helpers(
     )
     carp_entry = make_config_entry(
         entry_id="carp-entry",
-        data={CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
+        data={
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_DEVICE_UNIQUE_ID: "stale-device-id",
+        },
+    )
+    blank_device_entry = make_config_entry(
+        entry_id="blank-device-entry",
+        data={CONF_DEVICE_UNIQUE_ID: "  \t"},
+    )
+    padded_device_entry = make_config_entry(
+        entry_id="padded-device-entry",
+        data={CONF_DEVICE_UNIQUE_ID: "  padded-device-id  "},
     )
 
     assert is_carp_entry(device_entry) is False
     assert config_entry_identity(device_entry) == "aa_bb_cc_dd_ee_ff"
     assert is_carp_entry(carp_entry) is True
     assert config_entry_identity(carp_entry) == "carp-entry"
+    assert config_entry_identity(blank_device_entry) == "blank-device-entry"
+    assert config_entry_identity(padded_device_entry) == "padded-device-id"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -93,6 +93,16 @@ def test_normalize_arp_mac(value: object, expected: str) -> None:
             "aa:bb:cc",
             id="fallback-key",
         ),
+        pytest.param(
+            {"mac": "  ", "mac-address": "AA-BB-CC"},
+            "aa:bb:cc",
+            id="blank-normalized-key-fallback",
+        ),
+        pytest.param(
+            {"mac": "  ", "mac-address": " \t"},
+            "",
+            id="both-keys-blank",
+        ),
     ],
 )
 def test_get_arp_mac(entry: dict[str, Any], expected: str) -> None:
@@ -106,6 +116,16 @@ def test_get_arp_mac(entry: dict[str, Any], expected: str) -> None:
         pytest.param({"ip": " 192.0.2.1 "}, "192.0.2.1", id="normalized-key"),
         pytest.param({"ip-address": " 192.0.2.2 "}, "192.0.2.2", id="raw-key"),
         pytest.param({"ip": 1}, "", id="invalid-value"),
+        pytest.param(
+            {"ip": "  ", "ip-address": " 192.0.2.3 "},
+            "192.0.2.3",
+            id="blank-normalized-key-fallback",
+        ),
+        pytest.param(
+            {"ip": " \t", "ip-address": "  "},
+            "",
+            id="both-keys-blank",
+        ),
     ],
 )
 def test_get_arp_ip(entry: dict[str, Any], expected: str) -> None:
@@ -135,6 +155,7 @@ def test_get_smart_device_name(entry: dict[str, Any], expected: str) -> None:
     "value",
     [
         {"vhid": 1, "subnet": "192.0.2.1"},
+        {"vhid": 255, "subnet": "192.0.2.255"},
         {"vhid": " 2 ", "subnet": " 192.0.2.2 "},
     ],
 )
@@ -154,6 +175,10 @@ def test_is_usable_carp_vip_accepts_normalized_identity_without_interface(
         {"vhid": "", "subnet": "192.0.2.1"},
         {"vhid": 1, "subnet": ""},
         {"vhid": True, "subnet": "192.0.2.1"},
+        {"vhid": 0, "subnet": "192.0.2.1"},
+        {"vhid": -1, "subnet": "192.0.2.1"},
+        {"vhid": 256, "subnet": "192.0.2.1"},
+        {"vhid": "not-a-vhid", "subnet": "192.0.2.1"},
     ],
 )
 def test_is_usable_carp_vip_rejects_missing_or_blank_identity(value: Any) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 """Unit tests for shared OPNsense integration helpers."""
 
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -8,14 +9,26 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import helpers as helpers_mod
-from custom_components.opnsense.const import DEFAULT_VERIFY_SSL
+from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_ENTRY_TYPE,
+    DEFAULT_VERIFY_SSL,
+    ENTRY_TYPE_CARP,
+)
 from custom_components.opnsense.helpers import (
     coerce_bool,
+    config_entry_identity,
     create_opnsense_client,
     create_opnsense_client_from_config_entry,
     firewall_nat_switch_unique_ids_from_payload,
     firewall_rule_id_from_payload,
     firewall_rule_switch_unique_ids_from_payload,
+    get_arp_ip,
+    get_arp_mac,
+    get_smart_device_name,
+    is_carp_entry,
+    is_usable_carp_vip,
+    normalize_arp_mac,
 )
 
 
@@ -58,6 +71,97 @@ def test_coerce_bool_returns_none_for_unknown_values(value: Any) -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("AA:BB:CC", "aa:bb:cc", id="colon-separated"),
+        pytest.param(" AA-BB-CC ", "aa:bb:cc", id="hyphen-separated"),
+        pytest.param(None, "", id="non-string"),
+    ],
+)
+def test_normalize_arp_mac(value: object, expected: str) -> None:
+    """Normalize ARP MAC values into the shared representation."""
+    assert normalize_arp_mac(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        pytest.param({"mac": "AA:BB:CC"}, "aa:bb:cc", id="normalized-key"),
+        pytest.param({"mac-address": "AA-BB-CC"}, "aa:bb:cc", id="raw-key"),
+        pytest.param(
+            {"mac": 1, "mac-address": "AA-BB-CC"},
+            "aa:bb:cc",
+            id="fallback-key",
+        ),
+    ],
+)
+def test_get_arp_mac(entry: dict[str, Any], expected: str) -> None:
+    """Read normalized and raw ARP MAC keys through one helper."""
+    assert get_arp_mac(entry) == expected
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        pytest.param({"ip": " 192.0.2.1 "}, "192.0.2.1", id="normalized-key"),
+        pytest.param({"ip-address": " 192.0.2.2 "}, "192.0.2.2", id="raw-key"),
+        pytest.param({"ip": 1}, "", id="invalid-value"),
+    ],
+)
+def test_get_arp_ip(entry: dict[str, Any], expected: str) -> None:
+    """Read and strip normalized and raw ARP IP keys through one helper."""
+    assert get_arp_ip(entry) == expected
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        pytest.param({"device": " nvme0 "}, "nvme0", id="device"),
+        pytest.param({"ident": " SERIAL-ONLY "}, "SERIAL-ONLY", id="ident-fallback"),
+        pytest.param(
+            {"device": "", "ident": "serial-only"},
+            "serial-only",
+            id="blank-device",
+        ),
+        pytest.param({"device": 1}, "", id="invalid-values"),
+    ],
+)
+def test_get_smart_device_name(entry: dict[str, Any], expected: str) -> None:
+    """Read SMART device identifiers from the shared helper."""
+    assert get_smart_device_name(entry) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"vhid": 1, "subnet": "192.0.2.1"},
+        {"vhid": " 2 ", "subnet": " 192.0.2.2 "},
+    ],
+)
+def test_is_usable_carp_vip_accepts_normalized_identity_without_interface(
+    value: dict[str, Any],
+) -> None:
+    """CARP VIP usability should accept integer/string VHIDs without interface names."""
+    assert is_usable_carp_vip(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        {},
+        [],
+        {"vhid": "", "subnet": "192.0.2.1"},
+        {"vhid": 1, "subnet": ""},
+        {"vhid": True, "subnet": "192.0.2.1"},
+    ],
+)
+def test_is_usable_carp_vip_rejects_missing_or_blank_identity(value: Any) -> None:
+    """CARP VIP usability should reject malformed or blank identity rows."""
+    assert is_usable_carp_vip(value) is False
+
+
+@pytest.mark.parametrize(
     (
         "throw_errors",
         "name",
@@ -89,6 +193,8 @@ def test_create_opnsense_client_builds_client_with_expected_options(
         return MagicMock()
 
     class _CookieJar:
+        """Fake aiohttp cookie jar that records its safety setting."""
+
         def __init__(self, *, unsafe: bool) -> None:
             """Capture the unsafe flag without requiring a running event loop."""
             self._unsafe = unsafe
@@ -243,3 +349,22 @@ def test_firewall_nat_switch_unique_ids_from_payload_builds_nat_ids() -> None:
         "deviceid_firewall_nat_source_nat_uuid_2",
         "deviceid_firewall_nat_source_nat_r4",
     }
+
+
+def test_entry_type_and_identity_helpers(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Validate config entry identity rules for device and CARP entries."""
+    device_entry = make_config_entry(
+        entry_id="device-entry",
+        data={CONF_DEVICE_UNIQUE_ID: "aa_bb_cc_dd_ee_ff"},
+    )
+    carp_entry = make_config_entry(
+        entry_id="carp-entry",
+        data={CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
+    )
+
+    assert is_carp_entry(device_entry) is False
+    assert config_entry_identity(device_entry) == "aa_bb_cc_dd_ee_ff"
+    assert is_carp_entry(carp_entry) is True
+    assert config_entry_identity(carp_entry) == "carp-entry"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,7 @@ from custom_components.opnsense.helpers import (
     config_entry_identity,
     create_opnsense_client,
     create_opnsense_client_from_config_entry,
+    dict_get,
     firewall_nat_switch_unique_ids_from_payload,
     firewall_rule_id_from_payload,
     firewall_rule_switch_unique_ids_from_payload,
@@ -30,6 +31,21 @@ from custom_components.opnsense.helpers import (
     is_usable_carp_vip,
     normalize_arp_mac,
 )
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        pytest.param("items.1.name", "second", id="valid-index"),
+        pytest.param("items.invalid.name", "missing", id="invalid-segment"),
+        pytest.param("items.2.name", "missing", id="out-of-range-index"),
+    ],
+)
+def test_dict_get_traverses_list_indexes(path: str, expected: str) -> None:
+    """Traverse list indexes safely when resolving dotted paths."""
+    data = {"items": [{"name": "first"}, {"name": "second"}]}
+
+    assert dict_get(data, path, "missing") == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -394,6 +394,42 @@ async def test_async_setup_entry_carp_entry_retries_on_transient_validation_fail
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_carp_reraises_connection_error_subclass(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP setup must preserve specialized connection failures."""
+
+    class SpecializedConnectionError(OPNsenseConnectionError):
+        """Connection failure carrying more specific client semantics."""
+
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=SpecializedConnectionError("specialized"))
+    client.async_close = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", MagicMock(return_value=client)
+    )
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    hass = cast("MagicMock", ph_hass)
+    hass.data = {}
+
+    with pytest.raises(SpecializedConnectionError, match="specialized"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "initial_data",
     [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1860,16 +1860,19 @@ async def test_async_update_listener_reload_and_remove(
 
 
 @pytest.mark.asyncio
-async def test_async_update_listener_removes_native_firewall_entities(
+@pytest.mark.parametrize(("sync_enabled", "expect_removed"), [(False, True), (True, False)])
+async def test_async_update_listener_handles_native_firewall_entities_by_sync_state(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    sync_enabled: bool,
+    expect_removed: bool,
 ) -> None:
-    """Update listener should remove native firewall entities when sync is disabled."""
+    """Remove native firewall entities only when Firewall/NAT sync is disabled."""
     entry = make_config_entry(
         data={
             init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_FIREWALL_AND_NAT: sync_enabled,
         },
         unique_id="unit two",
     )
@@ -1912,7 +1915,10 @@ async def test_async_update_listener_removes_native_firewall_entities(
 
     await init_mod._async_update_listener(hass, entry)
 
-    entity_registry.async_remove.assert_called_once_with(ent.entity_id)
+    if expect_removed:
+        entity_registry.async_remove.assert_called_once_with(ent.entity_id)
+    else:
+        entity_registry.async_remove.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -563,20 +563,13 @@ async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "error",
-    [
-        pytest.param(init_mod.OPNsenseError("boom"), id="generic"),
-        pytest.param(OPNsenseTimeoutError("timed out"), id="timeout"),
-    ],
-)
 async def test_async_setup_entry_closes_client_when_validation_fails(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
-    error: init_mod.OPNsenseError,
 ) -> None:
     """async_setup_entry should close a constructed client when validation fails."""
+    error = init_mod.OPNsenseError("boom")
     client = MagicMock()
     client.validate = AsyncMock(side_effect=error)
     client.async_close = AsyncMock(return_value=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -559,6 +559,7 @@ async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.runtime_data is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,10 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
+    OPNsenseInvalidAuth,
+    OPNsenseInvalidURL,
+    OPNsensePrivilegeMissing,
+    OPNsenseSSLError,
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
@@ -598,6 +602,144 @@ async def test_async_setup_entry_closes_client_when_validation_fails(
     hass.data = {}
 
     with pytest.raises(type(error), match=str(error)):
+        await init_mod.async_setup_entry(hass, entry)
+
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_does_not_catch_raw_validation_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Validation timeout mapping belongs to aiopnsense, not setup-entry cleanup."""
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=TimeoutError)
+    client.async_close = AsyncMock(return_value=True)
+
+    def _create_client(**kwargs: Any) -> Any:
+        """Return the timeout-raising client for this setup-entry test."""
+        return client
+
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={},
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = AsyncMock()
+    hass.data = {}
+
+    with pytest.raises(TimeoutError):
+        await init_mod.async_setup_entry(hass, entry)
+
+    client.async_close.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "exc", [OPNsenseTimeoutError, OPNsenseConnectionError], ids=["timeout", "connection"]
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_retries_on_transient_validation_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    exc: type[BaseException],
+) -> None:
+    """Transient validation connection failures should trigger ConfigEntryNotReady."""
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=exc("timed out"))
+    client.async_close = AsyncMock(return_value=True)
+
+    def _create_client(**kwargs: Any) -> Any:
+        """Return the timeout-raising client for this setup-entry test."""
+        return client
+
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={},
+    )
+
+    hass = ph_hass
+    monkeypatch.setattr(
+        hass.config_entries, "async_forward_entry_setups", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(hass.config_entries, "async_reload", AsyncMock())
+    hass.data.clear()
+
+    with pytest.raises(ConfigEntryNotReady):
+        await init_mod.async_setup_entry(hass, entry)
+
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OPNsenseInvalidAuth,
+        OPNsensePrivilegeMissing,
+        OPNsenseSSLError,
+        OPNsenseInvalidURL,
+    ],
+    ids=[
+        "invalid_auth",
+        "privilege_missing",
+        "ssl_error",
+        "invalid_url",
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_does_not_retry_non_transient_validation_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    exc: type[BaseException],
+) -> None:
+    """Non-transient validation failures should bubble as hard errors."""
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=exc("invalid"))
+    client.async_close = AsyncMock(return_value=True)
+
+    def _create_client(**kwargs: Any) -> Any:
+        """Return the auth-failing client for this setup-entry test."""
+        return client
+
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={},
+    )
+
+    hass = ph_hass
+    monkeypatch.setattr(
+        hass.config_entries, "async_forward_entry_setups", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(hass.config_entries, "async_reload", AsyncMock())
+    hass.data.clear()
+
+    with pytest.raises(exc):
         await init_mod.async_setup_entry(hass, entry)
 
     client.async_close.assert_awaited_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -669,7 +669,7 @@ async def test_async_setup_entry_does_not_catch_raw_validation_timeout(
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Validation timeout mapping belongs to aiopnsense, not setup-entry cleanup."""
+    """Setup should close the client and re-raise a raw validation timeout."""
     client = MagicMock()
     client.validate = AsyncMock(side_effect=TimeoutError)
     client.async_close = AsyncMock(return_value=True)
@@ -698,7 +698,7 @@ async def test_async_setup_entry_does_not_catch_raw_validation_timeout(
     with pytest.raises(TimeoutError):
         await init_mod.async_setup_entry(hass, entry)
 
-    client.async_close.assert_not_awaited()
+    client.async_close.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -547,6 +547,9 @@ async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
         },
         options={},
     )
+    remove_listener = MagicMock()
+    entry.add_update_listener = MagicMock(return_value=remove_listener)
+    entry.async_on_unload = MagicMock(return_value=None)
     hass = ph_hass
     hass.data = {}
     hass.config_entries.async_forward_entry_setups = AsyncMock(
@@ -558,8 +561,67 @@ async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
 
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
+    entry.add_update_listener.assert_not_called()
+    entry.async_on_unload.assert_not_called()
+    remove_listener.assert_not_called()
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
     assert entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_carp_registers_update_listener_after_forwarding(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP update-listener registration should follow platform forwarding."""
+    call_order: list[str] = []
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    coordinator.data = {"carp": {"interfaces": [{"vhid": 1, "subnet": "192.0.2.1"}]}}
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    remove_listener = MagicMock()
+
+    def _add_update_listener(listener: Any) -> MagicMock:
+        """Record listener registration and return its removal callback."""
+        call_order.append("add_listener")
+        return remove_listener
+
+    def _async_on_unload(unregister: MagicMock) -> None:
+        """Record unload-callback registration."""
+        call_order.append("async_on_unload")
+
+    entry.add_update_listener = MagicMock(side_effect=_add_update_listener)
+    entry.async_on_unload = MagicMock(side_effect=_async_on_unload)
+
+    async def _forward_entry_setups(*_args: Any, **_kwargs: Any) -> bool:
+        """Record CARP platform forwarding and report success."""
+        call_order.append("forward")
+        return True
+
+    hass = ph_hass
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(side_effect=_forward_entry_setups)
+
+    assert await init_mod.async_setup_entry(hass, entry) is True
+
+    assert call_order == ["forward", "add_listener", "async_on_unload"]
+    entry.add_update_listener.assert_called_once_with(init_mod._async_update_listener)
+    entry.async_on_unload.assert_called_once_with(remove_listener)
+    remove_listener.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,21 +7,29 @@ and removal/unload behaviors for the hass-opnsense integration.
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any, Never
+from typing import Any, Never, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call
 
-from aiopnsense.exceptions import OPNsenseConnectionError, OPNsenseTimeoutError
-from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
+from aiopnsense.exceptions import (
+    OPNsenseBelowMinFirmware,
+    OPNsenseConnectionError,
+    OPNsenseTimeoutError,
+    OPNsenseUnknownFirmware,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.opnsense as opnsense_mod
 from custom_components.opnsense.const import (
+    CONF_ENTRY_TYPE,
     CONF_GRANULAR_SYNC_OPTIONS,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_TLS_INSECURE,
+    ENTRY_TYPE_CARP,
 )
 from tests.utilities import patch_opnsense_client
 
@@ -78,39 +86,31 @@ def test_align_aiopnsense_log_level_mirrors_opnsense_when_unset() -> None:
         aiopnsense_helper_logger.setLevel(original_aiopnsense_helper_level)
 
 
-def test_align_aiopnsense_log_level_keeps_explicit_aiopnsense_level() -> None:
-    """aiopnsense-specific logger configuration should remain authoritative."""
+@pytest.mark.parametrize(
+    ("opnsense_level", "aiopnsense_level", "expected_level"),
+    [
+        pytest.param(logging.DEBUG, logging.WARNING, logging.WARNING, id="explicit-aiopnsense"),
+        pytest.param(logging.NOTSET, logging.NOTSET, logging.NOTSET, id="both-unset"),
+    ],
+)
+def test_align_aiopnsense_log_level_preserves_setting(
+    opnsense_level: int,
+    aiopnsense_level: int,
+    expected_level: int,
+) -> None:
+    """Aiopnsense logger settings should remain authoritative when already set."""
     opnsense_logger = logging.getLogger("custom_components.opnsense")
     aiopnsense_logger = logging.getLogger("aiopnsense")
     original_opnsense_level = opnsense_logger.level
     original_aiopnsense_level = aiopnsense_logger.level
 
     try:
-        opnsense_logger.setLevel(logging.DEBUG)
-        aiopnsense_logger.setLevel(logging.WARNING)
+        opnsense_logger.setLevel(opnsense_level)
+        aiopnsense_logger.setLevel(aiopnsense_level)
 
         init_mod._align_aiopnsense_log_level()
 
-        assert aiopnsense_logger.level == logging.WARNING
-    finally:
-        opnsense_logger.setLevel(original_opnsense_level)
-        aiopnsense_logger.setLevel(original_aiopnsense_level)
-
-
-def test_align_aiopnsense_log_level_leaves_both_loggers_unset() -> None:
-    """Unset loggers should continue to inherit the root logger level."""
-    opnsense_logger = logging.getLogger("custom_components.opnsense")
-    aiopnsense_logger = logging.getLogger("aiopnsense")
-    original_opnsense_level = opnsense_logger.level
-    original_aiopnsense_level = aiopnsense_logger.level
-
-    try:
-        opnsense_logger.setLevel(logging.NOTSET)
-        aiopnsense_logger.setLevel(logging.NOTSET)
-
-        init_mod._align_aiopnsense_log_level()
-
-        assert aiopnsense_logger.level == logging.NOTSET
+        assert aiopnsense_logger.level == expected_level
     finally:
         opnsense_logger.setLevel(original_opnsense_level)
         aiopnsense_logger.setLevel(original_aiopnsense_level)
@@ -145,9 +145,9 @@ async def test_async_setup_entry_success(
     )
 
     # use migration fixture which may wrap the real hass or provide a MagicMock
-    hass = ph_hass
-    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    hass.config_entries.async_reload = AsyncMock()
+    hass = cast("MagicMock", ph_hass)
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    hass.config_entries.async_reload = AsyncMock()  # type: ignore[method-assign]
 
     # ensure hass.data is a real dict for the integration to populate
     hass.data = {}
@@ -204,7 +204,7 @@ async def test_async_setup_entry_validates_client_before_probes(
         options={},
     )
 
-    hass = ph_hass
+    hass = cast("MagicMock", ph_hass)
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
@@ -216,6 +216,345 @@ async def test_async_setup_entry_validates_client_before_probes(
         "get_device_unique_id",
         "get_host_firmware_version",
     ]
+    assert entry.runtime_data.device_unique_id == "dev1"
+    expected_platforms = [Platform.SENSOR, Platform.SWITCH, Platform.BINARY_SENSOR, Platform.UPDATE]
+    assert entry.runtime_data.loaded_platforms == expected_platforms
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_carp_entry_uses_identity_less_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP entries use identity-less coordinator state and Sensor-only platform setup."""
+    validate_calls: list[dict[str, Any]] = []
+    create_calls: dict[str, Any] = {}
+    client = MagicMock()
+    client.get_host_firmware_version = AsyncMock(return_value="99.0")
+
+    async def _validate(**kwargs: Any) -> bool:
+        """Record setup validation kwargs and return successful validation."""
+        validate_calls.append(kwargs)
+        return True
+
+    client.validate = _validate
+    client.get_device_unique_id = AsyncMock(return_value="ignore-me")
+    client.async_close = AsyncMock(return_value=True)
+
+    def _create_client(**kwargs: Any) -> Any:
+        """Record how the client factory is called and return the fake client."""
+        create_calls.update(kwargs)
+        return client
+
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
+
+    captured = {}
+
+    class _CarpCoordinator:
+        """Fake coordinator used to exercise CARP setup without polling."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            """Capture coordinator construction kwargs for CARP assertions."""
+            captured.update(kwargs)
+            self.data = {"carp": {"interfaces": [{"vhid": 1, "subnet": "192.0.2.1"}]}}
+
+        async def async_config_entry_first_refresh(self) -> bool:
+            """Complete the coordinator's initial refresh protocol."""
+            return True
+
+        async def async_shutdown(self) -> bool:
+            """Complete the coordinator's shutdown protocol."""
+            return True
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _CarpCoordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+
+    hass = cast("MagicMock", ph_hass)
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    hass.config_entries.async_reload = MagicMock()  # type: ignore[method-assign]
+    hass.data = {}
+
+    res = await init_mod.async_setup_entry(hass, entry)
+    assert res is True
+    assert create_calls.get("hass") is hass
+    assert create_calls.get("config_entry") is entry
+    assert create_calls.get("throw_errors", False) is False
+    assert captured["device_unique_id"] is None
+    assert captured["config_entry"] is entry
+    assert validate_calls == [{"require_device_id": False}]
+    client.get_device_unique_id.assert_not_awaited()
+    client.get_host_firmware_version.assert_not_awaited()
+
+    assert entry.runtime_data.device_unique_id is None
+    assert entry.runtime_data.loaded_platforms == init_mod.CARP_PLATFORMS
+    assert entry.runtime_data.device_tracker_coordinator is None
+    assert hass.config_entries.async_forward_entry_setups.await_count == 1  # type: ignore[union-attr]
+    hass.config_entries.async_forward_entry_setups.assert_awaited_with(entry, [Platform.SENSOR])  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware])
+async def test_async_setup_entry_carp_validation_firmware_errors_fail_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    exc: type[Exception],
+) -> None:
+    """CARP setup must fail fast on firmware validation exceptions."""
+    coordinator = AsyncMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
+    coordinator.async_shutdown = AsyncMock(return_value=True)
+    coordinator.data = {"carp": {"interfaces": [{"vhid": 1, "subnet": "192.0.2.1"}]}}
+    coordinator_factory = MagicMock(return_value=coordinator)
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=exc("firmware"))
+    client.async_close = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", coordinator_factory)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+
+    hass = ph_hass
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+    with pytest.raises(exc):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator_factory.assert_not_called()
+    hass.config_entries.async_forward_entry_setups.assert_not_awaited()
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [OPNsenseTimeoutError, OPNsenseConnectionError],
+    ids=["timeout", "connection"],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_carp_entry_retries_on_transient_validation_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    exc: type[BaseException],
+) -> None:
+    """CARP setup should retry on transient validation transport failures."""
+    client = MagicMock()
+    client.validate = AsyncMock(side_effect=exc("transient"))
+    client.async_close = AsyncMock(return_value=True)
+
+    create_client = MagicMock(return_value=client)
+    coordinator_factory = MagicMock()
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", create_client)
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", coordinator_factory)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+
+    hass = cast("MagicMock", ph_hass)
+    hass.data = {}
+
+    with pytest.raises(ConfigEntryNotReady):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator_factory.assert_not_called()
+    create_client.assert_called_once()
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_data",
+    [
+        {},
+        {"carp": {}},
+        {"carp": {"interfaces": []}},
+        {"carp": {"interfaces": [{}]}},
+    ],
+)
+async def test_async_setup_entry_carp_requires_usable_initial_vip_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    initial_data: dict[str, Any],
+) -> None:
+    """CARP setup should retry when the first refresh has no usable VIP inventory."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    coordinator.data = initial_data
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    hass = ph_hass
+    hass.data = {init_mod.DOMAIN: {entry.entry_id: client}}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+    with pytest.raises(ConfigEntryNotReady, match="usable CARP VIP"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    hass.config_entries.async_forward_entry_setups.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "interface",
+    [
+        {"vhid": 1, "subnet": "192.0.2.1"},
+        {"vhid": " 2 ", "subnet": " 192.0.2.2 "},
+    ],
+)
+async def test_async_setup_entry_carp_accepts_usable_initial_vip_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    interface: dict[str, Any],
+) -> None:
+    """CARP setup should forward platforms when the first inventory has a usable VIP."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    coordinator.data = {"carp": {"interfaces": [interface]}}
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    hass = ph_hass
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+    assert await init_mod.async_setup_entry(hass, entry) is True
+
+    coordinator.async_shutdown.assert_not_awaited()
+    client.async_close.assert_not_awaited()
+    hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
+        entry, [Platform.SENSOR]
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_carp_first_refresh_failure_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP setup should stop its coordinator, close the client, and remove hass data."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    coordinator.async_config_entry_first_refresh.side_effect = RuntimeError("refresh failed")
+    coordinator.data = {"carp": {"interfaces": [{"vhid": 1, "subnet": "192.0.2.1"}]}}
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    hass = ph_hass
+    hass.data = {init_mod.DOMAIN: {entry.entry_id: client}}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+
+    with pytest.raises(RuntimeError, match="refresh failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    hass.config_entries.async_forward_entry_setups.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP platform-forward failures should clean up runtime state and the client."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    coordinator.data = {"carp": {"interfaces": [{"vhid": 1, "subnet": "192.0.2.1"}]}}
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        options={},
+    )
+    hass = ph_hass
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock(
+        side_effect=RuntimeError("CARP platform forwarding failed")
+    )
+
+    with pytest.raises(RuntimeError, match="CARP platform forwarding failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
 
 
 @pytest.mark.asyncio
@@ -1438,19 +1777,38 @@ async def test_async_setup_calls_services_and_handles_exceptions(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_id", "entry_data", "entry_unique_id", "entity_unique_id_prefix"),
+    [
+        (
+            "device-entry",
+            {init_mod.CONF_DEVICE_UNIQUE_ID: "dev1", "sync_telemetry": False},
+            "stale-device-id",
+            "dev1",
+        ),
+        (
+            "carp-entry",
+            {CONF_ENTRY_TYPE: ENTRY_TYPE_CARP, "sync_telemetry": False},
+            None,
+            "carp_entry",
+        ),
+    ],
+)
 async def test_async_update_listener_reload_and_remove(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    entry_id: str,
+    entry_data: dict[str, Any],
+    entry_unique_id: str | None,
+    entity_unique_id_prefix: str,
 ) -> None:
-    """When SHOULD_RELOAD True and sync disabled, update listener schedules reload and removes entities."""
+    """Remove disabled entities using the same identity prefix as entity creation."""
     # Prepare entry with SHOULD_RELOAD True and granular sync option disabled to force removal_prefixes
     entry = make_config_entry(
-        data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            "sync_telemetry": False,
-        },
-        unique_id="unit one",
+        entry_id=entry_id,
+        data=entry_data,
+        unique_id=entry_unique_id,
     )
     setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
     # config entries and hass async reload stub
@@ -1461,6 +1819,8 @@ async def test_async_update_listener_reload_and_remove(
 
     # construct an entity that should be removed by unique_id prefix
     class Ent:
+        """Minimal entity registry entry used by listener cleanup tests."""
+
         def __init__(self, entity_id: Any, unique_id: Any) -> None:
             """Store the entity and unique IDs used by the update-listener test."""
             self.entity_id = entity_id
@@ -1470,10 +1830,7 @@ async def test_async_update_listener_reload_and_remove(
     # explicitly use the 'sync_telemetry' prefix so the test targets the intended sync item
     prefix = list(init_mod.GRANULAR_SYNC_PREFIX["sync_telemetry"])
     pre = prefix[0]
-    ent = Ent(
-        "sensor.x",
-        f"{slugify(entry.data[init_mod.CONF_DEVICE_UNIQUE_ID])}_{pre}_suffix",
-    )
+    ent = Ent("sensor.x", f"{entity_unique_id_prefix}_{pre}_suffix")
 
     # monkeypatch entity registry functions
     er_reg = MagicMock()
@@ -2405,6 +2762,8 @@ async def test_async_setup_entry_awesomeversion_exception(
     # fake client where device id matches but awesomeversion comparison raises
     # monkeypatch AwesomeVersion to a class that raises on comparison
     class DummyAV:
+        """AwesomeVersion replacement that raises on comparisons."""
+
         def __init__(self, v: Any) -> None:
             """Store the version string used by the comparison stub."""
             self.v = v
@@ -2675,6 +3034,8 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
     """_migrate_3_to_4 should defer filesystem remaps when telemetry is invalid."""
 
     class Client:
+        """Fake client returning invalid telemetry during migration."""
+
         async def get_telemetry(self) -> None:
             """Return an invalid telemetry payload for migration hardening."""
             return
@@ -3401,16 +3762,38 @@ async def test_async_setup_entry_registers_update_listener_after_forwarding(
     remove_listener = MagicMock()
 
     def _add_update_listener(listener: Any) -> MagicMock:
+        """Record listener registration and return the removal callback.
+
+        Args:
+            listener: Update listener registered on the config entry.
+
+        Returns:
+            MagicMock: Callback used to unregister the listener.
+        """
         call_order.append("add_listener")
         return remove_listener
 
     def _async_on_unload(unregister: MagicMock) -> None:
+        """Record when Home Assistant registers the unload callback.
+
+        Args:
+            unregister: Unload callback passed by the config entry.
+        """
         call_order.append("async_on_unload")
 
     entry.add_update_listener = MagicMock(side_effect=_add_update_listener)
     entry.async_on_unload = MagicMock(side_effect=_async_on_unload)
 
     async def _forward_entry_setups(*_args: Any, **_kwargs: Any) -> bool:
+        """Record platform forwarding and report success.
+
+        Args:
+            *_args: Positional setup arguments ignored by the stub.
+            **_kwargs: Keyword setup arguments ignored by the stub.
+
+        Returns:
+            bool: Always ``True`` for the test setup path.
+        """
         call_order.append("forward")
         return True
 
@@ -3442,6 +3825,8 @@ async def test_migrate_2_to_3_handles_identifier_collision(
     dev.identifiers = {("opnsense", "old")}
 
     class DeviceRegistry:
+        """Fake device registry that raises identifier collisions."""
+
         def __init__(self) -> None:
             """Provide a fake device registry object for the collision test."""
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -196,9 +196,25 @@ def _build_mock_hass() -> Any:
 
     # config_entries API surface used inside tests
     class _Cfg:
+        """Minimal config-entry registry used by integration tests."""
+
         def __init__(self) -> None:
             """Initialize _Cfg."""
             self._entries: dict[str, Any] = {}
+
+        def async_entries(self, domain: str | None = None) -> list[MockConfigEntry]:
+            """Return config entries matching domain.
+
+            Args:
+                domain: Domain name used to filter registry entries.
+            """
+            if domain is None:
+                return list(self._entries.values())
+            return [
+                entry
+                for entry in self._entries.values()
+                if getattr(entry, "domain", None) == domain
+            ]
 
         def async_update_entry(
             self,
@@ -294,8 +310,8 @@ async def test_e2e_basic_config_flow_and_setup(
     object.__setattr__(flow, "_abort_if_unique_id_configured", lambda: None)
 
     user_input = _make_basic_user_input()
-    # Run user step -> should create entry directly (no granular sync)
-    result = await flow.async_step_user(user_input=user_input)
+    # Run device step -> should create entry directly (no granular sync)
+    result = await flow.async_step_device(user_input=user_input)
     assert result["type"] == "create_entry"
     data = result["data"]
     assert data[CONF_DEVICE_UNIQUE_ID] == "dev-basic"
@@ -367,10 +383,10 @@ async def test_e2e_granular_sync_and_options_device_tracker(
     object.__setattr__(flow, "async_set_unique_id", _noop_unique_id)
     object.__setattr__(flow, "_abort_if_unique_id_configured", lambda: None)
 
-    # Step 1: user chooses granular sync
+    # Step 1: device step chooses granular sync
     user_input = _make_basic_user_input()
     user_input[CONF_GRANULAR_SYNC_OPTIONS] = True
-    res1 = await flow.async_step_user(user_input=user_input)
+    res1 = await flow.async_step_device(user_input=user_input)
     assert res1["type"] == "form" and res1["step_id"] == "granular_sync"
 
     # Step 2: granular sync submission (empty -> defaults True)
@@ -397,6 +413,14 @@ async def test_e2e_granular_sync_and_options_device_tracker(
         hass.config_entries._entries = {entry.entry_id: entry}
 
         def _get_known_entry(entry_id: str) -> MockConfigEntry | None:
+            """Return the fake config entry registered under an ID.
+
+            Args:
+                entry_id: Config-entry identifier to look up.
+
+            Returns:
+                MockConfigEntry | None: Matching fake entry, if registered.
+            """
             return hass.config_entries._entries.get(entry_id)
 
         hass.config_entries.async_get_known_entry = _get_known_entry
@@ -484,7 +508,7 @@ async def test_e2e_reload_and_unload(
     object.__setattr__(flow, "async_set_unique_id", _noop_unique_id)
     object.__setattr__(flow, "_abort_if_unique_id_configured", lambda: None)
 
-    result = await flow.async_step_user(user_input=_make_basic_user_input())
+    result = await flow.async_step_device(user_input=_make_basic_user_input())
     data = result["data"]
 
     # Runtime path patches
@@ -553,12 +577,16 @@ async def test_e2e_full_migration_chain(
 
     # Fake device & entity registry implementations
     class FakeDevice:
+        """Minimal device registry item used by migration tests."""
+
         def __init__(self, id_: str, identifiers: set[tuple[str, str]]) -> None:
             """Initialize FakeDevice."""
             self.id = id_
             self.identifiers = identifiers
 
     class FakeDeviceRegistry:
+        """Fake device registry that records identifier updates."""
+
         def __init__(self) -> None:
             """Initialize FakeDeviceRegistry."""
             self._devices: list[FakeDevice] = [
@@ -585,6 +613,8 @@ async def test_e2e_full_migration_chain(
             raise ValueError("device not found")
 
     class FakeEntity:
+        """Minimal entity registry item used by migration tests."""
+
         def __init__(self, entity_id: str, unique_id: str, device_id: str) -> None:
             """Initialize FakeEntity.
 
@@ -598,6 +628,8 @@ async def test_e2e_full_migration_chain(
             self.device_id = device_id
 
     class FakeEntityRegistry:
+        """Fake entity registry that stores migration test entities."""
+
         def __init__(self) -> None:
             """Initialize FakeEntityRegistry."""
             self._entities: dict[str, FakeEntity] = {}
@@ -684,6 +716,8 @@ async def test_e2e_full_migration_chain(
     migration_clients: list[Any] = []
 
     class _MigClient:
+        """Fake client used across the migration chain."""
+
         def __init__(self) -> None:
             """Track migration client instances created during the migration chain."""
             self.close_calls = 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,11 @@ from collections.abc import Callable, Iterable
 from typing import Any, Never, cast
 from unittest.mock import MagicMock
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -25,8 +29,10 @@ from custom_components.opnsense.const import (
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.sensor import (
+    OPNsenseCarpActiveResponderSensor,
     OPNsenseCarpInterfaceSensor,
     OPNsenseCarpStatusSensor,
+    OPNsenseCarpVipSensor,
     OPNsenseDHCPLeasesSensor,
     OPNsenseFilesystemSensor,
     OPNsenseGatewaySensor,
@@ -41,6 +47,11 @@ from custom_components.opnsense.sensor import (
     normalize_filesystem_mountpoint,
     slugify_filesystem_mountpoint,
 )
+
+
+def _carp_entry_sensor_unique_id(entry: MockConfigEntry, key: str) -> str:
+    """Return the repository-normalized unique ID for a CARP entry sensor."""
+    return sensor_module.slugify(f"{entry.entry_id}_{key}")
 
 
 def test_static_sensor_descriptions_live_in_sensor_module() -> None:
@@ -77,6 +88,191 @@ async def test_async_setup_entry_invalid_state(
 
     await async_setup_entry(MagicMock(), config_entry, cast("AddEntitiesCallback", add_entities))
     assert called is False
+
+
+@pytest.mark.asyncio
+async def test_carp_entry_setup_has_exact_read_only_vip_inventory(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP entries should expose only the responder, summary, and VIP sensors."""
+    entry = make_config_entry(
+        data={"entry_type": "carp"},
+        entry_id="carp-entry",
+        title="CARP VIP",
+    )
+    state: dict[str, Any] = {
+        "system_info": {"name": "node-a"},
+        "carp": {
+            "interfaces": [
+                {"vhid": 1, "subnet": "192.0.2.1", "interface": "igc0", "status": "BACKUP"},
+                {
+                    "vhid": "2",
+                    "subnet": "198.51.100.1",
+                    "interface": "igc1",
+                    "status": "MASTER",
+                },
+            ],
+            "status_summary": {"state": "healthy"},
+        },
+    }
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Collect entities created by the sensor platform."""
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+
+    keys = {entity.entity_description.key for entity in created}
+    expected_keys = {
+        "carp.active_responder",
+        "carp.status_summary",
+        sensor_module._build_carp_vip_sensor_key("1", "192.0.2.1"),
+        sensor_module._build_carp_vip_sensor_key("2", "198.51.100.1"),
+    }
+    expected_unique_ids = {_carp_entry_sensor_unique_id(entry, key) for key in expected_keys}
+    assert keys == expected_keys
+    assert {entity.unique_id for entity in created} == expected_unique_ids
+    descriptions = {entity.entity_description.key: entity.entity_description for entity in created}
+    assert descriptions["carp.active_responder"].translation_key == "carp_active_responder"
+    assert descriptions["carp.status_summary"].translation_key == "carp_status_summary"
+    vip_descriptions = [
+        description for key, description in descriptions.items() if key.startswith("carp.vip.")
+    ]
+    assert {description.translation_key for description in vip_descriptions} == {"carp_vip"}
+    assert all(
+        set(description.translation_placeholders or {}) == {"subnet", "vhid"}
+        for description in vip_descriptions
+    )
+    assert all(
+        entity.entity_description.entity_registry_enabled_default is False
+        for entity in created
+        if entity.entity_description.key.startswith("carp.vip.")
+    )
+    assert isinstance(
+        next(
+            entity for entity in created if entity.entity_description.key == "carp.active_responder"
+        ),
+        OPNsenseCarpActiveResponderSensor,
+    )
+    assert all(
+        isinstance(entity, OPNsenseCarpVipSensor)
+        for entity in created
+        if entity.entity_description.key.startswith("carp.vip.")
+    )
+    assert all(entity.entity_description.key.startswith("carp.") for entity in created)
+
+
+@pytest.mark.asyncio
+async def test_carp_entry_failover_keeps_vip_identity_and_updates_responder(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP failover should update the responder while retaining each VIP entity."""
+    entry = make_config_entry(
+        data={"entry_type": "carp"},
+        entry_id="carp-entry",
+        title="CARP VIP",
+    )
+    state: dict[str, Any] = {
+        "system_info": {"name": "node-a"},
+        "carp": {
+            "interfaces": [
+                {
+                    "vhid": 1,
+                    "subnet": "192.0.2.1",
+                    "interface": "igc0",
+                    "status": "BACKUP",
+                    "advskew": 100,
+                    "advbase": 1,
+                    "subnet_bits": 24,
+                    "descr": "Primary VIP",
+                    "mode": "carp",
+                }
+            ],
+            "status_summary": {"state": "healthy"},
+        },
+    }
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Collect entities created by the sensor platform."""
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+    responder = next(
+        entity for entity in created if entity.entity_description.key == "carp.active_responder"
+    )
+    vip = next(
+        entity for entity in created if entity.entity_description.key.startswith("carp.vip.")
+    )
+    initial_unique_id = vip.unique_id
+    for entity in (responder, vip):
+        entity.hass = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", lambda: None)
+        entity._handle_coordinator_update()
+
+    assert responder.native_value == "node-a"
+    assert responder.extra_state_attributes == {}
+    assert vip.available is True
+    assert vip.native_value == "BACKUP"
+    assert vip.icon == "mdi:backup-restore"
+
+    state["system_info"]["name"] = "node-b"
+    state["carp"]["interfaces"][0]["interface"] = "ix0"
+    state["carp"]["interfaces"][0]["status"] = "MASTER"
+    responder._handle_coordinator_update()
+    vip._handle_coordinator_update()
+
+    assert responder.native_value == "node-b"
+    assert vip.available is True
+    assert vip.native_value == "MASTER"
+    assert vip.icon == "mdi:check-network"
+    assert vip.unique_id == initial_unique_id
+    assert vip.extra_state_attributes is not None
+    assert vip.extra_state_attributes == {
+        "interface": "ix0",
+        "vhid": 1,
+        "advskew": 100,
+        "advbase": 1,
+        "subnet_bits": 24,
+        "subnet": "192.0.2.1",
+        "descr": "Primary VIP",
+        "mode": "carp",
+    }
+
+
+@pytest.mark.parametrize("system_info", [{}, {"name": None}, {"name": ""}, {"name": "  "}])
+def test_carp_active_responder_unavailable_without_name(
+    system_info: dict[str, Any],
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """The active responder sensor should fail closed for missing or blank names."""
+    entry = make_config_entry(data={"entry_type": "carp"}, entry_id="carp-entry")
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"system_info": system_info}
+    sensor = OPNsenseCarpActiveResponderSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=SensorEntityDescription(
+            key="carp.active_responder",
+            name="Active CARP Responder",
+            translation_key="carp_active_responder",
+        ),
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.carp_active_responder_unavailable"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+    assert sensor.extra_state_attributes == {}
 
 
 @pytest.mark.asyncio
@@ -906,6 +1102,96 @@ def test_build_carp_interface_sensor_key(
 
 
 @pytest.mark.parametrize(
+    ("subnet", "equivalent_subnet"),
+    [
+        ("192.0.2.1/32", "192.0.2.1"),
+        (
+            "2001:db8::1/128",
+            "2001:0db8:0000:0000:0000:0000:0000:0001",
+        ),
+    ],
+)
+def test_build_carp_vip_sensor_key_normalizes_equivalent_subnet_text(
+    subnet: str,
+    equivalent_subnet: str,
+) -> None:
+    """Equivalent subnet text forms should map to the same CARP VIP key."""
+    assert sensor_module._build_carp_vip_sensor_key(
+        "7", subnet
+    ) == sensor_module._build_carp_vip_sensor_key("7", equivalent_subnet)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_subnet", "updated_subnet"),
+    [
+        ("192.0.2.1/32", "192.0.2.1"),
+        (
+            "2001:DB8::0001",
+            "2001:db8::1",
+        ),
+    ],
+)
+async def test_carp_vip_sensor_matches_canonicalized_subnet_identity_on_updates(
+    make_config_entry: Callable[..., MockConfigEntry],
+    initial_subnet: str,
+    updated_subnet: str,
+) -> None:
+    """CARP VIP updates should match across textual subnet variants."""
+    entry = make_config_entry(
+        data={"entry_type": "carp"},
+        entry_id="carp-entry",
+        title="CARP VIP",
+    )
+    state: dict[str, Any] = {
+        "carp": {
+            "interfaces": [
+                {
+                    "vhid": "1",
+                    "subnet": initial_subnet,
+                    "status": "BACKUP",
+                    "interface": "igc0",
+                }
+            ],
+            "status_summary": {"state": "healthy"},
+        }
+    }
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+    created: list[Any] = []
+
+    def add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Collect entities created by async_setup_entry."""
+        created.extend(entities)
+
+    await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
+    vip = next(
+        entity for entity in created if entity.entity_description.key.startswith("carp.vip.")
+    )
+    initial_unique_id = vip.unique_id
+    object.__setattr__(vip, "hass", MagicMock())
+    object.__setattr__(vip, "async_write_ha_state", lambda: None)
+
+    vip._handle_coordinator_update()
+    assert vip.native_value == "BACKUP"
+    assert vip.extra_state_attributes is not None
+    assert vip.extra_state_attributes["subnet"] == initial_subnet
+
+    state["carp"]["interfaces"][0]["subnet"] = updated_subnet
+    state["carp"]["interfaces"][0]["status"] = "MASTER"
+    vip._handle_coordinator_update()
+
+    assert vip.unique_id == initial_unique_id
+    assert vip.native_value == "MASTER"
+    assert vip.extra_state_attributes is not None
+    assert vip.extra_state_attributes["subnet"] == updated_subnet
+    assert vip.entity_description.key == sensor_module._build_carp_vip_sensor_key(
+        "1", updated_subnet
+    )
+
+
+@pytest.mark.parametrize(
     ("key", "expected"),
     [
         ("carp.interface.wan.203_0_113_10", ("wan", "203_0_113_10")),
@@ -1312,6 +1598,8 @@ def test_vpn_sensor_handles_exceptions_from_instance_get(
     """
 
     class BrokenInstance(dict):
+        """Mapping that raises from ``get`` for sensor error-path testing."""
+
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenInstance.
 
@@ -1456,42 +1744,29 @@ def test_temp_sensor_basic_variants(
             assert attrs.get("device_id") == "dev0"
 
 
-def test_temp_sensor_key_malformed_key_marked_unavailable(
+@pytest.mark.parametrize(
+    "description_key",
+    [
+        pytest.param("telemetry.temps", id="missing-sensor-key"),
+        pytest.param("foo.bar.sensor1", id="wrong-prefix"),
+    ],
+)
+def test_temp_sensor_invalid_description_key_marked_unavailable(
+    description_key: str,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Malformed temp sensor keys should fail closed to unavailable instead of raising."""
+    """Invalid temp sensor keys should fail closed to unavailable instead of raising."""
     coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord.data = {"telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}}}
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = "telemetry.temps"
-    desc.name = "Malformed Temp Key"
+    desc.key = description_key
+    desc.name = "Invalid Temp Key"
 
     s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
     s.hass = MagicMock()
-    s.entity_id = "sensor.temp_malformed_key"
-    object.__setattr__(s, "async_write_ha_state", lambda: None)
-    s._handle_coordinator_update()
-
-    assert s.available is False
-
-
-def test_temp_sensor_key_wrong_prefix_marked_unavailable(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Wrong key prefix should fail closed even when matching telemetry value exists."""
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}}}
-    entry = make_config_entry()
-
-    desc = MagicMock()
-    desc.key = "foo.bar.sensor1"
-    desc.name = "Wrong Prefix Temp Key"
-
-    s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
-    s.hass = MagicMock()
-    s.entity_id = "sensor.temp_wrong_prefix_key"
+    s.entity_id = "sensor.temp_invalid_key"
     object.__setattr__(s, "async_write_ha_state", lambda: None)
     s._handle_coordinator_update()
 
@@ -1533,6 +1808,8 @@ def test_temp_sensor_handles_index_exceptions(
     """Temp sensor should mark itself unavailable when indexing temp raises exceptions."""
 
     class BrokenTemp:
+        """Value object that raises when indexed by the temperature sensor."""
+
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenTemp.
 
@@ -2312,6 +2589,8 @@ def test_dhcp_leases_handles_exceptions(
     """
 
     class BrokenLease:
+        """Lease mapping that raises from ``get`` for error-path testing."""
+
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenLease.
 
@@ -2361,6 +2640,8 @@ def test_dhcp_lease_interfaces_items_raises(
     """Ensure exceptions raised by lease_interfaces.items() are caught and sensor becomes unavailable."""
 
     class BrokenLeaseInterfaces(dict):
+        """Lease-interface mapping that raises while iterating items."""
+
         def items(self) -> Never:
             """Raise the parametrized exception when lease interfaces are iterated.
 
@@ -2398,6 +2679,8 @@ def test_dhcp_leases_iterable_raises_on_iter(
     """Ensure exceptions raised while iterating the leases list are caught and sensor becomes unavailable."""
 
     class BrokenLeaseList(list):
+        """Lease list that raises when the sensor begins iteration."""
+
         def __iter__(self) -> Never:
             """Raise the parametrized exception when the lease list is iterated.
 
@@ -2438,6 +2721,8 @@ def test_dhcp_leases_inner_except_writes_unavailable(
     """
 
     class BrokenLease:
+        """Lease mapping that raises during the inner aggregation loop."""
+
         def get(self, *args, **kwargs) -> Never:
             """Raise ``KeyError`` when the sensor reads the lease mapping.
 
@@ -2486,6 +2771,8 @@ def test_dhcp_leases_items_except_writes_unavailable(
     """Verify exceptions from lease_interfaces.items() cause unavailable state and write."""
 
     class BrokenLeaseInterfaces(dict):
+        """Lease-interface mapping that raises during item iteration."""
+
         def items(self) -> Never:
             """Raise ``KeyError`` when interface items are requested.
 
@@ -2535,6 +2822,8 @@ def test_dhcp_leases_per_interface_handles_exceptions(
     """
 
     class BrokenLease(dict):
+        """Lease mapping that raises while reading per-interface data."""
+
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenLease.
 
@@ -2762,6 +3051,7 @@ class _BadDHCPLeaseInterfaces(dict):
     """Mapping that raises when items() is queried."""
 
     def items(self) -> Never:  # type: ignore[override]
+        """Raise when the compiler queries interface items."""
         raise RuntimeError("items failure for test")
 
 
@@ -3812,6 +4102,43 @@ async def test_async_setup_entry_creates_smart_disk_sensors_by_default(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_creates_smart_disk_sensors_from_ident_only_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART temperature sensors should be compiled when rows provide `ident` only."""
+    smart_entities = await _async_setup_smart_entities(
+        make_config_entry,
+        {
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_CERTIFICATES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: True,
+        },
+        {
+            "smart": [{"ident": "SERIAL-ONLY"}],
+            "smart_info": {"SERIAL-ONLY": {"temperature": {"current": 58}}},
+        },
+    )
+
+    assert {entity.entity_description.key for entity in smart_entities} == {
+        "smart.serial_only.temperature",
+    }
+    entity = smart_entities[0]
+    _prepare_smart_sensor(entity)
+    entity._handle_coordinator_update()
+
+    assert entity.available is True
+    assert entity.native_value == 58
+    assert entity.extra_state_attributes == {"ident": "SERIAL-ONLY"}
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_creates_smart_temperature_sensors_from_smart_info(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -4090,6 +4417,26 @@ def test_smart_sensor_strips_device_name_before_smart_info_lookup(
 
     assert sensor.available is True
     assert sensor.native_value == 37
+
+
+def test_smart_sensor_uses_ident_when_device_missing(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sensors should identify rows using `ident` when `device` is absent."""
+    sensor = _build_smart_sensor(
+        make_config_entry,
+        {
+            "smart": [{"ident": "SERIAL-ONLY"}],
+            "smart_info": {"SERIAL-ONLY": {"temperature": {"current": 58}}},
+        },
+        "smart.serial_only.temperature",
+    )
+    _prepare_smart_sensor(sensor, "sensor.smart_serial_only_temperature")
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == 58
+    assert sensor.extra_state_attributes == {"ident": "SERIAL-ONLY"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -167,6 +167,33 @@ async def test_carp_entry_setup_has_exact_read_only_vip_inventory(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_data", "expected_translation_key"),
+    [
+        ({}, None),
+        ({"entry_type": "carp"}, "carp_status_summary"),
+    ],
+)
+async def test_carp_status_description_preserves_entry_mode_naming(
+    entry_data: dict[str, Any],
+    expected_translation_key: str | None,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP status should keep legacy device naming and translated CARP naming."""
+    entry = make_config_entry(data=entry_data)
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"carp": {"status_summary": {"state": "healthy"}}}
+
+    entities = await sensor_module._compile_carp_status_sensor(entry, coordinator, coordinator.data)
+
+    assert len(entities) == 1
+    sensor = entities[0]
+    assert sensor.entity_description.translation_key == expected_translation_key
+    if expected_translation_key is None:
+        assert sensor.name == "CARP Status"
+
+
+@pytest.mark.asyncio
 async def test_carp_entry_failover_keeps_vip_identity_and_updates_responder(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -245,6 +272,58 @@ async def test_carp_entry_failover_keeps_vip_identity_and_updates_responder(
         "descr": "Primary VIP",
         "mode": "carp",
     }
+
+
+@pytest.mark.parametrize(
+    "unavailable_scenario",
+    ["malformed_key", "disappeared_vip", "missing_status"],
+)
+def test_carp_vip_sensor_clears_attributes_when_becoming_unavailable(
+    unavailable_scenario: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """A CARP VIP should not retain attributes after its payload becomes unusable."""
+    entry = make_config_entry(data={"entry_type": "carp"}, entry_id="carp-entry")
+    interface = {
+        "vhid": 1,
+        "subnet": "192.0.2.1",
+        "interface": "igc0",
+        "status": "MASTER",
+    }
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"carp": {"interfaces": [interface]}}
+    description = MagicMock(spec=SensorEntityDescription)
+    description.key = sensor_module._build_carp_vip_sensor_key("1", "192.0.2.1")
+    description.name = "CARP VIP 192.0.2.1 (VHID 1)"
+    description.translation_key = "carp_vip"
+    sensor = OPNsenseCarpVipSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=description,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.carp_vip"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+    assert sensor.available is True
+    assert sensor.extra_state_attributes == {
+        "interface": "igc0",
+        "vhid": 1,
+        "subnet": "192.0.2.1",
+    }
+
+    if unavailable_scenario == "malformed_key":
+        description.key = "carp.vip.invalid"
+    elif unavailable_scenario == "disappeared_vip":
+        coordinator.data["carp"]["interfaces"] = []
+    else:
+        interface.pop("status")
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+    assert sensor.extra_state_attributes == {}
 
 
 @pytest.mark.parametrize("system_info", [{}, {"name": None}, {"name": ""}, {"name": "  "}])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -351,6 +351,131 @@ def test_carp_active_responder_unavailable_without_name(
     assert sensor.extra_state_attributes == {}
 
 
+def test_carp_active_responder_unavailable_without_system_info(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """The active responder should fail closed when system information is absent."""
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    sensor = OPNsenseCarpActiveResponderSensor(
+        config_entry=make_config_entry(data={"entry_type": "carp"}),
+        coordinator=coordinator,
+        entity_description=SensorEntityDescription(key="carp.active_responder"),
+    )
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+    assert sensor.extra_state_attributes == {}
+
+
+def test_carp_value_normalization_handles_empty_and_conversion_errors() -> None:
+    """CARP normalization should return blanks for absent or unconvertible values."""
+
+    class UnconvertibleValue:
+        """Value whose string conversion fails."""
+
+        def __str__(self) -> str:
+            """Raise a representative conversion error."""
+            raise ValueError
+
+    assert sensor_module._normalize_carp_value(None) == ""
+    assert sensor_module._normalize_carp_value(UnconvertibleValue()) == ""
+
+
+@pytest.mark.parametrize(
+    ("subnet", "expected"),
+    [("  ", ""), ("not an ip", "not_an_ip")],
+)
+def test_carp_vip_subnet_normalization_fallbacks(subnet: str, expected: str) -> None:
+    """CARP subnet normalization should handle blanks and non-IP identifiers."""
+    assert sensor_module._normalize_carp_vip_subnet(subnet) == expected
+
+
+@pytest.mark.parametrize("key", ["carp.vip..192_0_2_1", "carp.vip.1."])
+def test_parse_carp_vip_sensor_key_rejects_blank_components(key: str) -> None:
+    """CARP VIP keys with blank identity components should be rejected."""
+    assert sensor_module._parse_carp_vip_sensor_key(key) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [[], {"carp": {"interfaces": "invalid"}}],
+)
+async def test_compile_carp_vip_sensors_rejects_malformed_containers(
+    state: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP VIP compilation should reject malformed state and interface containers."""
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    assert (
+        await sensor_module._compile_carp_vip_sensors(make_config_entry(), coordinator, state) == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_carp_vip_sensors_skips_bad_rows_and_duplicates(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP VIP compilation should skip malformed, incomplete, and duplicate rows."""
+    valid = {"vhid": "1", "subnet": "192.0.2.1", "status": "MASTER"}
+    state = {
+        "carp": {"interfaces": ["invalid", {"vhid": ""}, {"subnet": "192.0.2.1"}, valid, valid]}
+    }
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_carp_vip_sensors(
+        make_config_entry(), coordinator, state
+    )
+
+    assert len(entities) == 1
+
+
+def test_carp_vip_sensor_skips_malformed_and_nonmatching_rows(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP VIP updates should ignore unusable rows and fail closed without a match."""
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {
+        "carp": {
+            "interfaces": [
+                "invalid",
+                {"vhid": "", "subnet": "192.0.2.1"},
+                {"vhid": "2", "subnet": "192.0.2.2", "status": "MASTER"},
+            ]
+        }
+    }
+    sensor = OPNsenseCarpVipSensor(
+        config_entry=make_config_entry(data={"entry_type": "carp"}),
+        coordinator=coordinator,
+        entity_description=SensorEntityDescription(key="carp.vip.1.192_0_2_1"),
+    )
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_carp_vip_sensor_non_string_status_uses_failure_icon(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP VIP sensors should use the failure icon for non-string states."""
+    sensor = OPNsenseCarpVipSensor(
+        config_entry=make_config_entry(data={"entry_type": "carp"}),
+        coordinator=MagicMock(spec=OPNsenseDataUpdateCoordinator),
+        entity_description=SensorEntityDescription(key="carp.vip.1.192_0_2_1"),
+    )
+    sensor._attr_native_value = 1
+
+    assert sensor.icon == "mdi:close-network-outline"
+
+
 @pytest.mark.asyncio
 async def test_static_key_sensor_cpu_and_boot_and_certificates(
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -49,11 +49,6 @@ from custom_components.opnsense.sensor import (
 )
 
 
-def _carp_entry_sensor_unique_id(entry: MockConfigEntry, key: str) -> str:
-    """Return the repository-normalized unique ID for a CARP entry sensor."""
-    return sensor_module.slugify(f"{entry.entry_id}_{key}")
-
-
 def test_static_sensor_descriptions_live_in_sensor_module() -> None:
     """Static sensor descriptions should be owned by the sensor platform."""
     telemetry_keys = {description.key for description in sensor_module.STATIC_TELEMETRY_SENSORS}
@@ -133,7 +128,9 @@ async def test_carp_entry_setup_has_exact_read_only_vip_inventory(
         sensor_module._build_carp_vip_sensor_key("1", "192.0.2.1"),
         sensor_module._build_carp_vip_sensor_key("2", "198.51.100.1"),
     }
-    expected_unique_ids = {_carp_entry_sensor_unique_id(entry, key) for key in expected_keys}
+    expected_unique_ids = {
+        sensor_module.slugify(f"{entry.entry_id}_{key}") for key in expected_keys
+    }
     assert keys == expected_keys
     assert {entity.unique_id for entity in created} == expected_unique_ids
     descriptions = {entity.entity_description.key: entity.entity_description for entity in created}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -368,6 +368,31 @@ async def test_get_clients_explicit_carp_target_raises_no_target_clients(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_kwargs",
+    [
+        pytest.param({"opndevice_id": "carp-device"}, id="device-target"),
+        pytest.param({"opnentity_id": "sensor.carp"}, id="entity-target"),
+    ],
+)
+async def test_get_clients_only_carp_entries_reject_explicit_targets(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    target_kwargs: dict[str, str],
+) -> None:
+    """Explicit targets fail when runtime state contains only CARP entries."""
+    hass_local = ph_hass
+    carp_client = MagicMock(name="carp")
+    hass_local.data = {DOMAIN: {"carp": carp_client}}
+    _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await services_mod._get_clients(hass_local, **target_kwargs)
+
+    assert exc_info.value.translation_key == "no_target_clients"
+
+
+@pytest.mark.asyncio
 async def test_get_clients_registry_errors_raise_for_explicit_targets(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -331,12 +331,20 @@ async def test_get_clients_untargeted_resolution_skips_carp_entries(
 
 
 @pytest.mark.asyncio
-async def test_get_clients_explicit_carp_device_target_raises_no_target_clients(
+@pytest.mark.parametrize(
+    "target_kind",
+    [
+        pytest.param("device", id="device-target"),
+        pytest.param("entity", id="entity-target"),
+    ],
+)
+async def test_get_clients_explicit_carp_target_raises_no_target_clients(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],
+    target_kind: str,
 ) -> None:
-    """CARP device targets must raise no_target_clients even when other entries exist."""
+    """Explicit CARP targets must raise no_target_clients even when other entries exist."""
     hass_local = ph_hass
     normal_client = MagicMock(name="normal")
     normal_client.name = "normal"
@@ -345,33 +353,16 @@ async def test_get_clients_explicit_carp_device_target_raises_no_target_clients(
     hass_local.data = {DOMAIN: {"normal": normal_client, "carp": carp_client}}
     _add_entry_for_client(hass_local, make_config_entry, "normal")
     _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
-    _patch_device_registry_entry(monkeypatch, "carp")
+
+    if target_kind == "device":
+        _patch_device_registry_entry(monkeypatch, "carp")
+        target_kwargs: dict[str, str] = {"opndevice_id": "carp-device"}
+    else:
+        _patch_entity_registry_entry(monkeypatch, "carp")
+        target_kwargs = {"opnentity_id": "sensor.carp"}
 
     with pytest.raises(ServiceValidationError) as exc_info:
-        await services_mod._get_clients(hass_local, opndevice_id="carp-device")
-
-    assert exc_info.value.translation_key == "no_target_clients"
-
-
-@pytest.mark.asyncio
-async def test_get_clients_explicit_carp_entity_target_raises_no_target_clients(
-    monkeypatch: pytest.MonkeyPatch,
-    ph_hass: HomeAssistant,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """CARP entity targets must raise no_target_clients even when other entries exist."""
-    hass_local = ph_hass
-    normal_client = MagicMock(name="normal")
-    normal_client.name = "normal"
-    carp_client = MagicMock(name="carp")
-    carp_client.name = "carp"
-    hass_local.data = {DOMAIN: {"normal": normal_client, "carp": carp_client}}
-    _add_entry_for_client(hass_local, make_config_entry, "normal")
-    _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
-    _patch_entity_registry_entry(monkeypatch, "carp")
-
-    with pytest.raises(ServiceValidationError) as exc_info:
-        await services_mod._get_clients(hass_local, opnentity_id="sensor.carp")
+        await services_mod._get_clients(hass_local, **target_kwargs)
 
     assert exc_info.value.translation_key == "no_target_clients"
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,6 +4,7 @@ These tests exercise service helpers, validation paths, and error handling
 for operations such as starting/stopping services and generating vouchers.
 """
 
+from collections.abc import Awaitable, Callable
 import json
 import logging
 from pathlib import Path
@@ -16,11 +17,15 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util.yaml import load_yaml_dict
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
 from custom_components.opnsense import services as services_mod
 from custom_components.opnsense.const import (
+    CONF_ENTRY_TYPE,
     DOMAIN,
+    ENTRY_TYPE_CARP,
+    ENTRY_TYPE_DEVICE,
     SERVICE_CLOSE_NOTICE,
     SERVICE_GENERATE_VOUCHERS,
     SERVICE_GET_VNSTAT_METRICS,
@@ -145,6 +150,25 @@ def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: device_registry)
 
 
+def _add_entry_for_client(
+    hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    entry_id: str,
+    client_kind: str = ENTRY_TYPE_DEVICE,
+) -> None:
+    """Register a MockConfigEntry in Home Assistant for a test client id.
+
+    Args:
+        hass: Home Assistant instance receiving the config entry.
+        make_config_entry: Factory that creates MockConfigEntry objects.
+        entry_id: Config entry identifier to register and map to the client.
+        client_kind: Config entry type; defaults to normal device entry.
+    """
+    entry_data = {CONF_ENTRY_TYPE: client_kind} if client_kind == ENTRY_TYPE_CARP else {}
+    entry = make_config_entry(data=entry_data, entry_id=entry_id)
+    entry.add_to_hass(hass)
+
+
 @pytest.mark.asyncio
 async def test_async_setup_services_registers_get_vnstat_metrics_case_insensitive_period() -> None:
     """Service setup should register get_vnstat_metrics with normalized period schema."""
@@ -254,18 +278,25 @@ def test_service_validation_error_uses_translation_metadata() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_get_clients returns clients from hass.data and supports filtering."""
-    hass_local = MagicMock(spec=HomeAssistant)
+async def test_get_clients_single_and_multiple(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """_get_clients resolves action clients from runtime state and explicit targets."""
+    hass_local = ph_hass
     client = MagicMock()
     client.name = "one"
     hass_local.data = {DOMAIN: {"e1": client}}
+    _add_entry_for_client(hass_local, make_config_entry, "e1")
+
     res = await services_mod._get_clients(hass_local)
     assert res == [client]
 
     client2 = MagicMock()
     client2.name = "two"
     hass_local.data[DOMAIN] = {"e1": client, "e2": client2}
+    _add_entry_for_client(hass_local, make_config_entry, "e2")
 
     _patch_device_registry_entry(monkeypatch, "e2")
     res = await services_mod._get_clients(hass_local, opndevice_id="dev123")
@@ -278,6 +309,71 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
     _patch_device_registry_entry(monkeypatch, None, {"e1"})
     res = await services_mod._get_clients(hass_local, opndevice_id="dev123")
     assert res == [client]
+
+
+@pytest.mark.asyncio
+async def test_get_clients_untargeted_resolution_skips_carp_entries(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Untargeted resolution returns normal-device clients and omits CARP clients."""
+    hass_local = ph_hass
+    normal_client = MagicMock(name="normal")
+    normal_client.name = "normal"
+    carp_client = MagicMock(name="carp")
+    carp_client.name = "carp"
+    hass_local.data = {DOMAIN: {"normal": normal_client, "carp": carp_client}}
+    _add_entry_for_client(hass_local, make_config_entry, "normal")
+    _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
+
+    assert await services_mod._get_clients(hass_local) == [normal_client]
+
+
+@pytest.mark.asyncio
+async def test_get_clients_explicit_carp_device_target_raises_no_target_clients(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP device targets must raise no_target_clients even when other entries exist."""
+    hass_local = ph_hass
+    normal_client = MagicMock(name="normal")
+    normal_client.name = "normal"
+    carp_client = MagicMock(name="carp")
+    carp_client.name = "carp"
+    hass_local.data = {DOMAIN: {"normal": normal_client, "carp": carp_client}}
+    _add_entry_for_client(hass_local, make_config_entry, "normal")
+    _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
+    _patch_device_registry_entry(monkeypatch, "carp")
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await services_mod._get_clients(hass_local, opndevice_id="carp-device")
+
+    assert exc_info.value.translation_key == "no_target_clients"
+
+
+@pytest.mark.asyncio
+async def test_get_clients_explicit_carp_entity_target_raises_no_target_clients(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP entity targets must raise no_target_clients even when other entries exist."""
+    hass_local = ph_hass
+    normal_client = MagicMock(name="normal")
+    normal_client.name = "normal"
+    carp_client = MagicMock(name="carp")
+    carp_client.name = "carp"
+    hass_local.data = {DOMAIN: {"normal": normal_client, "carp": carp_client}}
+    _add_entry_for_client(hass_local, make_config_entry, "normal")
+    _add_entry_for_client(hass_local, make_config_entry, "carp", ENTRY_TYPE_CARP)
+    _patch_entity_registry_entry(monkeypatch, "carp")
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await services_mod._get_clients(hass_local, opnentity_id="sensor.carp")
+
+    assert exc_info.value.translation_key == "no_target_clients"
 
 
 @pytest.mark.asyncio
@@ -778,6 +874,64 @@ async def test_get_clients_no_data_returns_empty() -> None:
     assert res == []
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_kwargs", "include_normal", "expect_error"),
+    [
+        ({}, True, False),
+        ({"device_id": "carp-device"}, True, True),
+        ({"entity_id": "sensor.carp"}, True, True),
+        ({}, False, False),
+    ],
+)
+async def test_service_system_reboot_does_not_call_carp_clients(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    target_kwargs: dict[str, str],
+    include_normal: bool,
+    expect_error: bool,
+) -> None:
+    """system_reboot must run only non-CARP clients and skip CARP targets/errors."""
+    hass = ph_hass
+    normal_client = MagicMock(name="normal")
+    normal_client.name = "normal"
+    normal_client.system_reboot = AsyncMock(return_value=None)
+    carp_client = MagicMock(name="carp")
+    carp_client.name = "carp"
+    carp_client.system_reboot = AsyncMock(return_value=None)
+    hass.data = {DOMAIN: {}}
+    if include_normal:
+        hass.data[DOMAIN]["normal"] = normal_client
+    hass.data[DOMAIN]["carp"] = carp_client
+
+    _add_entry_for_client(hass, make_config_entry, "carp", ENTRY_TYPE_CARP)
+    if include_normal:
+        _add_entry_for_client(hass, make_config_entry, "normal")
+
+    if "device_id" in target_kwargs:
+        _patch_device_registry_entry(monkeypatch, "carp")
+    if "entity_id" in target_kwargs:
+        _patch_entity_registry_entry(monkeypatch, "carp")
+
+    call = _service_call(target_kwargs)
+    if expect_error:
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await services_mod._service_system_reboot(hass, call)
+        assert exc_info.value.translation_key == "no_target_clients"
+    else:
+        await services_mod._service_system_reboot(hass, call)
+        if include_normal:
+            normal_client.system_reboot.assert_awaited_once_with()
+
+    if include_normal:
+        if expect_error:
+            normal_client.system_reboot.assert_not_awaited()
+    else:
+        normal_client.system_reboot.assert_not_awaited()
+    carp_client.system_reboot.assert_not_awaited()
+
+
 @pytest.fixture
 def fake_get_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fixture that monkeypatches services_mod._get_clients to return an empty list."""
@@ -785,39 +939,27 @@ def fake_get_empty(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_restart_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
-    """If no clients are found, restarting a service should raise ServiceValidationError."""
+@pytest.mark.parametrize(
+    "service_handler",
+    [
+        pytest.param(services_mod._service_restart_service, id="restart"),
+        pytest.param(services_mod._service_start_service, id="start"),
+        pytest.param(services_mod._service_stop_service, id="stop"),
+    ],
+)
+async def test_service_no_clients_raises(
+    ph_hass: Any,
+    fake_get_empty: None,
+    service_handler: Callable[..., Awaitable[None]],
+) -> None:
+    """Service start/stop/restart should raise when no clients are available."""
     hass = ph_hass
     hass.data = {}
 
     call = _service_call({"service_id": "svc"})
 
     with pytest.raises(ServiceValidationError):
-        await services_mod._service_restart_service(hass, call)
-
-
-@pytest.mark.asyncio
-async def test_start_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
-    """If no clients are found, starting a service should raise ServiceValidationError."""
-    hass = ph_hass
-    hass.data = {}
-
-    call = _service_call({"service_id": "svc"})
-
-    with pytest.raises(ServiceValidationError):
-        await services_mod._service_start_service(hass, call)
-
-
-@pytest.mark.asyncio
-async def test_stop_service_no_clients_raises(ph_hass: Any, fake_get_empty: None) -> None:
-    """If no clients are found, stopping a service should raise ServiceValidationError."""
-    hass = ph_hass
-    hass.data = {}
-
-    call = _service_call({"service_id": "svc"})
-
-    with pytest.raises(ServiceValidationError):
-        await services_mod._service_stop_service(hass, call)
+        await service_handler(hass, call)
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3218,10 +3218,10 @@ async def test_vpn_entries_skip_non_mapping_and_missing_enabled(
     assert ents == []
 
 
-def test_service_helper_methods(
+def test_service_switch_initializes_property_name(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
-    """Service switch helper methods extract property and service id correctly."""
+    """Service switches extract the property name from their entity key."""
     desc = SwitchEntityDescription(key="service.svcx.status", name="SvcX")
     config_entry_srv = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
     setattr(config_entry_srv.runtime_data, COORDINATOR, coordinator)
@@ -3230,8 +3230,7 @@ def test_service_helper_methods(
         coordinator=coordinator,
         entity_description=desc,
     )
-    assert ent._opnsense_get_property_name() == "status"
-    assert ent._opnsense_get_service_id() == "svcx"
+    assert ent._prop_name == "status"
 
 
 def test_vpn_instance_key_parsing(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -885,12 +885,12 @@ async def test_async_install_handles_masked_polling_response(
 
 
 @pytest.mark.asyncio
-async def test_async_install_retries_masked_polling_then_skips_reboot_and_metadata(
+async def test_async_install_propagates_polling_errors(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """Malformed polling responses beyond retry limit should not fetch firmware info."""
+    """async_install should not hide errors raised while polling firmware status."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -885,12 +885,12 @@ async def test_async_install_handles_masked_polling_response(
 
 
 @pytest.mark.asyncio
-async def test_async_install_propagates_polling_errors(
+async def test_async_install_stops_after_four_invalid_polling_responses(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """async_install should not hide errors raised while polling firmware status."""
+    """Stop after four malformed polls without fetching firmware info or rebooting."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -83,11 +83,13 @@ def _write_pin_files(
     *,
     manifest_version: str,
     pyproject_version: str | None = None,
+    prek_version: str | None = None,
     pyproject_text: str | None = None,
-) -> tuple[Path, Path]:
-    """Write temporary manifest and pyproject files with aiopnsense pins."""
+) -> tuple[Path, Path, Path]:
+    """Write temporary manifest, pyproject, and prek files with aiopnsense pins."""
     manifest_path = tmp_path / "manifest.json"
     pyproject_path = tmp_path / "pyproject.toml"
+    prek_path = tmp_path / "prek.toml"
     manifest_path.write_text(
         json.dumps(
             {
@@ -106,7 +108,19 @@ ha = [
 ]
 """
     pyproject_path.write_text(pyproject_text)
-    return manifest_path, pyproject_path
+    prek_path.write_text(
+        f"""[[repos]]
+repo = "https://github.com/pre-commit/mirrors-mypy"
+
+[[repos.hooks]]
+id = "mypy"
+additional_dependencies = [
+  "aiopnsense=={prek_version or pyproject_version or manifest_version}",
+  "homeassistant-stubs"
+]
+"""
+    )
+    return manifest_path, pyproject_path, prek_path
 
 
 @pytest.fixture
@@ -146,7 +160,10 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
         ("Automated update of aiopnsense dependency pins.", "describes generated PRs"),
         ("custom_components/opnsense/manifest.json", "updates the integration manifest"),
         ("pyproject.toml", "updates the local dependency pin"),
+        ("prek.toml", "updates the isolated mypy-hook dependency pin"),
         ("pyproject_current", "reports pyproject drift in PR metadata"),
+        ("prek_current", "reports prek mypy-hook drift in PR metadata"),
+        ("--prek-path prek.toml", "passes the prek configuration to the updater"),
         (str(SCRIPT_PATH), "runs the checked-in updater helper"),
         (str(RELEASE_NOTES_SCRIPT_PATH), "runs the checked-in release-note helper"),
         (str(CLEANUP_SCRIPT_PATH), "runs the checked-in cleanup helper"),
@@ -204,7 +221,7 @@ def test_updater_script_pin_update_scenarios(
     expected_target: str,
 ) -> None:
     """Updater script should handle stable, prerelease, and drift pin scenarios."""
-    manifest_path, pyproject_path = _write_pin_files(
+    manifest_path, pyproject_path, prek_path = _write_pin_files(
         tmp_path,
         manifest_version=manifest_version,
         pyproject_version=pyproject_version,
@@ -213,22 +230,25 @@ def test_updater_script_pin_update_scenarios(
     result = updater_script.update_pins(
         manifest_path=manifest_path,
         pyproject_path=pyproject_path,
+        prek_path=prek_path,
         latest_version=latest_version,
     )
 
     assert result.current == manifest_version
     assert result.pyproject_current == pyproject_version
+    assert result.prek_current == pyproject_version
     assert result.latest == expected_target
     assert result.update_needed is expected_update_needed
     assert f"aiopnsense=={expected_target}" in manifest_path.read_text()
     assert f'    "aiopnsense=={expected_target}",' in pyproject_path.read_text()
+    assert f'  "aiopnsense=={expected_target}",' in prek_path.read_text()
 
 
 def test_updater_script_updates_pyproject_pin_without_trailing_comma(
     tmp_path: Path, updater_script: ModuleType
 ) -> None:
     """Updater script should preserve valid TOML dependency-list formatting."""
-    manifest_path, pyproject_path = _write_pin_files(
+    manifest_path, pyproject_path, prek_path = _write_pin_files(
         tmp_path,
         manifest_version="1.0.8",
         pyproject_text="""[dependency-groups]
@@ -242,11 +262,63 @@ ha = [
     result = updater_script.update_pins(
         manifest_path=manifest_path,
         pyproject_path=pyproject_path,
+        prek_path=prek_path,
         latest_version="1.0.9",
     )
 
     assert result.update_needed is True
     assert '    "aiopnsense==1.0.9"\n' in pyproject_path.read_text()
+
+
+def test_updater_script_repairs_prek_mypy_pin_drift(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater should synchronize a stale isolated mypy-hook dependency pin."""
+    manifest_path, pyproject_path, prek_path = _write_pin_files(
+        tmp_path,
+        manifest_version="1.1.3",
+        pyproject_version="1.1.3",
+        prek_version="1.1.2",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        prek_path=prek_path,
+        latest_version="1.1.3",
+    )
+
+    assert result.prek_current == "1.1.2"
+    assert result.latest == "1.1.3"
+    assert result.update_needed is True
+    assert '  "aiopnsense==1.1.3",' in prek_path.read_text()
+
+
+def test_updater_script_rejects_missing_prek_mypy_pin(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater should fail when prek cannot install aiopnsense for mypy."""
+    manifest_path, pyproject_path, prek_path = _write_pin_files(
+        tmp_path,
+        manifest_version="1.1.3",
+    )
+    prek_path.write_text(
+        """[[repos]]
+repo = "https://github.com/pre-commit/mirrors-mypy"
+
+[[repos.hooks]]
+id = "mypy"
+additional_dependencies = ["homeassistant-stubs"]
+"""
+    )
+
+    with pytest.raises(ValueError, match="mypy hook"):
+        updater_script.update_pins(
+            manifest_path=manifest_path,
+            pyproject_path=pyproject_path,
+            prek_path=prek_path,
+            latest_version="1.1.3",
+        )
 
 
 @pytest.mark.parametrize(
@@ -293,7 +365,7 @@ def test_updater_script_rejects_duplicate_pyproject_pins(
     updater_script: ModuleType,
 ) -> None:
     """Updater script should fail clearly when pyproject has ambiguous pins."""
-    manifest_path, pyproject_path = _write_pin_files(
+    manifest_path, pyproject_path, prek_path = _write_pin_files(
         tmp_path,
         manifest_version="1.0.8",
         pyproject_text="""[dependency-groups]
@@ -308,6 +380,7 @@ ha = [
         updater_script.update_pins(
             manifest_path=manifest_path,
             pyproject_path=pyproject_path,
+            prek_path=prek_path,
             latest_version="1.0.10",
         )
 
@@ -344,12 +417,14 @@ def test_release_note_script_builds_sanitized_pr_body(
         releases=releases,
         current_version="1.0.8",
         pyproject_current_version="1.0.8",
+        prek_current_version="1.0.8",
         latest_version="1.0.9",
     )
 
     body = body_path.read_text()
     assert "Automated update of aiopnsense dependency pins." in body
     assert "Updated pinned version: `aiopnsense==1.0.9`" in body
+    assert "Previous prek mypy pin: `aiopnsense==1.0.8`" in body
     assert "### Fixes @<!-- -->someone (1.0.9)" in body
     assert "fixes \\#123 and thanks helper" in body
     assert "Ignored current" not in body
@@ -374,6 +449,8 @@ def test_release_note_script_handles_url_errors(
             "--current-version",
             "1.0.8",
             "--pyproject-current-version",
+            "1.0.8",
+            "--prek-current-version",
             "1.0.8",
             "--latest-version",
             "1.0.9",


### PR DESCRIPTION
## Summary

Adds an independent, read-only CARP VIP entry type that follows the active responder and exposes CARP-specific sensors. Physical-node entries remain responsible for complete monitoring and all mutating controls.

## What Changed

- Add dedicated CARP VIP setup, validation, reconfiguration, options, and URL-conflict handling
- Set up CARP VIP entries with a sensor-only coordinator and CARP-focused refresh categories
- Add sensors for the active responder, aggregate CARP status, and each VIP state keyed by VHID and subnet
- Keep CARP VIP identity independent of whichever physical node currently serves the shared endpoint
- Keep node telemetry, services, updates, actions, switches, and device trackers restricted to physical-device entries
- Consolidate shared CARP, ARP, SMART, and config-entry identity normalization helpers
- Document the recommended node-plus-VIP topology, entity ownership, limitations, and maintenance-switch safety boundary
- Keep the manifest, project, and isolated mypy-hook aiopnsense pins synchronized
- Add regression coverage across setup, config flow, coordinators, entities, services, workflow tooling, and cleanup behavior

## Why

A shared CARP endpoint can move between physical nodes, so treating it as a normal node entry gives it the wrong identity and control model. A separate read-only entry provides stable failover visibility without implying standby-node health or sending mutating actions through whichever node currently owns the VIP.
