### PR TITLE
Remove brittle test implementation assertions

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1086,10 +1086,10 @@ async def test_get_dt_entries_skips_non_mapping_arp_rows(
         selected_devices=["AA-BB-CC-DD-EE-FF"],
     )
 
-    assert list(res.keys()) == [
+    assert set(res) == {
         "aa:bb:cc:dd:ee:ff",
         "aa:bb:cc:00:00:02",
-    ]
+    }
     assert res["aa:bb:cc:dd:ee:ff"] == "Not currently detected [aa:bb:cc:dd:ee:ff]"
     assert res["aa:bb:cc:00:00:02"] == "hostb [10.0.0.10 | aa:bb:cc:00:00:02]"
 
@@ -1400,7 +1400,6 @@ def test_async_get_options_flow_returns_options_flow() -> None:
     cfg = MagicMock()
     res = cf_mod.OPNsenseConfigFlow.async_get_options_flow(cfg)
     assert isinstance(res, cf_mod.OPNsenseOptionsFlow)
-    assert isinstance(cf_mod.OPNsenseOptionsFlow(), cf_mod.OPNsenseOptionsFlow)
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3476,13 +3476,17 @@ async def test_migrate_3_to_4_preserves_mixed_marker_precedence(
     result = await _migrate_3_to_4(hass, config_entry, client)
 
     assert result is True
-    assert entity_registry.async_update_entity.call_args_list == [
-        call(
-            gateway_entity.entity_id,
-            new_unique_id="abc_gateway_lan_connected_client_count",
-        ),
-        call(openvpn_entity.entity_id, new_unique_id="abc_openvpn_vpn"),
-    ]
+    entity_registry.async_update_entity.assert_has_calls(
+        [
+            call(
+                gateway_entity.entity_id,
+                new_unique_id="abc_gateway_lan_connected_client_count",
+            ),
+            call(openvpn_entity.entity_id, new_unique_id="abc_openvpn_vpn"),
+        ],
+        any_order=True,
+    )
+    assert entity_registry.async_update_entity.call_count == 2
     entity_registry.async_remove.assert_called_once_with(connected_entity.entity_id)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -798,8 +798,8 @@ async def test_e2e_full_migration_chain(
     ok = await async_migrate_entry(hass, entry)
     assert ok is True
     assert entry.version == 5
-    assert len(migration_clients) == 1
-    assert migration_clients[0].close_calls == 1
+    assert migration_clients
+    assert all(client.close_calls == 1 for client in migration_clients)
     # v1->2: tls_insecure removed, verify_ssl added (inverse of True -> False)
     assert CONF_TLS_INSECURE not in entry.data
     assert entry.data.get(CONF_VERIFY_SSL) is False

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1323,13 +1323,13 @@ async def test_reload_failure_keeps_entry_update_and_keeps_issue(
     assert result["reason"] == "repair_failed"
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
-    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
-        "data": expected_updated_data,
-        "unique_id": observed_device_id,
-    }
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data=expected_updated_data,
+        unique_id=observed_device_id,
+    )
     assert entry.data == expected_updated_data
     assert entry.unique_id == observed_device_id
-    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
     issue_delete.assert_not_called()
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
     hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import const as const_module, sensor as sensor_module
+from custom_components.opnsense import sensor as sensor_module
 from custom_components.opnsense.const import (
     CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_CARP,
@@ -43,7 +43,6 @@ from custom_components.opnsense.sensor import (
     OPNsenseFilesystemSensor,
     OPNsenseGatewaySensor,
     OPNsenseInterfaceSensor,
-    OPNsenseLiveTrafficSensor,
     OPNsenseNUTSensor,
     OPNsenseSmartSensor,
     OPNsenseSpeedtestSensor,
@@ -56,19 +55,6 @@ from custom_components.opnsense.sensor import (
     slugify_filesystem_mountpoint,
 )
 from custom_components.opnsense.traffic_coordinator import OPNsenseLiveTrafficCoordinator
-
-
-def test_static_sensor_descriptions_live_in_sensor_module() -> None:
-    """Static sensor descriptions should be owned by the sensor platform."""
-    telemetry_keys = {description.key for description in sensor_module.STATIC_TELEMETRY_SENSORS}
-    certificate_keys = {description.key for description in sensor_module.STATIC_CERTIFICATE_SENSORS}
-    nut_keys = {description.key for description in sensor_module.STATIC_NUT_SENSORS}
-
-    assert not hasattr(const_module, "STATIC_TELEMETRY_SENSORS")
-    assert not hasattr(const_module, "STATIC_CERTIFICATE_SENSORS")
-    assert "telemetry.cpu.usage_total" in telemetry_keys
-    assert "certificates" in certificate_keys
-    assert nut_keys == {"nut.ups_status", "nut.battery_charge", "nut.ups_load"}
 
 
 @pytest.mark.asyncio
@@ -2212,11 +2198,6 @@ def test_build_vpn_rate_sensor_description_suggests_megabits_per_second(
     assert description.device_class == SensorDeviceClass.DATA_RATE
 
 
-def test_sensor_module_import() -> None:
-    """Test that the sensor module can be imported via relative import."""
-    assert sensor_module is not None
-
-
 @pytest.mark.parametrize(
     ("input_value", "expected"),
     [
@@ -3328,46 +3309,6 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert recorded["entities"] is None, description
 
 
-def test_vnstat_rows_are_complete_defaults_and_rejects_falsy_rows() -> None:
-    """VnStat inventories should treat missing keys as empty and falsy payloads as incomplete."""
-    assert sensor_module._vnstat_rows_are_complete({}) is True
-    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": {}}}) is True
-    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": False}}) is False
-    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": 0}}) is False
-    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": []}}) is False
-
-
-def test_vpn_sensor_rows_are_complete_defaults_and_rejects_falsy_rows() -> None:
-    """VPN inventories should default missing client/server groups to {} and reject falsy groups."""
-    assert (
-        sensor_module._vpn_sensor_rows_are_complete(
-            {
-                "openvpn": {"clients": {}, "servers": {}},
-                "wireguard": {"clients": {}, "servers": {}},
-            }
-        )
-        is True
-    )
-    assert (
-        sensor_module._vpn_sensor_rows_are_complete(
-            {
-                "openvpn": {"clients": {}, "servers": {}},
-                "wireguard": {"clients": [], "servers": {}},
-            }
-        )
-        is False
-    )
-    assert (
-        sensor_module._vpn_sensor_rows_are_complete(
-            {
-                "openvpn": {"clients": {}, "servers": {}},
-                "wireguard": {"clients": {}, "servers": False},
-            }
-        )
-        is False
-    )
-
-
 @pytest.mark.parametrize(
     ("state", "sync_option", "expected_key"),
     [
@@ -3504,9 +3445,54 @@ async def test_async_setup_entry_ignores_unconsumed_openvpn_client_rows(
             True,
             [],
         ),
+        (
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": [], "servers": {}},
+            },
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            None,
+        ),
+        (
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": {}, "servers": False},
+            },
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            None,
+        ),
         # vnStat
         ({}, False, True, False, False, False, False, False, False, False, None),
         ({"vnstat": {}}, False, True, False, False, False, False, False, False, False, []),
+        (
+            {"vnstat": {"interfaces": False}},
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+        ),
         # Speedtest
         ({}, False, False, True, False, False, False, False, False, False, None),
         ({"speedtest": {}}, False, False, True, False, False, False, False, False, False, []),
@@ -3622,8 +3608,11 @@ async def test_async_setup_entry_ignores_unconsumed_openvpn_client_rows(
         "empty_gateway_inventory",
         "missing_vpn_inventory",
         "empty_vpn_inventory",
+        "incomplete_vpn_inventory_falsy_clients",
+        "incomplete_vpn_inventory_falsy_servers",
         "missing_vnstat_inventory",
         "empty_vnstat_inventory",
+        "incomplete_vnstat_inventory_falsy_interfaces",
         "missing_speedtest_inventory",
         "empty_speedtest_inventory",
         "missing_telemetry_inventory",
@@ -5646,6 +5635,10 @@ async def test_compile_interface_sensors_routes_rate_keys_to_live_traffic_coordi
             "eth0": {
                 "name": "WAN",
                 "status": "up",
+                "inbytes_kilobytes_per_second": 11,
+                "outbytes_kilobytes_per_second": 12,
+                "inpkts_packets_per_second": 13,
+                "outpkts_packets_per_second": 14,
             }
         }
     }
@@ -5671,6 +5664,7 @@ async def test_compile_interface_sensors_routes_rate_keys_to_live_traffic_coordi
     coordinator.data = main_state
     live_traffic_coordinator = MagicMock(spec=OPNsenseLiveTrafficCoordinator)
     live_traffic_coordinator.data = live_state
+    live_traffic_coordinator.last_update_success = True
     setattr(entry.runtime_data, COORDINATOR, coordinator)
     entry.runtime_data.live_traffic_coordinator = live_traffic_coordinator
 
@@ -5678,87 +5672,19 @@ async def test_compile_interface_sensors_routes_rate_keys_to_live_traffic_coordi
 
     entities_by_key = {entity.entity_description.key: entity for entity in entities}
 
-    traffic_sensor_contracts = {
-        "interface.eth0.inerrs": (
-            "Interface WAN Errors In Total",
-            "interface_wan_errors_in_total",
-        ),
-        "interface.eth0.outerrs": (
-            "Interface WAN Errors Out Total",
-            "interface_wan_errors_out_total",
-        ),
-        "interface.eth0.collisions": (
-            "Interface WAN Collisions Total",
-            "interface_wan_collisions_total",
-        ),
-        "interface.eth0.inbytes": (
-            "Interface WAN Traffic In Total",
-            "interface_wan_traffic_in_total",
-        ),
-        "interface.eth0.inbytes_kilobytes_per_second": (
-            "Interface WAN Traffic In Rate",
-            "interface_wan_traffic_in_rate",
-        ),
-        "interface.eth0.outbytes": (
-            "Interface WAN Traffic Out Total",
-            "interface_wan_traffic_out_total",
-        ),
-        "interface.eth0.outbytes_kilobytes_per_second": (
-            "Interface WAN Traffic Out Rate",
-            "interface_wan_traffic_out_rate",
-        ),
-        "interface.eth0.inpkts": (
-            "Interface WAN Packets In Total",
-            "interface_wan_packets_in_total",
-        ),
-        "interface.eth0.inpkts_packets_per_second": (
-            "Interface WAN Packets In Rate",
-            "interface_wan_packets_in_rate",
-        ),
-        "interface.eth0.outpkts": (
-            "Interface WAN Packets Out Total",
-            "interface_wan_packets_out_total",
-        ),
-        "interface.eth0.outpkts_packets_per_second": (
-            "Interface WAN Packets Out Rate",
-            "interface_wan_packets_out_rate",
-        ),
-    }
-    for key, (expected_name, expected_object_id) in traffic_sensor_contracts.items():
-        sensor = entities_by_key[key]
-        assert sensor.entity_description.name == expected_name
-        assert slugify(expected_name) == expected_object_id
-        assert sensor.unique_id == slugify(f"id_{key}")
-
-    for key in (
-        "interface.eth0.inbytes_kilobytes_per_second",
-        "interface.eth0.outbytes_kilobytes_per_second",
+    for key, expected_value in (
+        ("interface.eth0.inbytes_kilobytes_per_second", 1.5),
+        ("interface.eth0.outbytes_kilobytes_per_second", 2.5),
+        ("interface.eth0.inpkts_packets_per_second", 3),
+        ("interface.eth0.outpkts_packets_per_second", 4),
     ):
         sensor = entities_by_key[key]
-        assert isinstance(sensor, OPNsenseLiveTrafficSensor)
-        assert sensor.coordinator is live_traffic_coordinator
-        description = sensor.entity_description
-        assert description.native_unit_of_measurement == UnitOfDataRate.KILOBYTES_PER_SECOND
-        assert description.suggested_unit_of_measurement == UnitOfDataRate.MEGABITS_PER_SECOND
-
-    for key in (
-        "interface.eth0.inpkts_packets_per_second",
-        "interface.eth0.outpkts_packets_per_second",
-    ):
-        sensor = entities_by_key[key]
-        assert isinstance(sensor, OPNsenseLiveTrafficSensor)
-        assert sensor.coordinator is live_traffic_coordinator
-
-    for key in (
-        "interface.eth0.status",
-        "interface.eth0.inbytes",
-        "interface.eth0.inpkts",
-        "interface.eth0.outbytes",
-        "interface.eth0.outpkts",
-    ):
-        sensor = entities_by_key[key]
-        assert isinstance(sensor, OPNsenseInterfaceSensor)
-        assert sensor.coordinator is coordinator
+        sensor.hass = MagicMock()
+        sensor.entity_id = f"sensor.{slugify(key)}"
+        object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+        sensor._handle_coordinator_update()
+        assert sensor.available is True
+        assert sensor.native_value == expected_value
 
 
 @pytest.mark.asyncio
@@ -5771,6 +5697,10 @@ async def test_compile_interface_sensors_routes_rate_keys_to_main_coordinator_wh
             "eth0": {
                 "name": "WAN",
                 "status": "up",
+                "inbytes_kilobytes_per_second": 11,
+                "outbytes_kilobytes_per_second": 12,
+                "inpkts_packets_per_second": 13,
+                "outpkts_packets_per_second": 14,
             }
         }
     }
@@ -5791,15 +5721,18 @@ async def test_compile_interface_sensors_routes_rate_keys_to_main_coordinator_wh
     entities = await sensor_module._compile_interface_sensors(entry, coordinator, state)
     entities_by_key = {entity.entity_description.key: entity for entity in entities}
 
-    for key in (
-        "interface.eth0.inbytes_kilobytes_per_second",
-        "interface.eth0.outbytes_kilobytes_per_second",
-        "interface.eth0.inpkts_packets_per_second",
-        "interface.eth0.outpkts_packets_per_second",
+    for key, expected_value in (
+        ("interface.eth0.inbytes_kilobytes_per_second", 11),
+        ("interface.eth0.outbytes_kilobytes_per_second", 12),
+        ("interface.eth0.inpkts_packets_per_second", 13),
+        ("interface.eth0.outpkts_packets_per_second", 14),
     ):
         sensor = entities_by_key[key]
-        assert isinstance(sensor, OPNsenseInterfaceSensor)
-        assert sensor.coordinator is coordinator
+        sensor.hass = MagicMock()
+        sensor.entity_id = f"sensor.{slugify(key)}"
+        object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+        sensor._handle_coordinator_update()
+        assert sensor.native_value == expected_value
 
 
 @pytest.mark.asyncio
@@ -5844,9 +5777,6 @@ async def test_compile_dotted_interface_rate_sensor_prefers_live_traffic_data_wh
         for entity in entities
         if entity.entity_description.key == "interface.wan.vlan.100.inbytes_kilobytes_per_second"
     )
-    assert isinstance(rate_sensor, OPNsenseLiveTrafficSensor)
-    assert rate_sensor.coordinator is live_traffic_coordinator
-
     rate_sensor.hass = MagicMock()
     rate_sensor.entity_id = "sensor.wan_vlan_100_inbytes_kilobytes_per_second"
     object.__setattr__(rate_sensor, "async_write_ha_state", lambda: None)
@@ -5893,11 +5823,9 @@ async def test_interface_rate_sensor_falls_back_when_live_traffic_is_unavailable
         for entity in entities
         if entity.entity_description.key == "interface.eth0.inbytes_kilobytes_per_second"
     )
-    assert isinstance(rate_sensor, OPNsenseLiveTrafficSensor)
     non_rate_sensor = next(
         entity for entity in entities if entity.entity_description.key == "interface.eth0.status"
     )
-    assert isinstance(non_rate_sensor, OPNsenseInterfaceSensor)
 
     rate_sensor.hass = MagicMock()
     rate_sensor.entity_id = "sensor.eth0_inbytes_kilobytes_per_second"
@@ -5919,4 +5847,11 @@ async def test_interface_rate_sensor_falls_back_when_live_traffic_is_unavailable
 
     setattr(entry.runtime_data, OPNSENSE_CLIENT, MagicMock())
     await rate_sensor.async_added_to_hass()
-    coordinator.async_add_listener.assert_called_once_with(rate_sensor._handle_coordinator_update)
+
+    polling_listener = coordinator.async_add_listener.call_args.args[0]
+    state["interfaces"]["eth0"]["inbytes_kilobytes_per_second"] = 30
+    live_traffic_coordinator.last_update_success = False
+    polling_listener()
+
+    assert rate_sensor.available is True
+    assert rate_sensor.native_value == 30

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2776,40 +2776,6 @@ async def test_vpn_toggle_parametrized(
         ent._client.toggle_vpn_instance.assert_awaited_once()
 
 
-def test_reset_delay_calls_existing_remover(
-    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Resetting delay should call any existing remover and replace it."""
-    desc = SwitchEntityDescription(key="service.svc1.status", name="Svc")
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, None)
-    ent = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=make_coord({}),
-        entity_description=desc,
-    )
-    called = {"old_removed": False, "new_removed": False}
-
-    def old_remover() -> None:
-        """Old remover."""
-        called["old_removed"] = True
-
-    def new_remover() -> None:
-        """New remover."""
-        called["new_removed"] = True
-
-    ent._delay_update_remove = old_remover
-    # monkeypatch async_call_later to return new_remover
-    monkeypatch.setattr(
-        "custom_components.opnsense.switch.async_call_later",
-        lambda hass, delay, action: new_remover,
-    )
-    ent._reset_delay()
-    assert called["old_removed"] is True
-    ent.delay_update = False
-    assert called["new_removed"] is True
-
-
 @pytest.mark.asyncio
 async def test_compile_service_skips_locked(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_traffic_coordinator.py
+++ b/tests/test_traffic_coordinator.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import AsyncIterator, Callable
-import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -168,11 +167,10 @@ def test_live_traffic_coordinator_all_skipped_payload_marks_failed_and_preserves
     assert coordinator.data is previous_data
 
 
-def test_live_traffic_coordinator_aggregates_sample_logging(
-    caplog: pytest.LogCaptureFixture,
+def test_live_traffic_coordinator_publishes_each_sample(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Live samples should notify listeners without logging every pushed update."""
+    """Live samples should publish every pushed update to listeners."""
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_LIVE_TRAFFIC: True})
     main_coordinator = MagicMock()
     main_coordinator.data = {"interfaces": {"wan": {"name": "WAN"}}}
@@ -184,19 +182,11 @@ def test_live_traffic_coordinator_aggregates_sample_logging(
     )
     listener = MagicMock()
     coordinator.async_add_listener(listener)
-    caplog.set_level(logging.DEBUG, logger="custom_components.opnsense.traffic_coordinator")
-
     payload = {"interfaces": {"wan": {"rx_bytes_per_second": 1000}}}
-    for _ in range(60):
+    for _ in range(2):
         assert coordinator._consume_payload(payload) is True
 
-    assert listener.call_count == 60
-    messages = [record.getMessage() for record in caplog.records]
-    assert not any("Manually updated" in message for message in messages)
-    assert (
-        messages.count("Processed 60 live interface traffic samples covering 60 interface updates")
-        == 1
-    )
+    assert listener.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -446,11 +436,10 @@ async def test_live_traffic_coordinator_consumes_stream_cancelled_error(
     ],
 )
 async def test_live_traffic_coordinator_consumes_stream_records_update_error(
-    caplog: pytest.LogCaptureFixture,
     make_config_entry: Callable[..., MockConfigEntry],
     stream_exception: Exception,
 ) -> None:
-    """Stream exceptions should produce one coordinator error without a warning."""
+    """Stream exceptions should mark the coordinator update as failed."""
 
     async def _stream() -> AsyncIterator[dict[str, Any]]:
         """Raise a stream error as soon as stream iteration starts.
@@ -465,18 +454,10 @@ async def test_live_traffic_coordinator_consumes_stream_records_update_error(
     client.stream_interface_traffic = MagicMock(return_value=_stream())
 
     coordinator, _ = _build_test_coordinator(make_config_entry, client=client)
-    caplog.set_level(logging.INFO, logger="custom_components.opnsense.traffic_coordinator")
-
     has_sample = await coordinator._consume_stream()
 
     assert has_sample is False
     assert coordinator.last_update_success is False
-    coordinator_records = [
-        record
-        for record in caplog.records
-        if record.name == "custom_components.opnsense.traffic_coordinator"
-    ]
-    assert sum(record.levelno >= logging.WARNING for record in coordinator_records) == 1
 
 
 @pytest.mark.asyncio
@@ -549,11 +530,10 @@ async def test_live_traffic_run_sleeps_poll_interval_when_live_traffic_disabled(
 
 @pytest.mark.asyncio
 async def test_live_traffic_run_reconnects_after_finite_valid_stream(
-    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """A finite valid stream should retry quietly and report its recovery."""
+    """A finite valid stream should reconnect while retaining published data."""
     client = _FakeStreamClient(
         [
             {
@@ -576,8 +556,6 @@ async def test_live_traffic_run_reconnects_after_finite_valid_stream(
             coordinator._shutdown_requested = True
 
     monkeypatch.setattr("custom_components.opnsense.traffic_coordinator.asyncio.sleep", _fake_sleep)
-    caplog.set_level(logging.INFO, logger="custom_components.opnsense.traffic_coordinator")
-
     await coordinator._run()
 
     assert sleep_calls == [5, 5]
@@ -586,45 +564,6 @@ async def test_live_traffic_run_reconnects_after_finite_valid_stream(
     assert client.stream_calls == [1, 1]
     assert coordinator.data["interfaces"]["wan"]["name"] == "WAN"
     assert coordinator.data["interfaces"]["wan"]["inbytes_kilobytes_per_second"] == 1.0
-    coordinator_records = [
-        record
-        for record in caplog.records
-        if record.name == "custom_components.opnsense.traffic_coordinator"
-    ]
-    assert not any(record.levelno >= logging.WARNING for record in coordinator_records)
-    assert (
-        sum(
-            record.getMessage() == "Live traffic stream recovered" for record in coordinator_records
-        )
-        == 1
-    )
-    assert (
-        sum(
-            record.getMessage() == "Retrying live traffic stream in 5 seconds"
-            for record in coordinator_records
-        )
-        == 2
-    )
-
-
-def test_live_traffic_retry_delay_caps_at_max_interval(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Retry delay should grow through backoff values and then cap."""
-    client = _FakeStreamClient(payloads=[])
-    coordinator, _ = _build_test_coordinator(make_config_entry, client=client)
-
-    assert coordinator._get_retry_delay() == 5
-    coordinator._failure_count = 1
-    assert coordinator._get_retry_delay() == 5
-    coordinator._failure_count = 2
-    assert coordinator._get_retry_delay() == 10
-    coordinator._failure_count = 3
-    assert coordinator._get_retry_delay() == 20
-    coordinator._failure_count = 4
-    assert coordinator._get_retry_delay() == 30
-    coordinator._failure_count = 10
-    assert coordinator._get_retry_delay() == 30
 
 
 @pytest.mark.asyncio

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -21,7 +21,6 @@ from custom_components.opnsense.const import (
 )
 from custom_components.opnsense.update import (
     OPNsenseFirmwareUpdatesAvailableUpdate,
-    _affected_package_count,
     async_setup_entry,
 )
 
@@ -266,13 +265,8 @@ def test_is_update_available_true_for_valid_status(
     assert ent.available is True
 
 
-def test_affected_package_count_counts_lists() -> None:
-    """Affected package count should count list-shaped package collections."""
-    assert _affected_package_count(["base", "kernel"]) == 2
-
-
 @pytest.mark.parametrize(
-    ("state", "expected_latest", "expected_series"),
+    ("state", "expected_latest"),
     [
         (
             _firmware_update_state(
@@ -282,7 +276,6 @@ def test_affected_package_count_counts_lists() -> None:
                 upgrade_packages=[{"name": "not-opnsense"}],
             ),
             "1_0_0+",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -292,7 +285,6 @@ def test_affected_package_count_counts_lists() -> None:
                 upgrade_packages=[{"name": "opnsense", "new_version": "1_0_1"}],
             ),
             "1_0_1",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -302,7 +294,6 @@ def test_affected_package_count_counts_lists() -> None:
                 upgrade_packages=[{"name": "opnsense", "new_version": ""}],
             ),
             "1_0_0+",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -315,7 +306,6 @@ def test_affected_package_count_counts_lists() -> None:
                 ],
             ),
             "1.0.1",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -329,7 +319,6 @@ def test_affected_package_count_counts_lists() -> None:
                 ],
             ),
             "1.0.2",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -338,7 +327,6 @@ def test_affected_package_count_counts_lists() -> None:
                 product_series="1.0",
             ),
             "1_0_0+",
-            "1.0",
         ),
         (
             _firmware_update_state(
@@ -347,7 +335,6 @@ def test_affected_package_count_counts_lists() -> None:
                 product_series="s1",
             ),
             None,
-            "s1",
         ),
         (
             _firmware_update_state(
@@ -358,7 +345,6 @@ def test_affected_package_count_counts_lists() -> None:
                 upgrade_major_version="2.1.3",
             ),
             "2.1.3",
-            "2.1",
         ),
         (
             _firmware_update_state(
@@ -369,19 +355,17 @@ def test_affected_package_count_counts_lists() -> None:
                 upgrade_major_version="",
             ),
             "2.0.0",
-            "2.0",
         ),
     ],
 )
-def test_get_versions_scenarios(
+def test_handle_coordinator_update_publishes_latest_version(
     state: dict[str, Any],
     expected_latest: str | None,
-    expected_series: str | None,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """Parameterize _get_versions behaviors across upgrade package presence and missing fields."""
-    entry = make_config_entry()
+    """Publish the expected latest version across representative firmware payloads."""
+    entry = make_config_entry({"url": "https://opnsense.example"})
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
         coordinator=dummy_coordinator,
@@ -389,38 +373,11 @@ def test_get_versions_scenarios(
             key="firmware.update_available", name="Firmware"
         ),
     )
-    _pv, pl, ps = ent._get_versions(state)
-    assert ps == expected_series
-    assert pl == expected_latest
-
-
-@pytest.mark.parametrize(
-    ("series", "expected"),
-    [
-        ("25.1", "community"),
-        ("1.1", "community"),
-        ("2.4", "business"),
-        ("3.4", "business"),
-        ("25.7", "community"),
-        ("1.10", "business"),
-    ],
-)
-def test_get_product_class_and_series_parsing(
-    series: str | None,
-    expected: Any,
-    make_config_entry: Callable[..., MockConfigEntry],
-    dummy_coordinator: MagicMock,
-) -> None:
-    """Parameterize product class mapping by series minor version."""
-    entry = make_config_entry()
-    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
-        config_entry=entry,
-        coordinator=dummy_coordinator,
-        entity_description=UpdateEntityDescription(
-            key="firmware.update_available", name="Firmware"
-        ),
-    )
-    assert ent._get_product_class(series) == expected
+    ent.coordinator.data = state
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+    ent._handle_coordinator_update()
+    expected_published = expected_latest.replace("_", ".") if expected_latest else None
+    assert ent.latest_version == expected_published
 
 
 def test_handle_coordinator_update_sets_attributes(
@@ -482,6 +439,7 @@ def test_handle_coordinator_update_sets_attributes(
     [
         pytest.param("2.0.0", "2_0_1", "2.1", "2.1.3", "community/2.1", id="community"),
         pytest.param("3.0.0", "3_0_1", "2.4", "2.4.1", "business/2.4", id="business"),
+        pytest.param("1.9.0", "1_9_1", "1.9", "1.10.3", "business/1.10", id="business-1.10"),
     ],
 )
 def test_handle_coordinator_update_upgrade_sets_release_url(
@@ -575,11 +533,10 @@ async def test_handle_coordinator_update_update_normalizes_product_latest(
 
 
 def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
-    monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """When _get_product_class returns None, release_url should fall back to the OPNsense UI changelog."""
+    """An unmapped firmware series should use the OPNsense UI changelog."""
     entry = make_config_entry(
         {
             CONF_DEVICE_UNIQUE_ID: "test-device-123",
@@ -597,19 +554,16 @@ def test_handle_coordinator_update_release_url_fallback_when_product_class_none(
 
     state = {
         "firmware_update_info": {
-            "status": "upgrade",
+            "status": "update",
             "product": {
                 "product_version": "2.0.0",
                 "product_latest": "2_0_1",
-                "product_series": "2.1",
+                "product_series": "25.13",
             },
-            "upgrade_major_version": "2.1.3",
         }
     }
     ent.coordinator.data = state
     object.__setattr__(ent, "async_write_ha_state", lambda: None)
-
-    monkeypatch.setattr(ent, "_get_product_class", lambda series: None)
 
     ent._handle_coordinator_update()
 
@@ -888,12 +842,12 @@ async def test_async_install_handles_masked_polling_response(
 
 
 @pytest.mark.asyncio
-async def test_async_install_stops_after_four_invalid_polling_responses(
+async def test_async_install_terminates_after_invalid_polling_responses(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
 ) -> None:
-    """Stop after four malformed polls without fetching firmware info or rebooting."""
+    """Malformed polling responses should terminate without fetching info or rebooting."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -921,7 +875,6 @@ async def test_async_install_stops_after_four_invalid_polling_responses(
     await ent.async_install()
 
     bad.upgrade_status.assert_awaited()
-    assert bad.upgrade_status.await_count == 4
     bad.upgrade_firmware.assert_awaited_once()
     bad.get_firmware_update_info.assert_not_awaited()
     assert bad.rebooted is False
@@ -1002,7 +955,7 @@ async def test_async_release_notes_returns_value(
             },
             "status_msg": "ok",
             "needs_reboot": "0",
-            "all_packages": {},
+            "all_packages": ["base", "kernel"],
             "new_packages": [],
             "reinstall_packages": [],
             "remove_packages": [],
@@ -1016,3 +969,4 @@ async def test_async_release_notes_returns_value(
     val = await ent.async_release_notes()
     assert val is not None
     assert "OPN" in val
+    assert "- total affected packages: 2" in val

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -858,7 +858,6 @@ async def test_async_install_terminates_after_invalid_polling_responses(
     )
 
     bad: Any = _FirmwareInstallClient(
-        status_responses=[None, None, None, None],
         firmware_info={"needs_reboot": "1", "upgrade_needs_reboot": None},
     )
     object.__setattr__(bad, "upgrade_status", AsyncMock(side_effect=[None, None, None, None]))

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -461,16 +461,16 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
         delete_merged_branches=True,
     )
 
-    assert set(client.closed_prs) == {10, 9}
-    assert set(client.deleted_refs) == {
+    assert sorted(client.closed_prs) == [9, 10]
+    assert sorted(client.deleted_refs) == [
         "heads/chore/update-aiopnsense-manifest",
         "heads/chore/update-aiopnsense-old",
-    }
-    assert set(result.closed_prs) == {10, 9}
-    assert set(result.deleted_branches) == {
+    ]
+    assert sorted(result.closed_prs) == [9, 10]
+    assert sorted(result.deleted_branches) == [
         "chore/update-aiopnsense-manifest",
         "chore/update-aiopnsense-old",
-    }
+    ]
 
 
 def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -1,14 +1,15 @@
 """Tests for the aiopnsense dependency update workflow."""
 
 from importlib import util
+from io import StringIO
 import json
 from pathlib import Path
 import sys
+import tomllib
 from types import ModuleType
 
 import pytest
 
-WORKFLOW_PATH = Path(".github/workflows/update_aiopnsense.yml")
 SCRIPT_PATH = Path(".github/scripts/update_aiopnsense_pins.py")
 RELEASE_NOTES_SCRIPT_PATH = Path(".github/scripts/build_aiopnsense_release_notes.py")
 CLEANUP_SCRIPT_PATH = Path(".github/scripts/cleanup_aiopnsense_update_branches.py")
@@ -153,50 +154,6 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
 
 
 @pytest.mark.parametrize(
-    ("needle", "reason"),
-    [
-        ("actions/setup-python@v6", "pins a Python runtime"),
-        ("python-version: '3.14'", "uses a tomllib-capable Python"),
-        ("Automated update of aiopnsense dependency pins.", "describes generated PRs"),
-        ("custom_components/opnsense/manifest.json", "updates the integration manifest"),
-        ("pyproject.toml", "updates the local dependency pin"),
-        ("prek.toml", "updates the isolated mypy-hook dependency pin"),
-        ("pyproject_current", "reports pyproject drift in PR metadata"),
-        ("prek_current", "reports prek mypy-hook drift in PR metadata"),
-        ("--prek-path prek.toml", "passes the prek configuration to the updater"),
-        (str(SCRIPT_PATH), "runs the checked-in updater helper"),
-        (str(RELEASE_NOTES_SCRIPT_PATH), "runs the checked-in release-note helper"),
-        (str(CLEANUP_SCRIPT_PATH), "runs the checked-in cleanup helper"),
-        ("--body-path aiopnsense-update-pr-body.md", "uses a PR body file"),
-        ("--delete-merged-branches", "cleans merged workflow-owned branches"),
-        ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
-        ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
-        ("REPOSITORY: ${{ github.repository }}", "exports repository before shell use"),
-        ('--repository "$REPOSITORY"', "avoids inline repository template expansion"),
-    ],
-)
-def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
-    """Workflow should include the expected aiopnsense updater logic."""
-    del reason
-
-    assert needle in _read_update_workflow_surface()
-
-
-def test_workflow_avoids_inline_repository_template_expansion() -> None:
-    """Workflow should not expand the repository context inside shell scripts."""
-    assert '--repository "${{ github.repository }}"' not in WORKFLOW_PATH.read_text()
-
-
-def _read_update_workflow_surface() -> str:
-    """Read workflow and helper surfaces checked by workflow assertions."""
-    return (
-        f"{WORKFLOW_PATH.read_text()}\n"
-        f"{RELEASE_NOTES_SCRIPT_PATH.read_text()}\n"
-        f"{CLEANUP_SCRIPT_PATH.read_text()}"
-    )
-
-
-@pytest.mark.parametrize(
     (
         "manifest_version",
         "pyproject_version",
@@ -239,9 +196,13 @@ def test_updater_script_pin_update_scenarios(
     assert result.prek_current == pyproject_version
     assert result.latest == expected_target
     assert result.update_needed is expected_update_needed
-    assert f"aiopnsense=={expected_target}" in manifest_path.read_text()
-    assert f'    "aiopnsense=={expected_target}",' in pyproject_path.read_text()
-    assert f'  "aiopnsense=={expected_target}",' in prek_path.read_text()
+    manifest = json.loads(manifest_path.read_text())
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    prek = tomllib.loads(prek_path.read_text())
+    expected_pin = f"aiopnsense=={expected_target}"
+    assert expected_pin in manifest["requirements"]
+    assert expected_pin in pyproject["dependency-groups"]["ha"]
+    assert expected_pin in prek["repos"][0]["hooks"][0]["additional_dependencies"]
 
 
 def test_updater_script_updates_pyproject_pin_without_trailing_comma(
@@ -267,7 +228,8 @@ ha = [
     )
 
     assert result.update_needed is True
-    assert '    "aiopnsense==1.0.9"\n' in pyproject_path.read_text()
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    assert "aiopnsense==1.0.9" in pyproject["dependency-groups"]["ha"]
 
 
 def test_updater_script_repairs_prek_mypy_pin_drift(
@@ -291,7 +253,8 @@ def test_updater_script_repairs_prek_mypy_pin_drift(
     assert result.prek_current == "1.1.2"
     assert result.latest == "1.1.3"
     assert result.update_needed is True
-    assert '  "aiopnsense==1.1.3",' in prek_path.read_text()
+    prek = tomllib.loads(prek_path.read_text())
+    assert "aiopnsense==1.1.3" in prek["repos"][0]["hooks"][0]["additional_dependencies"]
 
 
 def test_updater_script_rejects_missing_prek_mypy_pin(
@@ -349,15 +312,19 @@ additional_dependencies = ["homeassistant-stubs"]
 )
 def test_updater_script_selects_latest_stable_from_pypi_payload(
     updater_script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
     payload: dict[str, object],
     expected_latest: str,
 ) -> None:
     """Updater script should select the latest installable stable PyPI release."""
-    latest = updater_script._select_latest_stable_version(
-        payload,
-    )
 
-    assert latest == expected_latest
+    def open_pypi_response(*_: object, **__: object) -> StringIO:
+        """Return the fake PyPI response as a readable context manager."""
+        return StringIO(json.dumps(payload))
+
+    monkeypatch.setattr(updater_script, "urlopen", open_pypi_response)
+
+    assert updater_script.fetch_latest_version() == expected_latest
 
 
 def test_updater_script_rejects_duplicate_pyproject_pins(
@@ -494,16 +461,16 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
         delete_merged_branches=True,
     )
 
-    assert client.closed_prs == [10, 9]
-    assert client.deleted_refs == [
+    assert set(client.closed_prs) == {10, 9}
+    assert set(client.deleted_refs) == {
         "heads/chore/update-aiopnsense-manifest",
         "heads/chore/update-aiopnsense-old",
-    ]
-    assert result.closed_prs == [10, 9]
-    assert result.deleted_branches == [
+    }
+    assert set(result.closed_prs) == {10, 9}
+    assert set(result.deleted_branches) == {
         "chore/update-aiopnsense-manifest",
         "chore/update-aiopnsense-old",
-    ]
+    }
 
 
 def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:


### PR DESCRIPTION
## Summary

Reworks brittle tests across the integration to assert observable behavior and stable data contracts instead of implementation details, exact incidental ordering, log text, or private helper structure. This keeps meaningful regression coverage while making routine refactors less likely to cause false failures.

## What Changed

- Replaced order-sensitive and raw mock-call inspections with state, call-contract, and order-independent assertions
- Folded inventory completeness cases into setup behavior coverage instead of testing private validation helpers directly
- Updated sensor tests to verify published values, availability, and live-traffic fallback behavior
- Removed tests coupled to concrete entity classes, module ownership, logging output, and internal retry/backoff mechanics
- Exercised firmware update behavior through entity state and release-note output rather than private parsing helpers
- Parsed JSON and TOML updater artifacts structurally, tested the public PyPI fetch boundary, and preserved cleanup mutation multiplicity without requiring execution order

## Why

The removed assertions primarily locked down internal organization or incidental execution details rather than user-visible behavior. The revised coverage protects configuration migration, entity publication, coordinator recovery, firmware update, and workflow-helper outcomes while allowing those internals to evolve safely.