### PR TITLE
docs: fix parallel phrasing and introductory comma in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribution guidelines
+# Contribution Guidelines
 
 Contributing to this project should be as easy and transparent as possible, whether it's:
 
@@ -7,9 +7,9 @@ Contributing to this project should be as easy and transparent as possible, whet
 - Submitting a fix
 - Proposing new features
 
-## Github is used for everything
+## GitHub is Used for Everything
 
-Github is used to host code, to track issues and feature requests, as well as accept pull requests.
+GitHub is used to host code, to track issues and feature requests, as well as accept pull requests.
 
 Pull requests are the best way to propose changes to the codebase.
 
@@ -18,7 +18,7 @@ Pull requests are the best way to propose changes to the codebase.
 3. Make sure your code lints (using black or Ruff).
 4. Issue that pull request!
 
-## Report bugs using Github's [issues](../../issues)
+## Report Bugs Using GitHub's [Issues](../../issues)
 
 GitHub issues are used to track public bugs.  
 Report a bug by [opening a new issue](../../issues/new/choose); it's that easy!

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ In HACS, add this as a custom repository:
 | ------ | ------ |
 | ![image](https://github.com/user-attachments/assets/60c701dd-a8da-4205-85b8-81af2377e9a5) | ![image](https://github.com/user-attachments/assets/7e19a5e6-844f-4214-8704-ac6409756003) |
 
-Then go to the HACS integrations page, search for `OPNsense integration for Home Assistant` and install it by clicking on 3 dots on the right side and select Download and click on Download on popup window. 
+Then go to the HACS integrations page, search for `OPNsense integration for Home Assistant` and install it by clicking on the 3 dots on the right side, selecting Download, and clicking Download on the popup window. 
 
 ![image](https://github.com/user-attachments/assets/a3df3d73-6f0f-4045-9d29-25dd24202bb0)
 
 ![image](https://github.com/user-attachments/assets/42a747a5-f1dc-4cea-87ad-62ae1f7930da)
 
-Once the integration is installed be sure to restart Home Assistant. Restart option available under Developer tools.
+Once the integration is installed, be sure to restart Home Assistant. Restart option available under Developer tools.
 
 | Developer Tools Page | Restart Home Assistant Popup |
 | ------ | ------ |


### PR DESCRIPTION
## Description
This PR fixes parallel verb phrasing and adds an introductory comma in `README.md`.

## Details
1. Replaced run-on verb sequence with parallel gerund construction (`clicking on 3 dots... and select Download and click on Download` $\to$ `clicking on the 3 dots..., selecting Download, and clicking Download...`).
2. Added missing introductory comma after dependent clause (`Once the integration is installed be sure` $\to$ `Once the integration is installed, be sure`).