### PR TITLE
fix: make live traffic polling interval configurable and respect defaults > 1s

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -39,10 +39,12 @@ from .const import (
     CONF_DEVICE_TRACKER_ENABLED,
     CONF_DEVICE_TRACKER_SCAN_INTERVAL,
     CONF_DEVICE_UNIQUE_ID,
+    CONF_LIVE_TRAFFIC_POLL_INTERVAL,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_LIVE_TRAFFIC,
     DEFAULT_DEVICE_TRACKER_ENABLED,
     DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL,
+    DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SYNC_OPTION_VALUE,
     DOMAIN,
@@ -700,11 +702,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         await _async_first_refresh_with_marker_issue(hass, entry, coordinator, repair_marker)
         if should_create_live_traffic_coordinator:
+            live_traffic_poll_interval: int = options.get(
+                CONF_LIVE_TRAFFIC_POLL_INTERVAL, DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL
+            )
             live_traffic_coordinator = OPNsenseLiveTrafficCoordinator(
                 hass=hass,
                 config_entry=entry,
                 coordinator=coordinator,
                 client=client,
+                poll_interval=live_traffic_poll_interval,
             )
 
         platforms: list[Platform] = PLATFORMS.copy()

--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -44,11 +44,13 @@ from .const import (
     CONF_ENTRY_TYPE,
     CONF_FIRMWARE_VERSION,
     CONF_GRANULAR_SYNC_OPTIONS,
+    CONF_LIVE_TRAFFIC_POLL_INTERVAL,
     CONF_MANUAL_DEVICES,
     DEFAULT_DEVICE_TRACKER_CONSIDER_HOME,
     DEFAULT_DEVICE_TRACKER_ENABLED,
     DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL,
     DEFAULT_GRANULAR_SYNC_OPTIONS,
+    DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SYNC_OPTION_VALUE,
     DEFAULT_VERIFY_SSL,
@@ -100,6 +102,7 @@ OPTIONS_INIT_NUMBER_BOUNDS: dict[str, tuple[int, int]] = {
     CONF_SCAN_INTERVAL: (10, 300),
     CONF_DEVICE_TRACKER_SCAN_INTERVAL: (30, 300),
     CONF_DEVICE_TRACKER_CONSIDER_HOME: (0, 3600),
+    CONF_LIVE_TRAFFIC_POLL_INTERVAL: (1, 300),
 }
 
 
@@ -799,6 +802,7 @@ def _build_options_init_schema(
     )
     defaults = {
         CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+        CONF_LIVE_TRAFFIC_POLL_INTERVAL: DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL,
         CONF_DEVICE_TRACKER_SCAN_INTERVAL: DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL,
         CONF_DEVICE_TRACKER_CONSIDER_HOME: DEFAULT_DEVICE_TRACKER_CONSIDER_HOME,
         **option_values,
@@ -811,6 +815,17 @@ def _build_options_init_schema(
 
     return vol.Schema(
         {
+            vol.Optional(
+                CONF_LIVE_TRAFFIC_POLL_INTERVAL,
+                default=defaults[CONF_LIVE_TRAFFIC_POLL_INTERVAL],
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=OPTIONS_INIT_NUMBER_BOUNDS[CONF_LIVE_TRAFFIC_POLL_INTERVAL][0],
+                    max=OPTIONS_INIT_NUMBER_BOUNDS[CONF_LIVE_TRAFFIC_POLL_INTERVAL][1],
+                    step=1,
+                    unit_of_measurement="seconds",
+                )
+            ),
             vol.Optional(
                 CONF_SCAN_INTERVAL,
                 default=defaults[CONF_SCAN_INTERVAL],

--- a/custom_components/opnsense/const.py
+++ b/custom_components/opnsense/const.py
@@ -26,6 +26,7 @@ DEVICE_TRACKER_COORDINATOR = "device_tracker_coordinator"
 SHOULD_RELOAD = "should_reload"
 TRACKED_MACS = "tracked_macs"
 DEFAULT_SCAN_INTERVAL = 30
+DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL = 5
 CONF_TLS_INSECURE = "tls_insecure"
 DEFAULT_TLS_INSECURE = False
 DEFAULT_VERIFY_SSL = True
@@ -62,6 +63,7 @@ CONF_SYNC_FIREWALL_AND_NAT = "sync_filters_and_nat"
 CONF_SYNC_UNBOUND = "sync_unbound"
 CONF_SYNC_INTERFACES = "sync_interfaces"
 CONF_SYNC_LIVE_TRAFFIC = "sync_live_traffic"
+CONF_LIVE_TRAFFIC_POLL_INTERVAL = "live_traffic_poll_interval"
 CONF_SYNC_CERTIFICATES = "sync_certificates"
 CONF_GRANULAR_SYNC_OPTIONS = "granular_sync_options"
 

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -100,6 +100,7 @@
       "init": {
         "data": {
           "scan_interval": "Scan Interval",
+          "live_traffic_poll_interval": "Live Traffic Poll Interval",
           "device_tracking_mode": "Device Tracker Mode",
           "device_tracker_scan_interval": "Device Tracker Scan Interval",
           "device_tracker_consider_home": "Device Tracker Consider Home",
@@ -108,7 +109,8 @@
         "description": "This screen exposes {options_scope}.",
         "data_description": {
           "device_tracking_mode": "For `Track only selected devices`, a next step lets you pick devices from recent ARP detections and add MAC addresses manually",
-          "scan_interval": "Scan interval controls how often this entry polls its source."
+          "scan_interval": "Scan interval controls how often this entry polls its source.",
+          "live_traffic_poll_interval": "Poll interval in seconds for live interface traffic updates."
         }
       },
       "granular_sync": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,7 @@ and options flow behaviors such as device tracker handling.
 
 from collections.abc import Callable
 import ipaddress
-from typing import Any, Never
+from typing import Any, Never, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from aiopnsense import exceptions as aiopnsense_exceptions
@@ -30,6 +30,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
+import custom_components.opnsense as init_mod
 import custom_components.opnsense.config_flow as cf_mod
 from custom_components.opnsense.config_flow import (
     CONF_DEVICE_TRACKING_MODE,
@@ -47,11 +48,14 @@ from custom_components.opnsense.const import (
     CONF_ENTRY_TYPE,
     CONF_FIRMWARE_VERSION,
     CONF_GRANULAR_SYNC_OPTIONS,
+    CONF_LIVE_TRAFFIC_POLL_INTERVAL,
     CONF_MANUAL_DEVICES,
     CONF_SYNC_FIREWALL_AND_NAT,
+    CONF_SYNC_INTERFACES,
     CONF_SYNC_LIVE_TRAFFIC,
     CONF_SYNC_SMART,
     CONF_SYNC_TELEMETRY,
+    DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     ENTRY_TYPE_CARP,
@@ -2745,3 +2749,85 @@ async def test_validate_input_granular_sync_uses_native_validation_only(
     client.is_plugin_installed.assert_not_awaited()
     client.set_use_snake_case.assert_not_awaited()
     client.async_close.assert_awaited_once()
+
+
+def test_options_init_schema_includes_live_traffic_poll_interval() -> None:
+    """Options init schema should expose a bounded live-traffic poll interval defaulting to 5s."""
+    oschema = cf_mod._build_options_init_schema(user_input=None)
+    validated = oschema({})
+    assert validated[CONF_LIVE_TRAFFIC_POLL_INTERVAL] == DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL
+    minimum, maximum = OPTIONS_INIT_NUMBER_BOUNDS[CONF_LIVE_TRAFFIC_POLL_INTERVAL]
+    assert minimum >= 1
+    assert oschema({CONF_LIVE_TRAFFIC_POLL_INTERVAL: 15})[CONF_LIVE_TRAFFIC_POLL_INTERVAL] == 15
+    with pytest.raises(vol.Invalid):
+        oschema({CONF_LIVE_TRAFFIC_POLL_INTERVAL: maximum + 1})
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_passes_configured_live_traffic_poll_interval(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator_capture: Any,
+    fake_client: Any,
+    fake_coordinator: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """The live traffic coordinator should receive the poll interval from entry options.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): pytest fixture used to replace dependencies.
+        ph_hass (Any): Patched Home Assistant test instance.
+        coordinator_capture (Any): Capture object recording constructed coordinators.
+        fake_client (Any): Mock OPNsense client used at the integration boundary.
+        fake_coordinator (Any): Mock coordinator installed for the scenario.
+        make_config_entry (Callable[..., MockConfigEntry]): Fixture that creates a mock configuration entry.
+    """
+    patch_opnsense_client(monkeypatch, init_mod, fake_client())
+    monkeypatch.setattr(
+        init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
+    )
+
+    construction_kwargs: list[dict[str, Any]] = []
+
+    def _live_factory(**kwargs: Any) -> Any:
+        """Capture constructor kwargs and return a fake live-traffic coordinator.
+
+        Args:
+            kwargs (Any): Keyword arguments passed to the live-traffic coordinator.
+
+        Returns:
+            Any: A fake coordinator with `async_start` and `async_shutdown` mocks.
+        """
+        construction_kwargs.append(kwargs)
+        live = MagicMock()
+        live.async_start = AsyncMock(return_value=True)
+        live.async_shutdown = AsyncMock(return_value=True)
+        return live
+
+    monkeypatch.setattr(init_mod, "OPNsenseLiveTrafficCoordinator", _live_factory)
+
+    for options, expected_interval in (
+        ({}, DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL),
+        ({CONF_LIVE_TRAFFIC_POLL_INTERVAL: 12}, 12),
+    ):
+        construction_kwargs.clear()
+        entry = make_config_entry(
+            data={
+                CONF_URL: "http://1.2.3.4",
+                CONF_USERNAME: "u",
+                CONF_PASSWORD: "p",
+                CONF_DEVICE_UNIQUE_ID: "dev1",
+                CONF_SYNC_INTERFACES: True,
+                CONF_SYNC_LIVE_TRAFFIC: True,
+            },
+            options={CONF_DEVICE_TRACKER_ENABLED: False, **options},
+        )
+        hass = cast("MagicMock", ph_hass)
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+        hass.config_entries.async_reload = MagicMock()
+        hass.data = {}
+
+        res = await init_mod.async_setup_entry(hass, entry)
+        assert res is True
+        assert len(construction_kwargs) == 1
+        assert construction_kwargs[0]["poll_interval"] == expected_interval

--- a/tests/test_traffic_coordinator.py
+++ b/tests/test_traffic_coordinator.py
@@ -683,3 +683,27 @@ async def test_live_traffic_run_applies_and_caps_backoff_sequence(
 
     assert sleep_calls == [5, 10, 20, 30, 30]
     assert coordinator._failure_count == 4
+
+
+@pytest.mark.asyncio
+async def test_live_traffic_coordinator_passes_configured_poll_interval_to_stream(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """The configured poll interval (not the hardcoded 1s default) should reach the stream call.
+
+    Args:
+        make_config_entry (Callable[..., MockConfigEntry]): Factory for the config entry under test.
+    """
+    main_coordinator = MagicMock()
+    main_coordinator.data = {"interfaces": {"wan": {"name": "WAN"}}}
+    client = _FakeStreamClient([])
+
+    coordinator, _ = _build_test_coordinator(
+        make_config_entry,
+        client=client,
+        poll_interval=7,
+    )
+
+    await coordinator._consume_stream()
+
+    assert client.stream_calls == [7]


### PR DESCRIPTION
## Problem

Live interface traffic polling runs at a hardcoded **1 Hz** regardless of the entry's `scan_interval` and is not configurable by the user. Each enabled interface gets a WebSocket stream polled once per second, indefinitely, which wastes network/CPU/battery resources for users who do not need sub-5-second traffic resolution and cannot turn it down.

Fixes #699

## Root cause

`custom_components/opnsense/__init__.py` constructs `OPNsenseLiveTrafficCoordinator(...)` without passing `poll_interval`, so the coordinator falls back to its own hardcoded default of `1` second. The coordinator intentionally ignores HA's `scan_interval` (it uses `update_interval=None` plus its own `asyncio.sleep(self._poll_interval)` loop), so no existing setting influenced the rate.

## Change

- Add a new option `live_traffic_poll_interval` (`CONF_LIVE_TRAFFIC_POLL_INTERVAL`), defaulting to **5 seconds** (`DEFAULT_LIVE_TRAFFIC_POLL_INTERVAL = 5`).
- Expose it in the existing options-flow init step as a bounded number selector (1–300 s, unit "seconds"), wired through `OPTIONS_INIT_NUMBER_BOUNDS` / `_build_options_init_schema` exactly like the existing scan-interval options, including clamping of stored values.
- Pass it from entry options into `OPNsenseLiveTrafficCoordinator(poll_interval=...)` at the construction site in `async_setup_entry`.
- Add labels/description for the new field to `translations/en.json`.

No changes were made to the coordinator's loop/retry architecture beyond threading the interval through.

## Why this is safe

- Existing installs without the new option get the 5 s default instead of 1 Hz — a strictly lower poll rate than before, matching the issue author's suggested default of >=5 s.
- Users who want faster updates can set it down to 1 s; the previous effective behavior remains reachable.
- The options flow change reuses the established bounds/normalization machinery, so validation, CARP entries (which use a separate schema) and granular-sync handling are untouched.

## Verification

- New tests:
  - `tests/test_traffic_coordinator.py`: coordinator forwards the configured interval (7 s) into `stream_interface_traffic`, proving the hardcoded 1 s default is bypassed.
  - `tests/test_config_flow.py`: options schema exposes the field with default 5, accepts in-range values, rejects out-of-range; `async_setup_entry` passes the configured value (and the default when unset) to the coordinator constructor.
- `uv sync --group pytest`; ran `pytest tests/test_traffic_coordinator.py tests/test_config_flow.py tests/test_init.py tests/test_integration.py` — all pass. Full suite: **1336 passed**.
- `ruff check`, `ruff format --check` and `pydoclint` clean on all touched files.