### PR TITLE
Fix release workflow Git authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,13 +144,14 @@ jobs:
         if: github.event.release.prerelease == false
         id: validation_ref
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           temp_ref="release-validation/${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git check-ref-format --branch "$temp_ref"
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" push origin "HEAD:refs/heads/$temp_ref"
+          gh auth setup-git --hostname github.com
+          git push origin "HEAD:refs/heads/$temp_ref"
           echo "name=$temp_ref" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch and verify immutable release gates
@@ -171,7 +172,7 @@ jobs:
       - name: Atomically advance target and guarded release tag
         if: github.event.release.prerelease == false && steps.base.outputs.resume != 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           ORIGINAL_TAG_OID: ${{ steps.base.outputs.tag-oid }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
@@ -185,8 +186,7 @@ jobs:
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$ORIGINAL_TAG_OID" ]]
           [[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]
           git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG" HEAD
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" \
-            push --atomic \
+          git push --atomic \
             --force-with-lease="refs/heads/$RELEASE_TARGET:$TARGET_SHA" \
             --force-with-lease="refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" \
             origin "HEAD:refs/heads/$RELEASE_TARGET" "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
@@ -220,7 +220,7 @@ jobs:
       - name: Delete validated temporary branch
         if: github.event.release.prerelease == false && success()
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" push origin --delete "$TEMP_REF"
+          git push origin --delete "$TEMP_REF"

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -382,6 +382,24 @@ def test_release_workflow_has_guarded_promotion_and_firmware_archive_contract() 
     )
 
 
+def test_release_workflow_uses_scoped_github_cli_credentials_for_git_pushes() -> None:
+    """Authenticate release pushes without persisting checkout credentials."""
+    document = _load_workflow("release.yml")
+    steps = _named_steps(document, "release")
+    push_step_names = (
+        "Publish B to an isolated validation branch",
+        "Atomically advance target and guarded release tag",
+        "Delete validated temporary branch",
+    )
+
+    for step_name in push_step_names:
+        step = steps[step_name]
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+        assert "extraheader" not in step["run"].lower()
+
+    assert "gh auth setup-git" in steps["Publish B to an isolated validation branch"]["run"]
+
+
 def test_release_workflow_preserves_resume_wiring_for_validated_release_commit() -> None:
     """Preserve resume wiring for a previously validated stable release commit."""
     document = _load_workflow("release.yml")


### PR DESCRIPTION
## Summary
Fixes stable-release Git authentication so the validation branch, guarded promotion, and cleanup pushes can authenticate reliably without persisting checkout credentials.

## What Changed
- Configure Git to use GitHub CLI's credential helper with the step-scoped `GH_TOKEN`.
- Route validation-branch publication, atomic branch/tag promotion, and temporary-branch deletion through that supported Git authentication path.
- Add a focused workflow contract that prevents manual `extraheader` authentication from returning.

## Why
The v1.0.6 release workflow reached its first authenticated push but failed with `could not read Username for 'https://github.com'`. The workflow had constructed an OAuth Bearer header for Git smart HTTP after intentionally disabling checkout credential persistence.

Using GitHub CLI's credential helper preserves the security boundary while providing Git with a supported credential flow for every release mutation.
