### PR TITLE
Fix deprecated device registry lookups

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -37,6 +37,9 @@ from .const import (
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseBaseEntity
 from .helpers import (
+    async_get_device_by_connection,
+    async_get_device_by_identifier,
+    async_get_devices_by_connection,
     detach_shared_router_parent,
     dict_get,
     get_arp_ip,
@@ -364,14 +367,18 @@ def _cleanup_stale_tracked_devices(
         return
 
     entity_registry = er.async_get(hass)
-    router_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
+    router_device = async_get_device_by_identifier(
+        device_registry,
+        (DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID]),
+        config_entry.entry_id,
     )
     router_device_id = router_device.id if router_device else None
 
     for mac_address in stale_mac_addresses:
-        rem_device = device_registry.async_get_device(
-            connections={(CONNECTION_NETWORK_MAC, mac_address)}
+        rem_device = async_get_device_by_connection(
+            device_registry,
+            (CONNECTION_NETWORK_MAC, mac_address),
+            config_entry.entry_id,
         )
         expected_unique_id = slugify(
             f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
@@ -462,13 +469,11 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             return False
 
         device_registry = async_get_dev_reg(hass)
-        existing_device = device_registry.async_get_device(
-            connections={(CONNECTION_NETWORK_MAC, self.mac_address)}
+        existing_devices = async_get_devices_by_connection(
+            device_registry,
+            (CONNECTION_NETWORK_MAC, self.mac_address),
         )
-        if existing_device is None:
-            return False
-
-        return getattr(existing_device, "disabled_by", None) is None
+        return any(getattr(device, "disabled_by", None) is None for device in existing_devices)
 
     @property
     def is_connected(self) -> bool:

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -1,6 +1,6 @@
 """Helper methods for OPNsense."""
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Callable, Mapping, MutableMapping
 import ipaddress
 import re
 from typing import Any
@@ -23,6 +23,82 @@ from .const import (
     ENTRY_TYPE_CARP,
     ENTRY_TYPE_DEVICE,
 )
+
+
+def async_get_device_by_identifier(
+    device_registry: DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> DeviceEntry | None:
+    """Get a config-entry device by identifier across supported HA versions.
+
+    Current Home Assistant releases provide config-entry-scoped device
+    lookups. Older supported releases, including 2026.3, expose only
+    ``async_get_device``.
+
+    Args:
+        device_registry (DeviceRegistry): Registry that owns the requested device.
+        identifier (tuple[str, str]): Domain and identifier value to match.
+        config_entry_id (str): Config entry that owns the requested device.
+
+    Returns:
+        DeviceEntry | None: Matching device, if registered.
+    """
+    modern_get: Callable[[tuple[str, str], str], DeviceEntry | None] | None = getattr(
+        device_registry, "async_get_device_by_identifier", None
+    )
+    if modern_get is not None:
+        return modern_get(identifier, config_entry_id)
+    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    return legacy_get(identifiers={identifier})
+
+
+def async_get_device_by_connection(
+    device_registry: DeviceRegistry,
+    connection: tuple[str, str],
+    config_entry_id: str,
+) -> DeviceEntry | None:
+    """Get a config-entry device by connection across supported HA versions.
+
+    Args:
+        device_registry (DeviceRegistry): Registry that owns the requested device.
+        connection (tuple[str, str]): Connection type and value to match.
+        config_entry_id (str): Config entry that owns the requested device.
+
+    Returns:
+        DeviceEntry | None: Matching device, if registered.
+    """
+    modern_get: Callable[[tuple[str, str], str], DeviceEntry | None] | None = getattr(
+        device_registry, "async_get_device_by_connection", None
+    )
+    if modern_get is not None:
+        return modern_get(connection, config_entry_id)
+    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    return legacy_get(connections={connection})
+
+
+def async_get_devices_by_connection(
+    device_registry: DeviceRegistry,
+    connection: tuple[str, str],
+) -> list[DeviceEntry]:
+    """Get all devices matching a connection across supported HA versions.
+
+    Args:
+        device_registry (DeviceRegistry): Registry that owns the requested devices.
+        connection (tuple[str, str]): Connection type and value to match.
+
+    Returns:
+        list[DeviceEntry]: Every matching device on current HA, or the single
+            unscoped match exposed by older supported releases.
+    """
+    modern_get: Callable[..., list[DeviceEntry]] | None = getattr(
+        device_registry, "async_get_devices", None
+    )
+    if modern_get is not None:
+        return modern_get(connections={connection})
+    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    device = legacy_get(connections={connection})
+    return [device] if device is not None else []
 
 
 def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = None) -> Any | None:
@@ -315,8 +391,10 @@ def find_replacement_router_device_id(
         owner_device_unique_id = owner_entry.data.get(CONF_DEVICE_UNIQUE_ID)
         if not isinstance(owner_device_unique_id, str):
             continue
-        owner_router = device_registry.async_get_device(
-            identifiers={(DOMAIN, owner_device_unique_id)}
+        owner_router = async_get_device_by_identifier(
+            device_registry,
+            (DOMAIN, owner_device_unique_id),
+            owner_entry_id,
         )
         if owner_router is not None:
             return owner_router.id

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from .const import DOMAIN
-from .helpers import detach_shared_router_parent
+from .helpers import async_get_device_by_identifier, detach_shared_router_parent
 
 REPAIR_MARKER_KEY: str = "device_id_repair"
 _REPAIR_MARKER_VERSION = 1
@@ -148,11 +148,15 @@ class RepairReconciliation:
                 )
             migrations.append((candidate, target_unique_id))
 
-        old_main = device_registry.async_get_device(
-            identifiers={(DOMAIN, self.marker.old_device_id)}
+        old_main = async_get_device_by_identifier(
+            device_registry,
+            (DOMAIN, self.marker.old_device_id),
+            self.config_entry.entry_id,
         )
-        new_main = device_registry.async_get_device(
-            identifiers={(DOMAIN, self.marker.new_device_id)}
+        new_main = async_get_device_by_identifier(
+            device_registry,
+            (DOMAIN, self.marker.new_device_id),
+            self.config_entry.entry_id,
         )
         if new_main is not None:
             if old_main is not None and new_main.id != old_main.id:
@@ -270,8 +274,10 @@ class RepairReconciliation:
             preserved_device_ids = {
                 entity.device_id for entity in surviving_entities if entity.device_id is not None
             }
-            main_device = device_registry.async_get_device(
-                identifiers={(DOMAIN, self.marker.new_device_id)}
+            main_device = async_get_device_by_identifier(
+                device_registry,
+                (DOMAIN, self.marker.new_device_id),
+                self.config_entry.entry_id,
             )
             if main_device is not None:
                 preserved_device_ids.add(main_device.id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -546,15 +546,15 @@ def fake_reg_factory() -> Any:
             Any: Configured object produced by the local test double.
 
         Args:
-            device_exists (bool): Whether ``async_get_device`` should return a device record.
+            device_exists (bool): Whether registry lookups should return a device record.
             device_id (str): Device identifier returned when ``device_exists`` is true.
             config_entries (set[str] | None): Config entries already linked to the fake device.
             disabled_by (str | None): Disable source reported by the fake device entry.
         """
         registry = MagicMock()
-        registry.async_get_device.side_effect = lambda *args, **kwargs: (
+        device = (
             None
-            if not device_exists or "identifiers" in kwargs
+            if not device_exists
             else MagicMock(
                 id=device_id,
                 via_device_id=None,
@@ -562,6 +562,12 @@ def fake_reg_factory() -> Any:
                 disabled_by=disabled_by,
             )
         )
+        registry.async_get_device.side_effect = lambda *args, **kwargs: (
+            None if "identifiers" in kwargs else device
+        )
+        registry.async_get_device_by_identifier.return_value = None
+        registry.async_get_device_by_connection.return_value = device
+        registry.async_get_devices.return_value = [] if device is None else [device]
         return registry
 
     return _make

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -2002,6 +2002,12 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
 
     device_registry = MagicMock()
     device_registry.async_get_device.side_effect = get_device
+    device_registry.async_get_device_by_identifier.side_effect = (
+        lambda identifier, _config_entry_id: get_device(identifiers={identifier})
+    )
+    device_registry.async_get_device_by_connection.side_effect = (
+        lambda connection, _config_entry_id: get_device(connections={connection})
+    )
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", MagicMock(return_value=device_registry))
 
     ph_hass.config_entries.async_update_entry = MagicMock()
@@ -2110,6 +2116,12 @@ async def test_async_setup_entry_removes_stale_tracker_entities_clears_missing_p
 
     device_registry = MagicMock()
     device_registry.async_get_device = MagicMock(side_effect=get_device)
+    device_registry.async_get_device_by_identifier.side_effect = (
+        lambda identifier, _config_entry_id: get_device(identifiers={identifier})
+    )
+    device_registry.async_get_device_by_connection.side_effect = (
+        lambda connection, _config_entry_id: get_device(connections={connection})
+    )
     device_registry.async_get = MagicMock(return_value=None)
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", MagicMock(return_value=device_registry))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -48,10 +48,12 @@ def test_async_get_device_by_identifier_supports_ha_versions(
     """
     device = MagicMock()
     legacy_get = MagicMock(return_value=device)
-    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    registry: Any = SimpleNamespace()
     if use_modern_api:
         modern_get = MagicMock(return_value=device)
         registry.async_get_device_by_identifier = modern_get
+    else:
+        registry.async_get_device = legacy_get
 
     result = async_get_device_by_identifier(
         registry,
@@ -78,10 +80,12 @@ def test_async_get_device_by_connection_supports_ha_versions(
     """
     device = MagicMock()
     legacy_get = MagicMock(return_value=device)
-    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    registry: Any = SimpleNamespace()
     if use_modern_api:
         modern_get = MagicMock(return_value=device)
         registry.async_get_device_by_connection = modern_get
+    else:
+        registry.async_get_device = legacy_get
 
     result = async_get_device_by_connection(
         registry,
@@ -108,10 +112,12 @@ def test_async_get_devices_by_connection_supports_ha_versions(
     """
     device = MagicMock()
     legacy_get = MagicMock(return_value=device)
-    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    registry: Any = SimpleNamespace()
     if use_modern_api:
         modern_get = MagicMock(return_value=[device, MagicMock()])
         registry.async_get_devices = modern_get
+    else:
+        registry.async_get_device = legacy_get
 
     result = async_get_devices_by_connection(
         registry,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 """Unit tests for shared OPNsense integration helpers."""
 
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -16,6 +17,9 @@ from custom_components.opnsense.const import (
     ENTRY_TYPE_CARP,
 )
 from custom_components.opnsense.helpers import (
+    async_get_device_by_connection,
+    async_get_device_by_identifier,
+    async_get_devices_by_connection,
     coerce_bool,
     config_entry_identity,
     create_opnsense_client,
@@ -31,6 +35,96 @@ from custom_components.opnsense.helpers import (
     is_usable_carp_vip,
     normalize_arp_mac,
 )
+
+
+@pytest.mark.parametrize("use_modern_api", [True, False], ids=["modern", "legacy"])
+def test_async_get_device_by_identifier_supports_ha_versions(
+    use_modern_api: bool,
+) -> None:
+    """Use the scoped identifier API when available and retain the HA 2026.3 fallback.
+
+    Args:
+        use_modern_api (bool): Whether the fake registry exposes the current scoped API.
+    """
+    device = MagicMock()
+    legacy_get = MagicMock(return_value=device)
+    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    if use_modern_api:
+        modern_get = MagicMock(return_value=device)
+        registry.async_get_device_by_identifier = modern_get
+
+    result = async_get_device_by_identifier(
+        registry,
+        ("opnsense", "router-id"),
+        "entry-id",
+    )
+
+    assert result is device
+    if use_modern_api:
+        modern_get.assert_called_once_with(("opnsense", "router-id"), "entry-id")
+        legacy_get.assert_not_called()
+    else:
+        legacy_get.assert_called_once_with(identifiers={("opnsense", "router-id")})
+
+
+@pytest.mark.parametrize("use_modern_api", [True, False], ids=["modern", "legacy"])
+def test_async_get_device_by_connection_supports_ha_versions(
+    use_modern_api: bool,
+) -> None:
+    """Use the scoped connection API when available and retain the HA 2026.3 fallback.
+
+    Args:
+        use_modern_api (bool): Whether the fake registry exposes the current scoped API.
+    """
+    device = MagicMock()
+    legacy_get = MagicMock(return_value=device)
+    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    if use_modern_api:
+        modern_get = MagicMock(return_value=device)
+        registry.async_get_device_by_connection = modern_get
+
+    result = async_get_device_by_connection(
+        registry,
+        ("mac", "aa:bb:cc:dd:ee:ff"),
+        "entry-id",
+    )
+
+    assert result is device
+    if use_modern_api:
+        modern_get.assert_called_once_with(("mac", "aa:bb:cc:dd:ee:ff"), "entry-id")
+        legacy_get.assert_not_called()
+    else:
+        legacy_get.assert_called_once_with(connections={("mac", "aa:bb:cc:dd:ee:ff")})
+
+
+@pytest.mark.parametrize("use_modern_api", [True, False], ids=["modern", "legacy"])
+def test_async_get_devices_by_connection_supports_ha_versions(
+    use_modern_api: bool,
+) -> None:
+    """Return every current match while adapting the singular HA 2026.3 fallback.
+
+    Args:
+        use_modern_api (bool): Whether the fake registry exposes the current multi-device API.
+    """
+    device = MagicMock()
+    legacy_get = MagicMock(return_value=device)
+    registry: Any = SimpleNamespace(async_get_device=legacy_get)
+    if use_modern_api:
+        modern_get = MagicMock(return_value=[device, MagicMock()])
+        registry.async_get_devices = modern_get
+
+    result = async_get_devices_by_connection(
+        registry,
+        ("mac", "aa:bb:cc:dd:ee:ff"),
+    )
+
+    if use_modern_api:
+        assert len(result) == 2
+        modern_get.assert_called_once_with(connections={("mac", "aa:bb:cc:dd:ee:ff")})
+        legacy_get.assert_not_called()
+    else:
+        assert result == [device]
+        legacy_get.assert_called_once_with(connections={("mac", "aa:bb:cc:dd:ee:ff")})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3539,6 +3539,9 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
         return identifier_router_map.get(key)
 
     dr_reg.async_get_device = MagicMock(side_effect=get_device)
+    dr_reg.async_get_device_by_identifier.side_effect = lambda identifier, _config_entry_id: (
+        get_device(identifiers={identifier})
+    )
     monkeypatch.setattr(dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
         dr,


### PR DESCRIPTION
## Summary

Updates OPNsense device-registry lookups to use config-entry-scoped Home Assistant APIs when available while retaining runtime compatibility with Home Assistant 2026.3. This removes current deprecation warnings and prevents breakage when the legacy lookup is removed.

## What Changed

- Added compatibility helpers for identifier, connection, and multi-device connection lookups.
- Scoped router, tracker-cleanup, and repair-reconciliation lookups to their owning config entries.
- Updated MAC matching to handle multiple devices that share a connection across config entries.
- Added regression coverage for Home Assistant 2026.3 fallback behavior and current releases without the legacy lookup API.

## Why

Home Assistant no longer treats device identifiers and connections as globally unique across config entries. Capability-based lookup helpers let current releases use the non-deprecated, unambiguous APIs while older supported releases continue through the legacy fallback.
