### PR TITLE
Fix Home Assistant device registry deprecations

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -310,6 +310,14 @@ async def async_setup_entry(
         reconciliation_complete = _track_all_arp_entries_are_complete(arp_entries)
     devices, mac_addresses, enabled_default = _compile_tracked_devices(config_entry, arp_entries)
 
+    router_device_id: str | None = None
+    if devices and getattr(dev_reg, "async_get_device_by_identifier", None) is not None:
+        router_device = dev_reg.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])},
+        )
+        router_device_id = router_device.id
+
     for device in devices:
         mac = device.get("mac")
         if not isinstance(mac, str):
@@ -321,6 +329,7 @@ async def async_setup_entry(
             mac=mac,
             mac_vendor=device.get("manufacturer", None),
             hostname=device.get("hostname", None),
+            router_device_id=router_device_id,
         )
         entities.append(entity)
     if not is_reconciliation_active(config_entry):
@@ -429,6 +438,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         mac: str,
         mac_vendor: str | None,
         hostname: str | None,
+        router_device_id: str | None = None,
     ) -> None:
         """Set up the OPNsense scanner entity.
 
@@ -439,6 +449,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             mac (str): MAC address tracked by the entity.
             mac_vendor (str | None): Vendor name reported for the MAC address.
             hostname (str | None): Hostname reported by OPNsense.
+            router_device_id (str | None): Registry id of the parent router on HA 2026.8+.
         """
         super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_vendor: str | None = mac_vendor
@@ -454,6 +465,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         self._attr_source_type: SourceType = SourceType.ROUTER
         self._attr_icon: str | None = None
         self._fallback_device_info_consumed: bool = False
+        self._router_device_id: str | None = router_device_id
 
     def _has_matching_enabled_mac_device(self) -> bool:
         """Return whether a matching MAC device exists and is not disabled.
@@ -637,10 +649,19 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         if self.mac_address is not None:
             connections.add((CONNECTION_NETWORK_MAC, self.mac_address))
 
-        return DeviceInfo(
+        device_info = DeviceInfo(
             connections=connections,
-            default_manufacturer=self._mac_vendor or "",
-            default_name=self.hostname or self.mac_address or "",
+            manufacturer=self._mac_vendor or "",
+            name=self.hostname or self.mac_address or "",
+        )
+        if self._router_device_id is not None:
+            device_info["via_device_id"] = self._router_device_id
+            return device_info
+
+        # Home Assistant 2026.3-2026.7 resolves parent devices by identifier.
+        legacy_device_info_factory: Any = DeviceInfo
+        return legacy_device_info_factory(
+            **device_info,
             via_device=(DOMAIN, self._device_unique_id),
         )
 

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -49,7 +49,8 @@ def async_get_device_by_identifier(
     )
     if modern_get is not None:
         return modern_get(identifier, config_entry_id)
-    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    legacy_registry: Any = device_registry
+    legacy_get: Callable[..., DeviceEntry | None] = legacy_registry.async_get_device
     return legacy_get(identifiers={identifier})
 
 
@@ -73,7 +74,8 @@ def async_get_device_by_connection(
     )
     if modern_get is not None:
         return modern_get(connection, config_entry_id)
-    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    legacy_registry: Any = device_registry
+    legacy_get: Callable[..., DeviceEntry | None] = legacy_registry.async_get_device
     return legacy_get(connections={connection})
 
 
@@ -96,9 +98,34 @@ def async_get_devices_by_connection(
     )
     if modern_get is not None:
         return modern_get(connections={connection})
-    legacy_get: Callable[..., DeviceEntry | None] = device_registry.async_get_device
+    legacy_registry: Any = device_registry
+    legacy_get: Callable[..., DeviceEntry | None] = legacy_registry.async_get_device
     device = legacy_get(connections={connection})
     return [device] if device is not None else []
+
+
+def device_belongs_to_config_entry(
+    device_entry: DeviceEntry,
+    config_entry_id: str,
+) -> bool:
+    """Return whether a device belongs to a config entry across supported HA versions.
+
+    Home Assistant 2026.8 and newer expose the single owner through
+    ``config_entry_id``. Older supported releases expose the legacy
+    ``config_entries`` set instead.
+
+    Args:
+        device_entry (DeviceEntry): Device whose ownership should be checked.
+        config_entry_id (str): Config entry expected to own the device.
+
+    Returns:
+        bool: Whether the device belongs to the requested config entry.
+    """
+    owner_entry_id = getattr(device_entry, "config_entry_id", None)
+    if isinstance(owner_entry_id, str):
+        return owner_entry_id == config_entry_id
+    legacy_entry_ids: set[str] = getattr(device_entry, "config_entries", set())
+    return config_entry_id in legacy_entry_ids
 
 
 def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = None) -> Any | None:
@@ -381,7 +408,10 @@ def find_replacement_router_device_id(
         str | None: Replacement router ``device_id`` if a surviving OPNsense entry
             can be resolved, otherwise ``None``.
     """
-    remaining_config_entries = sorted(shared_device_entry.config_entries)
+    if isinstance(getattr(shared_device_entry, "config_entry_id", None), str):
+        return None
+    legacy_entry_ids: set[str] = getattr(shared_device_entry, "config_entries", set())
+    remaining_config_entries = sorted(legacy_entry_ids)
     for owner_entry_id in remaining_config_entries:
         if owner_entry_id == shared_config_entry_id:
             continue
@@ -409,7 +439,12 @@ def detach_shared_router_parent(
     config_entries: ConfigEntries,
     device_registry: DeviceRegistry,
 ) -> tuple[bool, str | None]:
-    """Detach a shared tracker device from a removed router config entry.
+    """Remove or detach a tracker device across supported HA versions.
+
+    Home Assistant 2026.8 and newer assign each device to one config entry,
+    so an OPNsense-owned tracker device is removed directly. Older supported
+    releases may share one device across config entries and retain the legacy
+    detach-and-reparent behavior.
 
     Args:
         shared_config_entry_id (str): The config entry being detached from the shared device.
@@ -429,6 +464,12 @@ def detach_shared_router_parent(
         and router_device_id is not None
         and shared_device_entry.via_device_id == router_device_id
     )
+    owner_entry_id = getattr(shared_device_entry, "config_entry_id", None)
+    if isinstance(owner_entry_id, str):
+        if owner_entry_id == shared_config_entry_id:
+            device_registry.async_remove_device(shared_device_entry.id)
+        return is_device_from_router, None
+
     replacement_router_id: str | None = None
     if is_device_from_router:
         replacement_router_id = find_replacement_router_device_id(
@@ -438,26 +479,18 @@ def detach_shared_router_parent(
             device_registry=device_registry,
         )
 
+    legacy_changes: dict[str, Any] = {"remove_config_entry_id": shared_config_entry_id}
     if replacement_router_id is not None:
-        device_registry.async_update_device(
-            shared_device_entry.id,
-            remove_config_entry_id=shared_config_entry_id,
-            via_device_id=replacement_router_id,
-        )
+        legacy_changes["via_device_id"] = replacement_router_id
+        device_registry.async_update_device(shared_device_entry.id, **legacy_changes)
         return is_device_from_router, replacement_router_id
 
     if is_device_from_router:
-        device_registry.async_update_device(
-            shared_device_entry.id,
-            remove_config_entry_id=shared_config_entry_id,
-            via_device_id=None,
-        )
+        legacy_changes["via_device_id"] = None
+        device_registry.async_update_device(shared_device_entry.id, **legacy_changes)
         return is_device_from_router, None
 
-    device_registry.async_update_device(
-        shared_device_entry.id,
-        remove_config_entry_id=shared_config_entry_id,
-    )
+    device_registry.async_update_device(shared_device_entry.id, **legacy_changes)
     return is_device_from_router, None
 
 

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -14,7 +14,11 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from .const import DOMAIN
-from .helpers import async_get_device_by_identifier, detach_shared_router_parent
+from .helpers import (
+    async_get_device_by_identifier,
+    detach_shared_router_parent,
+    device_belongs_to_config_entry,
+)
 
 REPAIR_MARKER_KEY: str = "device_id_repair"
 _REPAIR_MARKER_VERSION = 1
@@ -161,7 +165,9 @@ class RepairReconciliation:
         if new_main is not None:
             if old_main is not None and new_main.id != old_main.id:
                 raise RepairReconciliationError("primary device identifier target collision")
-            if old_main is None and self.config_entry.entry_id not in new_main.config_entries:
+            if old_main is None and not device_belongs_to_config_entry(
+                new_main, self.config_entry.entry_id
+            ):
                 raise RepairReconciliationError("primary device identifier target collision")
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -568,6 +568,7 @@ def fake_reg_factory() -> Any:
         registry.async_get_device_by_identifier.return_value = None
         registry.async_get_device_by_connection.return_value = device
         registry.async_get_devices.return_value = [] if device is None else [device]
+        registry.async_get_or_create.return_value = MagicMock(id="router-device-id")
         return registry
 
     return _make

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -225,6 +225,15 @@ async def test_async_setup_entry_configured_devices(
     assert uid.endswith("mac_aa_bb_cc")
     assert "aa_bb_cc" in uid
     assert created.mac_address == "aa:bb:cc"
+    assert created._router_device_id == "router-device-id"
+    device_info = created.device_info
+    assert device_info is not None
+    assert device_info["via_device_id"] == "router-device-id"
+    assert "via_device" not in device_info
+    fake.async_get_or_create.assert_called_once_with(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "dev1")},
+    )
     assert hass.config_entries.async_update_entry.called
     call = hass.config_entries.async_update_entry.call_args
     args = call.args
@@ -961,6 +970,7 @@ async def test_restore_last_state_and_device_info(
         mac="aa:bb:cc",
         mac_vendor="mfg",
         hostname="dev",
+        router_device_id="router-device-id",
     )
     assert ent.name is None
     assert ent.unique_id == "dev1_mac_aa_bb_cc"
@@ -991,21 +1001,35 @@ async def test_restore_last_state_and_device_info(
     assert "last_known_connected_time" in attributes
 
     devinfo = ent.device_info
-    # support both DeviceInfo object and dict-shaped DeviceInfo used in tests
-    if isinstance(devinfo, MutableMapping):
-        connections = devinfo.get("connections", [])
-        via = devinfo.get("via_device")
-        default_name = devinfo.get("default_name")
-    else:
-        connections = getattr(devinfo, "connections", [])
-        via = getattr(devinfo, "via_device", None)
-        default_name = getattr(devinfo, "default_name", None)
+    assert devinfo is not None
+    assert any(t[1] == "aa:bb:cc" for t in devinfo["connections"])
+    assert devinfo["name"] == "dev"
+    assert devinfo["manufacturer"] == "mfg"
+    assert devinfo["via_device_id"] == "router-device-id"
+    assert "default_name" not in devinfo
+    assert "default_manufacturer" not in devinfo
+    assert "via_device" not in devinfo
 
-    assert any(t[1] == "aa:bb:cc" for t in connections)
-    assert default_name == "dev"
-    assert via is not None
-    assert via[0] == DOMAIN
-    assert via[1] == entry.data[CONF_DEVICE_UNIQUE_ID]
+
+def test_device_info_uses_legacy_parent_identifier(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Retain identifier-based parent linking for Home Assistant 2026.3-2026.7.
+
+    Args:
+        coordinator (MagicMock): Mock coordinator supplying entity data and client behavior.
+        make_config_entry (Callable[..., MockConfigEntry]): Factory for the fake integration config entry.
+    """
+    entity = _make_scanner_entity(coordinator, make_config_entry)
+
+    device_info = entity.device_info
+
+    assert device_info is not None
+    assert device_info["via_device"] == (DOMAIN, "dev1")
+    assert "via_device_id" not in device_info
+    assert "default_name" not in device_info
+    assert "default_manufacturer" not in device_info
 
 
 @pytest.mark.asyncio

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,6 +24,8 @@ from custom_components.opnsense.helpers import (
     config_entry_identity,
     create_opnsense_client,
     create_opnsense_client_from_config_entry,
+    detach_shared_router_parent,
+    device_belongs_to_config_entry,
     dict_get,
     firewall_nat_switch_unique_ids_from_payload,
     firewall_rule_id_from_payload,
@@ -131,6 +133,71 @@ def test_async_get_devices_by_connection_supports_ha_versions(
     else:
         assert result == [device]
         legacy_get.assert_called_once_with(connections={("mac", "aa:bb:cc:dd:ee:ff")})
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        pytest.param(SimpleNamespace(config_entry_id="entry-id"), True, id="modern-owner"),
+        pytest.param(SimpleNamespace(config_entry_id="other-entry"), False, id="modern-foreign"),
+        pytest.param(
+            SimpleNamespace(config_entries={"entry-id", "other-entry"}),
+            True,
+            id="legacy-shared",
+        ),
+    ],
+)
+def test_device_belongs_to_config_entry_supports_ha_versions(
+    device: Any,
+    expected: bool,
+) -> None:
+    """Read singular modern ownership before falling back to the legacy set.
+
+    Args:
+        device (Any): Device entry shaped for the selected Home Assistant API generation.
+        expected (bool): Whether the helper should report ownership by ``entry-id``.
+    """
+    assert device_belongs_to_config_entry(device, "entry-id") is expected
+
+
+@pytest.mark.parametrize(
+    ("owner_entry_id", "expected_removed"),
+    [
+        pytest.param("entry-id", True, id="owned"),
+        pytest.param("other-entry", False, id="foreign"),
+    ],
+)
+def test_detach_tracker_uses_modern_device_removal(
+    owner_entry_id: str,
+    expected_removed: bool,
+) -> None:
+    """Remove a singly-owned modern device without deprecated update parameters.
+
+    Args:
+        owner_entry_id (str): Config entry that owns the simulated tracker device.
+        expected_removed (bool): Whether the tracker should be removed.
+    """
+    device: Any = SimpleNamespace(
+        id="tracker-id",
+        config_entry_id=owner_entry_id,
+        via_device_id="router-id",
+    )
+    registry = MagicMock()
+
+    result = detach_shared_router_parent(
+        shared_config_entry_id="entry-id",
+        shared_device_entry=device,
+        router_device_id="router-id",
+        config_entries=MagicMock(),
+        device_registry=registry,
+    )
+
+    assert result == (True, None)
+    if expected_removed:
+        registry.async_remove_device.assert_called_once_with("tracker-id")
+    else:
+        registry.async_remove_device.assert_not_called()
+    registry.async_update_device.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Updates device tracker registration and cleanup for Home Assistant's single-config-entry device registry while retaining compatibility with Home Assistant 2026.3 through 2026.7.

## What Changed

- Use `manufacturer`, `name`, and `via_device_id` for tracker device information on Home Assistant 2026.8 and newer.
- Remove singly owned tracker devices with `async_remove_device()` and use `config_entry_id` for ownership checks.
- Keep feature-detected legacy lookup, parent-link, and shared-device cleanup behavior for Home Assistant 2026.3 through 2026.7.
- Cover modern and legacy ownership, cleanup, and device-information paths with regression tests.

## Why

Home Assistant now assigns each device to one config entry and is deprecating the older shared-device APIs. Adapting at the registry boundary avoids deprecation warnings and future removals without raising the integration's minimum supported Home Assistant version.

## Validation

- `./.venv/bin/pytest` (`1391 passed`)
- `./.venv/bin/prek run --all-files`
