### PR TITLE
Standardize Dependabot auto-merge safeguards

### DIFF
--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -1,0 +1,149 @@
+/** Validate that a dependency pull request remains safe to auto-merge. */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEPENDABOT = "dependabot[bot]";
+const WEB_FLOW = "web-flow";
+
+function refuse(message) {
+  throw new Error(`Refusing auto-merge; ${message}`);
+}
+
+function dependencyEcosystem(headRef) {
+  if (headRef.startsWith("dependabot/uv/")) return "uv";
+  if (headRef.startsWith("dependabot/npm_and_yarn/")) return "npm";
+  if (headRef.startsWith("dependabot/github_actions/")) return "github-actions";
+  refuse(`unsupported Dependabot branch: ${headRef}`);
+}
+
+function assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory) {
+  if (changedFiles.length === 0)
+    refuse("the pull request has no changed files.");
+  if (ecosystem === "uv") {
+    if (changedFiles.length !== 1 || changedFiles[0] !== "uv.lock")
+      refuse("uv updates must change only uv.lock.");
+    return;
+  }
+  if (ecosystem === "npm") {
+    const isPackageFile = (path) =>
+      path === "package.json" || path === "package-lock.json";
+    if (
+      changedFiles.length !== 2 ||
+      !changedFiles.includes("package.json") ||
+      !changedFiles.includes("package-lock.json") ||
+      !changedFiles.every(isPackageFile)
+    )
+      refuse(
+        "npm updates must change only package.json and package-lock.json.",
+      );
+    return;
+  }
+
+  const isExistingAllowedFile = (path) =>
+    (/^\.github\/workflows\/[^/]+\.ya?ml$/.test(path) ||
+      path === "action.yml" ||
+      path === "action.yaml") &&
+    existsSync(resolve(trustedBaseDirectory, path));
+  if (!changedFiles.every(isExistingAllowedFile))
+    refuse("the update changes a file outside the trusted dependency scope.");
+}
+
+function assertDirectDependabotHistory(event, commits) {
+  const [commit] = commits;
+  if (
+    commits.length !== 1 ||
+    commit?.author?.login !== DEPENDABOT ||
+    commit?.commit?.verification?.verified !== true ||
+    commit?.sha !== event.pull_request.head.sha
+  )
+    refuse("the pull request does not have a verified Dependabot head commit.");
+}
+
+function assertUpdateBranchHistory(event, commits) {
+  if (event.action !== "synchronize")
+    refuse(`the triggering actor was not ${DEPENDABOT}.`);
+  if (commits.length < 2)
+    refuse("the synchronization was not a GitHub Update branch merge.");
+  if (
+    commits[0]?.author?.login !== DEPENDABOT ||
+    commits[0]?.commit?.verification?.verified !== true
+  )
+    refuse("the pull request history does not begin with Dependabot.");
+
+  for (let index = 1; index < commits.length; index += 1) {
+    const commit = commits[index];
+    const previous = commits[index - 1];
+    if (
+      commit?.committer?.login !== WEB_FLOW ||
+      commit?.commit?.verification?.verified !== true ||
+      commit?.parents?.length !== 2 ||
+      commit.parents[0]?.sha !== previous?.sha
+    )
+      refuse("the pull request contains a non-Dependabot edit.");
+  }
+
+  const latest = commits.at(-1);
+  if (
+    latest?.sha !== event.pull_request.head.sha ||
+    latest.parents[1]?.sha !== event.pull_request.base.sha
+  )
+    refuse("the latest commit is not an update from the current base branch.");
+}
+
+/**
+ * Authorize a Dependabot update or a chain containing only GitHub Update branch merges.
+ *
+ * @param {object} input Validation inputs from the pull-request event and API.
+ */
+export function authorizeDependabotUpdate({
+  actor,
+  changedFiles,
+  commits,
+  event,
+  trustedBaseDirectory = process.cwd(),
+}) {
+  const pullRequest = event.pull_request;
+  if (
+    event.repository?.fork !== false ||
+    pullRequest?.user?.login !== DEPENDABOT ||
+    pullRequest?.head?.repo?.full_name !== event.repository?.full_name ||
+    pullRequest?.base?.ref !== event.repository?.default_branch
+  )
+    refuse(
+      "the pull request does not have the required Dependabot provenance.",
+    );
+
+  const ecosystem = dependencyEcosystem(pullRequest.head.ref);
+  if (actor === DEPENDABOT) assertDirectDependabotHistory(event, commits);
+  else assertUpdateBranchHistory(event, commits);
+  assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory);
+  return ecosystem;
+}
+
+function main() {
+  const [, , eventPath, changedFilesPath, commitsPath] = process.argv;
+  if (!eventPath || !changedFilesPath || !commitsPath)
+    throw new Error(
+      "Usage: dependabot-auto-merge.mjs EVENT CHANGED_FILES COMMITS",
+    );
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const changedFiles = readFileSync(changedFilesPath, "utf8")
+    .split("\n")
+    .filter(Boolean);
+  const commitPages = JSON.parse(readFileSync(commitsPath, "utf8"));
+  const commits = commitPages.flat();
+  authorizeDependabotUpdate({
+    actor: process.env.GITHUB_ACTOR,
+    changedFiles,
+    commits,
+    event,
+  });
+  console.log("Authorized dependency update files and commit history.");
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+)
+  main();

--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -71,12 +71,19 @@ function assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory) {
     refuse("the update changes a file outside the trusted dependency scope.");
 }
 
+function isVerifiedDependabotCommit(commit) {
+  return (
+    commit?.author?.login === DEPENDABOT &&
+    commit?.committer?.login === WEB_FLOW &&
+    commit?.commit?.verification?.verified === true
+  );
+}
+
 function assertDirectDependabotHistory(event, commits) {
   const [commit] = commits;
   if (
     commits.length !== 1 ||
-    commit?.author?.login !== DEPENDABOT ||
-    commit?.commit?.verification?.verified !== true ||
+    !isVerifiedDependabotCommit(commit) ||
     commit?.sha !== event.pull_request.head.sha
   )
     refuse("the pull request does not have a verified Dependabot head commit.");
@@ -113,10 +120,7 @@ function assertMergeParentAncestry(event, commits, ancestryProofs) {
 function assertUpdateBranchHistory(event, commits, ancestryProofs) {
   if (commits.length < 2)
     refuse("the pull request is not a GitHub Update branch merge.");
-  if (
-    commits[0]?.author?.login !== DEPENDABOT ||
-    commits[0]?.commit?.verification?.verified !== true
-  )
+  if (!isVerifiedDependabotCommit(commits[0]))
     refuse("the pull request history does not begin with Dependabot.");
 
   for (let index = 1; index < commits.length; index += 1) {

--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -82,11 +82,37 @@ function assertDirectDependabotHistory(event, commits) {
     refuse("the pull request does not have a verified Dependabot head commit.");
 }
 
-function assertUpdateBranchHistory(event, commits) {
-  if (event.action !== "synchronize")
-    refuse(`the triggering actor was not ${DEPENDABOT}.`);
+function assertMergeParentAncestry(event, commits, ancestryProofs) {
+  const mergeCommits = commits.slice(1);
+  const currentBase = event.pull_request.base.sha;
+  if (
+    !Array.isArray(ancestryProofs) ||
+    ancestryProofs.length !== mergeCommits.length
+  )
+    refuse("the merge-parent ancestry evidence is incomplete.");
+
+  for (const [index, commit] of mergeCommits.entries()) {
+    const secondParent = commit?.parents?.[1]?.sha;
+    const proof = ancestryProofs[index];
+    if (
+      typeof secondParent !== "string" ||
+      proof?.parent_sha !== secondParent ||
+      proof?.base_sha !== currentBase ||
+      proof?.base_commit !== secondParent ||
+      proof?.head_commit !== currentBase ||
+      proof?.merge_base_commit !== secondParent ||
+      !["ahead", "identical"].includes(proof?.status) ||
+      !Number.isInteger(proof?.ahead_by) ||
+      proof.ahead_by < 0 ||
+      proof?.behind_by !== 0
+    )
+      refuse("a merge second parent is not proven to be on the current base.");
+  }
+}
+
+function assertUpdateBranchHistory(event, commits, ancestryProofs) {
   if (commits.length < 2)
-    refuse("the synchronization was not a GitHub Update branch merge.");
+    refuse("the pull request is not a GitHub Update branch merge.");
   if (
     commits[0]?.author?.login !== DEPENDABOT ||
     commits[0]?.commit?.verification?.verified !== true
@@ -105,6 +131,7 @@ function assertUpdateBranchHistory(event, commits) {
       refuse("the pull request contains a non-Dependabot edit.");
   }
 
+  assertMergeParentAncestry(event, commits, ancestryProofs);
   const latest = commits.at(-1);
   if (
     latest?.sha !== event.pull_request.head.sha ||
@@ -119,7 +146,7 @@ function assertUpdateBranchHistory(event, commits) {
  * @param {object} input Validation inputs from the pull-request event and API.
  */
 export function authorizeDependabotUpdate({
-  actor,
+  ancestryProofs = [],
   changedFiles,
   commits,
   event,
@@ -137,17 +164,18 @@ export function authorizeDependabotUpdate({
     );
 
   const ecosystem = dependencyEcosystem(pullRequest.head.ref);
-  if (actor === DEPENDABOT) assertDirectDependabotHistory(event, commits);
-  else assertUpdateBranchHistory(event, commits);
+  if (commits.length === 1) assertDirectDependabotHistory(event, commits);
+  else assertUpdateBranchHistory(event, commits, ancestryProofs);
   assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory);
   return ecosystem;
 }
 
 function main() {
-  const [, , eventPath, changedFilesPath, commitsPath] = process.argv;
-  if (!eventPath || !changedFilesPath || !commitsPath)
+  const [, , eventPath, changedFilesPath, commitsPath, ancestryProofsPath] =
+    process.argv;
+  if (!eventPath || !changedFilesPath || !commitsPath || !ancestryProofsPath)
     throw new Error(
-      "Usage: dependabot-auto-merge.mjs EVENT CHANGED_FILES COMMITS",
+      "Usage: dependabot-auto-merge.mjs EVENT CHANGED_FILES COMMITS ANCESTRY_PROOFS",
     );
   const event = JSON.parse(readFileSync(eventPath, "utf8"));
   const changedFiles = readFileSync(changedFilesPath, "utf8")
@@ -155,8 +183,9 @@ function main() {
     .filter(Boolean);
   const commitPages = JSON.parse(readFileSync(commitsPath, "utf8"));
   const commits = commitPages.flat();
+  const ancestryProofs = JSON.parse(readFileSync(ancestryProofsPath, "utf8"));
   authorizeDependabotUpdate({
-    actor: process.env.GITHUB_ACTOR,
+    ancestryProofs,
     changedFiles,
     commits,
     event,

--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -1,6 +1,6 @@
 /** Validate that a dependency pull request remains safe to auto-merge. */
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const DEPENDABOT = "dependabot[bot]";
@@ -17,23 +17,46 @@ function dependencyEcosystem(headRef) {
   refuse(`unsupported Dependabot branch: ${headRef}`);
 }
 
+function isTrustedBaseFile(trustedBaseDirectory, path) {
+  const base = resolve(trustedBaseDirectory);
+  const candidate = resolve(base, path);
+  const pathFromBase = relative(base, candidate);
+  if (
+    pathFromBase === "" ||
+    isAbsolute(pathFromBase) ||
+    pathFromBase === ".." ||
+    pathFromBase.startsWith(`..${sep}`)
+  )
+    return false;
+  return existsSync(candidate) && statSync(candidate).isFile();
+}
+
 function assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory) {
   if (changedFiles.length === 0)
     refuse("the pull request has no changed files.");
   if (ecosystem === "uv") {
+    if (!isTrustedBaseFile(trustedBaseDirectory, "uv.lock"))
+      refuse("the trusted base does not use uv.");
     if (changedFiles.length !== 1 || changedFiles[0] !== "uv.lock")
       refuse("uv updates must change only uv.lock.");
     return;
   }
   if (ecosystem === "npm") {
+    if (
+      !isTrustedBaseFile(trustedBaseDirectory, "package.json") ||
+      !isTrustedBaseFile(trustedBaseDirectory, "package-lock.json")
+    )
+      refuse("the trusted base does not use npm.");
     const isPackageFile = (path) =>
       path === "package.json" || path === "package-lock.json";
-    if (
-      changedFiles.length !== 2 ||
-      !changedFiles.includes("package.json") ||
-      !changedFiles.includes("package-lock.json") ||
-      !changedFiles.every(isPackageFile)
-    )
+    const isLockfileOnly =
+      changedFiles.length === 1 && changedFiles[0] === "package-lock.json";
+    const isManifestAndLockfile =
+      changedFiles.length === 2 &&
+      changedFiles.includes("package.json") &&
+      changedFiles.includes("package-lock.json") &&
+      changedFiles.every(isPackageFile);
+    if (!isLockfileOnly && !isManifestAndLockfile)
       refuse(
         "npm updates must change only package.json and package-lock.json.",
       );
@@ -42,9 +65,8 @@ function assertAllowedFiles(ecosystem, changedFiles, trustedBaseDirectory) {
 
   const isExistingAllowedFile = (path) =>
     (/^\.github\/workflows\/[^/]+\.ya?ml$/.test(path) ||
-      path === "action.yml" ||
-      path === "action.yaml") &&
-    existsSync(resolve(trustedBaseDirectory, path));
+      /(^|\/)action\.ya?ml$/.test(path)) &&
+    isTrustedBaseFile(trustedBaseDirectory, path);
   if (!changedFiles.every(isExistingAllowedFile))
     refuse("the update changes a file outside the trusted dependency scope.");
 }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,10 +11,7 @@ concurrency:
 jobs:
   authorize-dependency-update:
     if: >-
-      github.event.repository.fork == false &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,14 +32,25 @@ jobs:
           set -euo pipefail
           changed_files="${RUNNER_TEMP}/dependabot-changed-files"
           commits="${RUNNER_TEMP}/dependabot-commits.json"
+          ancestry_proofs="${RUNNER_TEMP}/dependabot-ancestry-proofs.json"
+          ancestry_proof_items="${RUNNER_TEMP}/dependabot-ancestry-proof-items.jsonl"
+          base_sha="${{ github.event.pull_request.base.sha }}"
           gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[].filename' > "${changed_files}"
           gh api --paginate --slurp \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" \
             > "${commits}"
+          : > "${ancestry_proof_items}"
+          while IFS= read -r second_parent; do
+            gh api "repos/${REPOSITORY}/compare/${second_parent}...${base_sha}" |
+              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${base_sha}" \
+                '{parent_sha, base_sha, base_commit: .base_commit.sha, head_commit: .head_commit.sha, merge_base_commit: .merge_base_commit.sha, status, ahead_by, behind_by}' \
+                >> "${ancestry_proof_items}"
+          done < <(jq -r '.[].[] | select(.parents | length == 2) | .parents[1].sha' "${commits}")
+          jq -s . "${ancestry_proof_items}" > "${ancestry_proofs}"
           node .github/scripts/dependabot-auto-merge.mjs \
-            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}"
+            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}" "${ancestry_proofs}"
 
   enable-auto-merge:
     needs: authorize-dependency-update

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Authorize dependency update files
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
@@ -34,7 +35,6 @@ jobs:
           commits="${RUNNER_TEMP}/dependabot-commits.json"
           ancestry_proofs="${RUNNER_TEMP}/dependabot-ancestry-proofs.json"
           ancestry_proof_items="${RUNNER_TEMP}/dependabot-ancestry-proof-items.jsonl"
-          base_sha="${{ github.event.pull_request.base.sha }}"
           gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[].filename' > "${changed_files}"
@@ -43,8 +43,8 @@ jobs:
             > "${commits}"
           : > "${ancestry_proof_items}"
           while IFS= read -r second_parent; do
-            gh api "repos/${REPOSITORY}/compare/${second_parent}...${base_sha}" |
-              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${base_sha}" \
+            gh api "repos/${REPOSITORY}/compare/${second_parent}...${BASE_SHA}" |
+              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${BASE_SHA}" \
                 '{parent_sha, base_sha, base_commit: .base_commit.sha, head_commit: .head_commit.sha, merge_base_commit: .merge_base_commit.sha, status, ahead_by, behind_by}' \
                 >> "${ancestry_proof_items}"
           done < <(jq -r '.[].[] | select(.parents | length == 2) | .parents[1].sha' "${commits}")

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,9 +14,6 @@ jobs:
       github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (startsWith(github.event.pull_request.head.ref, 'dependabot/uv/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/')) &&
       github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
@@ -67,9 +64,6 @@ jobs:
       github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (startsWith(github.event.pull_request.head.ref, 'dependabot/uv/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/')) &&
       github.event.pull_request.base.ref == github.event.repository.default_branch
     needs: authorize-dependency-update
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot dependency auto-merge
+name: Dependabot auto-merge
 
 on:
   pull_request:
@@ -9,59 +9,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify-dependency-update:
+  authorize-dependency-update:
     if: >-
       github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'dependabot/uv/') ||
+      startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/') ||
+      startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/')) &&
       github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - name: Fetch Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v3
+      - name: Checkout trusted authorization helper
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: Verify supported dependency update
+      - name: Authorize dependency update files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE_ECOSYSTEM: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          changed_files="$(gh api --paginate \
+          set -euo pipefail
+          changed_files="${RUNNER_TEMP}/dependabot-changed-files"
+          commits="${RUNNER_TEMP}/dependabot-commits.json"
+          gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
-            --jq '.[].filename')"
-          [[ -n "${changed_files}" ]] || {
-            echo "Refusing auto-merge; no changed files were reported"
-            exit 1
-          }
-          case "${PACKAGE_ECOSYSTEM}" in
-            uv)
-              [[ "${changed_files}" == "uv.lock" ]] || {
-                echo "Refusing uv auto-merge; changed files were:"
-                echo "${changed_files}"
-                exit 1
-              }
-              ;;
-            github_actions)
-              invalid_files="$(printf '%s\n' "${changed_files}" | grep -Ev '^\.github/workflows/[^/]+\.ya?ml$' || true)"
-              [[ -z "${invalid_files}" ]] || {
-                echo "Refusing GitHub Actions auto-merge; unexpected files were:"
-                echo "${invalid_files}"
-                exit 1
-              }
-              ;;
-            *)
-              echo "Refusing unsupported ecosystem: ${PACKAGE_ECOSYSTEM}"
-              exit 1
-              ;;
-          esac
+            --jq '.[].filename' > "${changed_files}"
+          gh api --paginate --slurp \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            > "${commits}"
+          node .github/scripts/dependabot-auto-merge.mjs \
+            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}"
 
   enable-auto-merge:
-    needs: verify-dependency-update
+    needs: authorize-dependency-update
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -77,12 +64,14 @@ jobs:
   disable-auto-merge:
     if: >-
       failure() && !cancelled() &&
-      needs.verify-dependency-update.result != 'success' &&
       github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'dependabot/uv/') ||
+      startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/') ||
+      startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/')) &&
       github.event.pull_request.base.ref == github.event.repository.default_branch
-    needs: verify-dependency-update
+    needs: authorize-dependency-update
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pytest_check.yml
+++ b/.github/workflows/pytest_check.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout trusted dependency authorization helper
@@ -47,14 +48,25 @@ jobs:
           set -euo pipefail
           changed_files="${RUNNER_TEMP}/dependabot-changed-files"
           commits="${RUNNER_TEMP}/dependabot-commits.json"
+          ancestry_proofs="${RUNNER_TEMP}/dependabot-ancestry-proofs.json"
+          ancestry_proof_items="${RUNNER_TEMP}/dependabot-ancestry-proof-items.jsonl"
+          base_sha="${{ github.event.pull_request.base.sha }}"
           gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[].filename' > "${changed_files}"
           gh api --paginate --slurp \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" \
             > "${commits}"
+          : > "${ancestry_proof_items}"
+          while IFS= read -r second_parent; do
+            gh api "repos/${REPOSITORY}/compare/${second_parent}...${base_sha}" |
+              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${base_sha}" \
+                '{parent_sha, base_sha, base_commit: .base_commit.sha, head_commit: .head_commit.sha, merge_base_commit: .merge_base_commit.sha, status, ahead_by, behind_by}' \
+                >> "${ancestry_proof_items}"
+          done < <(jq -r '.[].[] | select(.parents | length == 2) | .parents[1].sha' "${commits}")
+          jq -s . "${ancestry_proof_items}" > "${ancestry_proofs}"
           node .github/scripts/dependabot-auto-merge.mjs \
-            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}"
+            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}" "${ancestry_proofs}"
 
       - name: Require expected release commit
         if: github.event_name == 'workflow_dispatch'
@@ -81,50 +93,32 @@ jobs:
       - name: Run pytest with coverage from the lock
         run: uv run --locked --group pytest pytest
 
-  coverage_publisher:
-    name: Publish coverage report
-    needs: tests
-    if: >-
-      github.event_name != 'workflow_dispatch' &&
-      (github.event_name != 'pull_request' ||
-      (github.event.pull_request.user.login != 'prek-autoupdate-bot' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'))
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-
-      - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          python-version: "3.14"
-          enable-cache: true
-          ignore-nothing-to-cache: true
-          cache-dependency-glob: uv.lock
-
-      - name: Run pytest with coverage from the lock
-        run: uv run --locked --group pytest pytest
-
-      - name: Generate coverage Comment (and possibly Post to PR)
+      - name: Generate coverage comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login != 'prek-autoupdate-bot' &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIVITY: process_pr
           MINIMUM_GREEN: 90
           MINIMUM_ORANGE: 70
 
-      - name: Store PR Comment to be Posted
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+      - name: Store PR coverage comment
+        if: steps.coverage_comment.outputs.comment_file_written == 'true'
         uses: actions/upload-artifact@v7
         with:
-          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
           name: python-coverage-comment-action
-          # If you use a different name, update COMMENT_FILENAME accordingly
           path: python-coverage-comment-action.txt
+          retention-days: 1
+
+      - name: Store coverage data for trusted publication
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-coverage-data
+          path: .coverage
+          include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/pytest_check.yml
+++ b/.github/workflows/pytest_check.yml
@@ -18,6 +18,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login == 'prek-autoupdate-bot' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
       !(contains(github.event.pull_request.labels.*.name, 'dependencies') ||
       github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
@@ -25,6 +26,36 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout trusted dependency authorization helper
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Authorize Dependabot update before checking out its head
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          changed_files="${RUNNER_TEMP}/dependabot-changed-files"
+          commits="${RUNNER_TEMP}/dependabot-commits.json"
+          gh api --paginate \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > "${changed_files}"
+          gh api --paginate --slurp \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            > "${commits}"
+          node .github/scripts/dependabot-auto-merge.mjs \
+            "${GITHUB_EVENT_PATH}" "${changed_files}" "${commits}"
+
       - name: Require expected release commit
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -56,7 +87,8 @@ jobs:
     if: >-
       github.event_name != 'workflow_dispatch' &&
       (github.event_name != 'pull_request' ||
-      github.event.pull_request.user.login != 'prek-autoupdate-bot')
+      (github.event.pull_request.user.login != 'prek-autoupdate-bot' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pytest_check.yml
+++ b/.github/workflows/pytest_check.yml
@@ -41,6 +41,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.user.login == 'dependabot[bot]'
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
@@ -50,7 +51,6 @@ jobs:
           commits="${RUNNER_TEMP}/dependabot-commits.json"
           ancestry_proofs="${RUNNER_TEMP}/dependabot-ancestry-proofs.json"
           ancestry_proof_items="${RUNNER_TEMP}/dependabot-ancestry-proof-items.jsonl"
-          base_sha="${{ github.event.pull_request.base.sha }}"
           gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[].filename' > "${changed_files}"
@@ -59,8 +59,8 @@ jobs:
             > "${commits}"
           : > "${ancestry_proof_items}"
           while IFS= read -r second_parent; do
-            gh api "repos/${REPOSITORY}/compare/${second_parent}...${base_sha}" |
-              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${base_sha}" \
+            gh api "repos/${REPOSITORY}/compare/${second_parent}...${BASE_SHA}" |
+              jq -c --arg parent_sha "${second_parent}" --arg base_sha "${BASE_SHA}" \
                 '{parent_sha, base_sha, base_commit: .base_commit.sha, head_commit: .head_commit.sha, merge_base_commit: .merge_base_commit.sha, status, ahead_by, behind_by}' \
                 >> "${ancestry_proof_items}"
           done < <(jq -r '.[].[] | select(.parents | length == 2) | .parents[1].sha' "${commits}")

--- a/.github/workflows/pytest_post_coverage.yml
+++ b/.github/workflows/pytest_post_coverage.yml
@@ -37,8 +37,12 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == github.event.repository.default_branch
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
+    concurrency:
+      group: pytest-default-coverage-${{ github.event.repository.default_branch }}
+      cancel-in-progress: true
     permissions:
       actions: read
       contents: write
@@ -47,19 +51,24 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
-      - name: Download coverage data from test run
+      - name: Verify trusted default branch matches test run
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          gh run download "${RUN_ID}" --repo "${REPOSITORY}" \
-            --name python-coverage-data --dir .
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"
 
-      - name: Publish default-branch coverage data
+      - name: Download coverage data from test run
+        uses: actions/download-artifact@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: python-coverage-data
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish coverage report
         uses: py-cov-action/python-coverage-comment-action@v4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pytest_post_coverage.yml
+++ b/.github/workflows/pytest_post_coverage.yml
@@ -29,4 +29,40 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIVITY: post_comment
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+
+  publish-default-coverage:
+    name: Publish default coverage data
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout tested default-branch commit
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download coverage data from test run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh run download "${RUN_ID}" --repo "${REPOSITORY}" \
+            --name python-coverage-data --dir .
+
+      - name: Publish default-branch coverage data
+        uses: py-cov-action/python-coverage-comment-action@v4.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIVITY: save_coverage_data_files
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70

--- a/tests/test_dependabot_auto_merge_workflow.py
+++ b/tests/test_dependabot_auto_merge_workflow.py
@@ -57,6 +57,7 @@ def _dependabot_commit(sha: str = HEAD_SHA, *, verified: bool = True) -> dict[st
     return {
         "author": {"login": "dependabot[bot]"},
         "commit": {"verification": {"verified": verified}},
+        "committer": {"login": "web-flow"},
         "parents": [],
         "sha": sha,
     }
@@ -275,6 +276,35 @@ def test_authorization_accepts_a_direct_reopened_dependabot_update(tmp_path: Pat
     )
 
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize("is_update_branch", [False, True], ids=["direct", "update-branch"])
+@pytest.mark.parametrize("committer", [None, "maintainer"], ids=["missing", "maintainer"])
+def test_authorization_rejects_untrusted_dependabot_root_committer(
+    tmp_path: Path, is_update_branch: bool, committer: str | None
+) -> None:
+    """Reject direct and reopened roots without a verified GitHub web-flow committer.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+        is_update_branch (bool): Whether to exercise a GitHub Update branch chain.
+        committer (str | None): Missing or untrusted root committer identity.
+    """
+    commits = _update_chain() if is_update_branch else [_dependabot_commit()]
+    if committer is None:
+        commits[0].pop("committer")
+    else:
+        commits[0]["committer"] = {"login": committer}
+    result = _authorize(
+        tmp_path,
+        ancestry_proofs=_update_chain_proofs() if is_update_branch else [],
+        changed_files=["uv.lock"],
+        commits=commits,
+        event=_event(),
+        trusted_base_files=["uv.lock"],
+    )
+
+    assert result.returncode != 0
 
 
 def test_authorization_rejects_invalid_dependabot_provenance(tmp_path: Path) -> None:
@@ -571,6 +601,19 @@ def _assert_trusted_checkout_precedes_authorization(job: dict[str, Any]) -> None
     assert checkout["with"]["persist-credentials"] is False
 
 
+def _assert_current_base_evidence_collector(step: dict[str, Any]) -> None:
+    """Assert that compare evidence receives the event base SHA through its environment.
+
+    Args:
+        step (dict[str, Any]): Authorization shell step from a parsed workflow.
+    """
+    assert step["env"]["BASE_SHA"] == "${{ github.event.pull_request.base.sha }}"
+    run = step["run"]
+    assert "compare/${second_parent}...${BASE_SHA}" in run
+    assert '--arg base_sha "${BASE_SHA}"' in run
+    assert 'base_sha="${{ github.event.pull_request.base.sha }}"' not in run
+
+
 def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
     """Keep authorization inputs read-only and coverage comments in the checkout-free writer.
 
@@ -588,7 +631,9 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
     assert authorization["permissions"]["pull-requests"] == "read"
     _assert_dependabot_author_condition(authorization["if"])
     _assert_trusted_checkout_precedes_authorization(authorization)
-    authorization_run = _step_with_run(authorization, "dependabot-auto-merge.mjs")["run"]
+    authorization_step = _step_with_run(authorization, "dependabot-auto-merge.mjs")
+    authorization_run = authorization_step["run"]
+    _assert_current_base_evidence_collector(authorization_step)
     for required_dataflow in (
         "pulls/${PR_NUMBER}/files",
         "pulls/${PR_NUMBER}/commits",
@@ -629,6 +674,7 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
         ):
             assert disallowed_restriction not in condition
     _assert_trusted_checkout_precedes_authorization(tests)
+    _assert_current_base_evidence_collector(authorizer)
     authorization_index = _steps(tests).index(authorizer)
     head_checkout_index = next(
         index

--- a/tests/test_dependabot_auto_merge_workflow.py
+++ b/tests/test_dependabot_auto_merge_workflow.py
@@ -81,6 +81,7 @@ def _authorize(
     changed_files: list[str],
     commits: list[dict[str, Any]],
     event: dict[str, Any],
+    trusted_base_files: list[str],
 ) -> subprocess.CompletedProcess[str]:
     """Run the checked-in authorization command with API-shaped inputs.
 
@@ -90,6 +91,7 @@ def _authorize(
         changed_files (list[str]): Files reported by the pull-request API.
         commits (list[dict[str, Any]]): Commit pages returned by the API.
         event (dict[str, Any]): Pull-request event payload.
+        trusted_base_files (list[str]): Files present in the trusted base checkout.
 
     Returns:
         subprocess.CompletedProcess[str]: Result from the authorizer process.
@@ -100,6 +102,10 @@ def _authorize(
     event_path = tmp_path / "event.json"
     changed_files_path = tmp_path / "changed-files"
     commits_path = tmp_path / "commits.json"
+    for trusted_base_file in trusted_base_files:
+        trusted_path = tmp_path / trusted_base_file
+        trusted_path.parent.mkdir(parents=True, exist_ok=True)
+        trusted_path.write_text("fixture\n", encoding="utf-8")
     event_path.write_text(json.dumps(event), encoding="utf-8")
     changed_files_path.write_text("\n".join(changed_files), encoding="utf-8")
     commits_path.write_text(json.dumps([commits]), encoding="utf-8")
@@ -116,16 +122,38 @@ def _authorize(
 
 
 @pytest.mark.parametrize(
-    ("changed_files", "authorized"),
-    [(["uv.lock"], True), (["pyproject.toml", "uv.lock"], False)],
+    ("head_ref", "trusted_base_files", "changed_files", "authorized"),
+    [
+        ("dependabot/uv/pytest-9.0.0", ["uv.lock"], ["uv.lock"], True),
+        ("dependabot/uv/pytest-9.0.0", ["uv.lock"], ["pyproject.toml", "uv.lock"], False),
+        (
+            "dependabot/uv/pytest-9.0.0",
+            ["package.json", "package-lock.json"],
+            ["uv.lock"],
+            False,
+        ),
+        (
+            "dependabot/npm_and_yarn/pytest-9.0.0",
+            ["package.json", "package-lock.json"],
+            ["package-lock.json"],
+            True,
+        ),
+        ("dependabot/npm_and_yarn/pytest-9.0.0", ["uv.lock"], ["package-lock.json"], False),
+    ],
 )
-def test_uv_authorization_requires_only_the_lockfile(
-    tmp_path: Path, changed_files: list[str], authorized: bool
+def test_authorization_derives_dependency_policy_from_the_trusted_base(
+    tmp_path: Path,
+    head_ref: str,
+    trusted_base_files: list[str],
+    changed_files: list[str],
+    authorized: bool,
 ) -> None:
-    """Authorize direct uv updates only when their API file list is lockfile-only.
+    """Authorize matching lockfile updates only when their trusted base uses that ecosystem.
 
     Args:
         tmp_path (Path): Trusted base checkout fixture directory.
+        head_ref (str): Dependabot branch associated with the update.
+        trusted_base_files (list[str]): Files in the trusted base checkout.
         changed_files (list[str]): Files reported by the pull-request API.
         authorized (bool): Whether the update should pass authorization.
     """
@@ -134,7 +162,8 @@ def test_uv_authorization_requires_only_the_lockfile(
         actor="dependabot[bot]",
         changed_files=changed_files,
         commits=[_dependabot_commit()],
-        event=_event("opened", "dependabot/uv/pytest-9.0.0"),
+        event=_event("opened", head_ref),
+        trusted_base_files=trusted_base_files,
     )
 
     assert (result.returncode == 0) is authorized
@@ -152,6 +181,7 @@ def test_authorization_accepts_only_verified_update_branch_history(tmp_path: Pat
         changed_files=["uv.lock"],
         commits=[_dependabot_commit(DEPENDABOT_SHA), _update_commit(DEPENDABOT_SHA)],
         event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+        trusted_base_files=["uv.lock"],
     )
     invalid = _authorize(
         tmp_path,
@@ -162,6 +192,7 @@ def test_authorization_accepts_only_verified_update_branch_history(tmp_path: Pat
             _update_commit(DEPENDABOT_SHA),
         ],
         event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+        trusted_base_files=["uv.lock"],
     )
 
     assert valid.returncode == 0
@@ -169,32 +200,31 @@ def test_authorization_accepts_only_verified_update_branch_history(tmp_path: Pat
 
 
 @pytest.mark.parametrize(
-    ("changed_file", "trusted_file", "authorized"),
+    ("changed_file", "trusted_base_files", "authorized"),
     [
-        (".github/workflows/pytest_check.yml", ".github/workflows/pytest_check.yml", True),
-        (".github/workflows/nested/unsafe.yml", ".github/workflows/nested/unsafe.yml", False),
+        (".github/workflows/pytest_check.yml", [".github/workflows/pytest_check.yml"], True),
+        ("actions/release/action.yaml", ["actions/release/action.yaml"], True),
+        (".github/workflows/nested/unsafe.yml", [".github/workflows/nested/unsafe.yml"], False),
     ],
 )
-def test_actions_authorization_requires_an_existing_top_level_file(
-    tmp_path: Path, changed_file: str, trusted_file: str, authorized: bool
+def test_actions_authorization_requires_trusted_allowed_files(
+    tmp_path: Path, changed_file: str, trusted_base_files: list[str], authorized: bool
 ) -> None:
-    """Authorize only trusted-base top-level GitHub Actions workflow updates.
+    """Authorize only trusted-base top-level workflows and action manifests.
 
     Args:
         tmp_path (Path): Trusted base checkout fixture directory.
         changed_file (str): File reported by the pull-request API.
-        trusted_file (str): Corresponding file present in the trusted checkout.
+        trusted_base_files (list[str]): Files in the trusted base checkout.
         authorized (bool): Whether the update should pass authorization.
     """
-    trusted_path = tmp_path / trusted_file
-    trusted_path.parent.mkdir(parents=True)
-    trusted_path.write_text("name: trusted\n", encoding="utf-8")
     result = _authorize(
         tmp_path,
         actor="dependabot[bot]",
         changed_files=[changed_file],
         commits=[_dependabot_commit()],
         event=_event("opened", "dependabot/github_actions/actions/checkout-7"),
+        trusted_base_files=trusted_base_files,
     )
 
     assert (result.returncode == 0) is authorized

--- a/tests/test_dependabot_auto_merge_workflow.py
+++ b/tests/test_dependabot_auto_merge_workflow.py
@@ -581,9 +581,11 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
     auto_merge = _load_workflow("dependabot-auto-merge.yml")
     pytest_check = _load_workflow("pytest_check.yml")
     post_coverage = _load_workflow("pytest_post_coverage.yml")
+    assert "concurrency" not in post_coverage
     authorization_id, authorization = _job_with_run(auto_merge, "dependabot-auto-merge.mjs")
 
-    assert authorization["permissions"] == {"contents": "read", "pull-requests": "read"}
+    assert authorization["permissions"]["contents"] == "read"
+    assert authorization["permissions"]["pull-requests"] == "read"
     _assert_dependabot_author_condition(authorization["if"])
     _assert_trusted_checkout_precedes_authorization(authorization)
     authorization_run = _step_with_run(authorization, "dependabot-auto-merge.mjs")["run"]
@@ -597,7 +599,8 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
     _, enable_auto_merge = _job_with_run(auto_merge, "gh pr merge --auto")
     assert enable_auto_merge["needs"] == authorization_id
     assert "if" not in enable_auto_merge
-    assert enable_auto_merge["permissions"] == {"contents": "write", "pull-requests": "write"}
+    assert enable_auto_merge["permissions"]["contents"] == "write"
+    assert enable_auto_merge["permissions"]["pull-requests"] == "write"
     _, disable_auto_merge = _job_with_run(auto_merge, "gh pr merge --disable-auto")
     assert "failure()" in str(disable_auto_merge["if"])
     assert "!cancelled()" in str(disable_auto_merge["if"])
@@ -607,13 +610,13 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
         if "write" in permissions.values():
             assert not any("actions/checkout@" in str(step.get("uses", "")) for step in _steps(job))
 
-    _, tests = _job_with_run(pytest_check, "uv run --locked --group pytest pytest")
-    assert tests["permissions"] == {"contents": "read", "pull-requests": "read"}
+    _, tests = _job_with_activity(pytest_check, "process_pr")
+    assert tests["permissions"]["contents"] == "read"
+    assert tests["permissions"]["pull-requests"] == "read"
     trusted_checkout = _step_with_major_action(tests, "actions/checkout")
-    assert trusted_checkout["with"] == {
-        "persist-credentials": False,
-        "ref": "${{ github.event.pull_request.base.sha }}",
-    }
+    trusted_checkout_with = trusted_checkout["with"]
+    assert trusted_checkout_with["persist-credentials"] is False
+    assert trusted_checkout_with["ref"] == "${{ github.event.pull_request.base.sha }}"
     authorizer = _step_with_run(tests, "dependabot-auto-merge.mjs")
     for step in (trusted_checkout, authorizer):
         condition = str(step["if"])
@@ -640,53 +643,71 @@ def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
         for permissions in [job.get("permissions", {})]
     )
     coverage = _step_with_activity(tests, "process_pr")
-    assert coverage["with"] == {
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
-        "ACTIVITY": "process_pr",
-        "MINIMUM_GREEN": 90,
-        "MINIMUM_ORANGE": 70,
-    }
+    coverage_with = coverage["with"]
+    assert coverage_with["GITHUB_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert coverage_with["ACTIVITY"] == "process_pr"
+    assert coverage_with["MINIMUM_GREEN"] == 90
+    assert coverage_with["MINIMUM_ORANGE"] == 70
     stored_coverage = next(
         step for step in _steps(tests) if step.get("with", {}).get("name") == "python-coverage-data"
     )
     assert re.fullmatch(r"actions/upload-artifact@v\d+(?:\.\d+)*", str(stored_coverage["uses"]))
-    assert stored_coverage["if"] == "github.event_name == 'push'"
-    assert stored_coverage["with"] == {
-        "name": "python-coverage-data",
-        "path": ".coverage",
-        "include-hidden-files": True,
-        "retention-days": 1,
-    }
+    assert "github.event_name == 'push'" in str(stored_coverage["if"])
+    stored_coverage_with = stored_coverage["with"]
+    assert stored_coverage_with["name"] == "python-coverage-data"
+    assert stored_coverage_with["path"] == ".coverage"
+    assert stored_coverage_with["include-hidden-files"] is True
+    assert stored_coverage_with["retention-days"] == 1
 
     _, post_job = _job_with_activity(post_coverage, "post_comment")
-    assert post_job["permissions"] == {
-        "pull-requests": "write",
-        "contents": "read",
-        "actions": "read",
-    }
+    assert post_job["permissions"]["pull-requests"] == "write"
+    assert post_job["permissions"]["contents"] == "read"
+    assert post_job["permissions"]["actions"] == "read"
+    assert all(
+        permission in {"actions", "contents", "pull-requests"}
+        for permission in post_job["permissions"]
+    )
+    assert "concurrency" not in post_job
     assert "workflow_run.event == 'pull_request'" in str(post_job["if"])
     assert "workflow_run.conclusion == 'success'" in str(post_job["if"])
-    assert not any("actions/checkout@" in str(step.get("uses", "")) for step in _steps(post_job))
+    assert not any(
+        re.fullmatch(r"actions/checkout@v\d+(?:\.\d+)*", str(step.get("uses", "")))
+        for step in _steps(post_job)
+    )
     post = _step_with_activity(post_job, "post_comment")
     assert post["with"]["GITHUB_PR_RUN_ID"] == "${{ github.event.workflow_run.id }}"
 
     _, publisher = _job_with_activity(post_coverage, "save_coverage_data_files")
-    assert publisher["permissions"] == {"actions": "read", "contents": "write"}
+    assert publisher["permissions"]["actions"] == "read"
+    assert publisher["permissions"]["contents"] == "write"
+    assert all(permission in {"actions", "contents"} for permission in publisher["permissions"])
     for required_term in (
         "workflow_run.event == 'push'",
         "workflow_run.conclusion == 'success'",
         "workflow_run.head_branch == github.event.repository.default_branch",
+        "workflow_run.head_repository.full_name == github.repository",
     ):
         assert required_term in str(publisher["if"])
     checkout = _step_with_major_action(publisher, "actions/checkout")
-    assert checkout["with"] == {
-        "persist-credentials": False,
-        "ref": "${{ github.event.workflow_run.head_sha }}",
-    }
-    download = _step_with_run(publisher, "gh run download")
-    assert "${RUN_ID}" in download["run"]
-    assert "${REPOSITORY}" in download["run"]
-    assert "--name python-coverage-data" in download["run"]
+    checkout_with = checkout["with"]
+    assert checkout_with["persist-credentials"] is False
+    assert checkout_with["ref"] == "${{ github.event.repository.default_branch }}"
+    verification = _step_with_run(publisher, "git rev-parse HEAD")
+    assert verification["env"]["EXPECTED_SHA"] == "${{ github.event.workflow_run.head_sha }}"
+    download = _step_with_major_action(publisher, "actions/download-artifact")
+    download_with = download["with"]
+    assert download_with["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert download_with["run-id"] == "${{ github.event.workflow_run.id }}"
+    assert download_with["name"] == "python-coverage-data"
+    assert download_with["path"] == "."
+    publisher_concurrency = publisher["concurrency"]
+    assert publisher_concurrency["cancel-in-progress"] is True
+    assert "github.event.repository.default_branch" in str(publisher_concurrency["group"])
+    assert (
+        _steps(publisher).index(checkout)
+        < _steps(publisher).index(verification)
+        < _steps(publisher).index(download)
+    )
     published_coverage = _step_with_activity(publisher, "save_coverage_data_files")
     assert published_coverage["with"]["MINIMUM_GREEN"] == 90
     assert published_coverage["with"]["MINIMUM_ORANGE"] == 70

--- a/tests/test_dependabot_auto_merge_workflow.py
+++ b/tests/test_dependabot_auto_merge_workflow.py
@@ -1,23 +1,29 @@
 """Executable behavior tests for Dependabot auto-merge authorization."""
 
 import json
-import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 from typing import Any
 
 import pytest
+import yaml
 
 AUTHORIZER = Path(__file__).parents[1] / ".github" / "scripts" / "dependabot-auto-merge.mjs"
+WORKFLOW_ROOT = Path(__file__).parents[1] / ".github" / "workflows"
 BASE_SHA = "4" * 40
 DEPENDABOT_SHA = "1" * 40
+FIRST_BASE_SHA = "2" * 40
+FIRST_UPDATE_SHA = "3" * 40
 HEAD_SHA = "5" * 40
 REPOSITORY = "Snuffy2/hass-opnsense"
 NODE = shutil.which("node")
 
 
-def _event(action: str, head_ref: str) -> dict[str, Any]:
+def _event(
+    action: str = "reopened", head_ref: str = "dependabot/uv/pytest-9.0.0"
+) -> dict[str, Any]:
     """Build a same-repository Dependabot pull-request event fixture.
 
     Args:
@@ -56,11 +62,13 @@ def _dependabot_commit(sha: str = HEAD_SHA, *, verified: bool = True) -> dict[st
     }
 
 
-def _update_commit(previous: str) -> dict[str, Any]:
+def _update_commit(sha: str, previous: str, base: str) -> dict[str, Any]:
     """Build a verified GitHub Update branch merge commit.
 
     Args:
-        previous (str): SHA of the preceding Dependabot commit.
+        sha (str): SHA of the merge commit.
+        previous (str): SHA of the preceding pull-request commit.
+        base (str): SHA of the base commit merged into the pull request.
 
     Returns:
         dict[str, Any]: Commit data for the current-base merge.
@@ -69,15 +77,59 @@ def _update_commit(previous: str) -> dict[str, Any]:
         "author": {"login": "Snuffy2"},
         "commit": {"verification": {"verified": True}},
         "committer": {"login": "web-flow"},
-        "parents": [{"sha": previous}, {"sha": BASE_SHA}],
-        "sha": HEAD_SHA,
+        "parents": [{"sha": previous}, {"sha": base}],
+        "sha": sha,
     }
+
+
+def _ancestry_proof(parent_sha: str, status: str = "ahead") -> dict[str, Any]:
+    """Build compare API evidence that a merge parent reaches the current base.
+
+    Args:
+        parent_sha (str): Merge second-parent SHA to compare against the current base.
+        status (str): GitHub compare status for the parent/base pair.
+
+    Returns:
+        dict[str, Any]: Reduced compare API response used by the authorizer.
+    """
+    return {
+        "ahead_by": 0 if status == "identical" else 1,
+        "base_commit": parent_sha,
+        "base_sha": BASE_SHA,
+        "behind_by": 0,
+        "head_commit": BASE_SHA,
+        "merge_base_commit": parent_sha,
+        "parent_sha": parent_sha,
+        "status": status,
+    }
+
+
+def _update_chain() -> list[dict[str, Any]]:
+    """Build a reopened Dependabot PR with two GitHub Update branch merges.
+
+    Returns:
+        list[dict[str, Any]]: Pull-request commits in API order.
+    """
+    return [
+        _dependabot_commit(DEPENDABOT_SHA),
+        _update_commit(FIRST_UPDATE_SHA, DEPENDABOT_SHA, FIRST_BASE_SHA),
+        _update_commit(HEAD_SHA, FIRST_UPDATE_SHA, BASE_SHA),
+    ]
+
+
+def _update_chain_proofs() -> list[dict[str, Any]]:
+    """Build compare evidence for every merge in :func:`_update_chain`.
+
+    Returns:
+        list[dict[str, Any]]: Reduced compare API responses in merge order.
+    """
+    return [_ancestry_proof(FIRST_BASE_SHA), _ancestry_proof(BASE_SHA, "identical")]
 
 
 def _authorize(
     tmp_path: Path,
     *,
-    actor: str,
+    ancestry_proofs: list[dict[str, Any]],
     changed_files: list[str],
     commits: list[dict[str, Any]],
     event: dict[str, Any],
@@ -87,7 +139,7 @@ def _authorize(
 
     Args:
         tmp_path (Path): Trusted base checkout fixture directory.
-        actor (str): GitHub Actions actor.
+        ancestry_proofs (list[dict[str, Any]]): Compare results for merge parents.
         changed_files (list[str]): Files reported by the pull-request API.
         commits (list[dict[str, Any]]): Commit pages returned by the API.
         event (dict[str, Any]): Pull-request event payload.
@@ -102,6 +154,7 @@ def _authorize(
     event_path = tmp_path / "event.json"
     changed_files_path = tmp_path / "changed-files"
     commits_path = tmp_path / "commits.json"
+    ancestry_proofs_path = tmp_path / "ancestry-proofs.json"
     for trusted_base_file in trusted_base_files:
         trusted_path = tmp_path / trusted_base_file
         trusted_path.parent.mkdir(parents=True, exist_ok=True)
@@ -109,13 +162,20 @@ def _authorize(
     event_path.write_text(json.dumps(event), encoding="utf-8")
     changed_files_path.write_text("\n".join(changed_files), encoding="utf-8")
     commits_path.write_text(json.dumps([commits]), encoding="utf-8")
+    ancestry_proofs_path.write_text(json.dumps(ancestry_proofs), encoding="utf-8")
     if NODE is None:
         raise RuntimeError("Node.js is required to run the Dependabot authorizer.")
     return subprocess.run(  # noqa: S603
-        [NODE, str(AUTHORIZER), str(event_path), str(changed_files_path), str(commits_path)],
+        [
+            NODE,
+            str(AUTHORIZER),
+            str(event_path),
+            str(changed_files_path),
+            str(commits_path),
+            str(ancestry_proofs_path),
+        ],
         check=False,
         cwd=tmp_path,
-        env={**os.environ, "GITHUB_ACTOR": actor},
         capture_output=True,
         text=True,
     )
@@ -159,7 +219,7 @@ def test_authorization_derives_dependency_policy_from_the_trusted_base(
     """
     result = _authorize(
         tmp_path,
-        actor="dependabot[bot]",
+        ancestry_proofs=[],
         changed_files=changed_files,
         commits=[_dependabot_commit()],
         event=_event("opened", head_ref),
@@ -169,34 +229,153 @@ def test_authorization_derives_dependency_policy_from_the_trusted_base(
     assert (result.returncode == 0) is authorized
 
 
-def test_authorization_accepts_only_verified_update_branch_history(tmp_path: Path) -> None:
-    """Accept a GitHub Update branch merge and reject an unverified base commit.
+def test_authorization_accepts_reopened_verified_update_branch_history(tmp_path: Path) -> None:
+    """Accept a reopened GitHub Update branch chain with complete ancestry evidence.
 
     Args:
         tmp_path (Path): Trusted base checkout fixture directory.
     """
     valid = _authorize(
         tmp_path,
-        actor="Snuffy2",
+        ancestry_proofs=_update_chain_proofs(),
         changed_files=["uv.lock"],
-        commits=[_dependabot_commit(DEPENDABOT_SHA), _update_commit(DEPENDABOT_SHA)],
-        event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+        commits=_update_chain(),
+        event=_event(),
         trusted_base_files=["uv.lock"],
     )
     invalid = _authorize(
         tmp_path,
-        actor="Snuffy2",
+        ancestry_proofs=_update_chain_proofs(),
         changed_files=["uv.lock"],
         commits=[
             _dependabot_commit(DEPENDABOT_SHA, verified=False),
-            _update_commit(DEPENDABOT_SHA),
+            _update_commit(HEAD_SHA, DEPENDABOT_SHA, BASE_SHA),
         ],
-        event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+        event=_event(),
         trusted_base_files=["uv.lock"],
     )
 
     assert valid.returncode == 0
     assert invalid.returncode != 0
+
+
+def test_authorization_accepts_a_direct_reopened_dependabot_update(tmp_path: Path) -> None:
+    """Accept a verified one-commit Dependabot pull request after reopening.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+    """
+    result = _authorize(
+        tmp_path,
+        ancestry_proofs=[],
+        changed_files=["uv.lock"],
+        commits=[_dependabot_commit()],
+        event=_event(),
+        trusted_base_files=["uv.lock"],
+    )
+
+    assert result.returncode == 0
+
+
+def test_authorization_rejects_invalid_dependabot_provenance(tmp_path: Path) -> None:
+    """Reject forked, foreign-head, and non-default-base Dependabot pull requests.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+    """
+    fork = _event()
+    fork["repository"]["fork"] = True
+    foreign_head = _event()
+    foreign_head["pull_request"]["head"]["repo"]["full_name"] = "fork/repository"
+    non_default_base = _event()
+    non_default_base["pull_request"]["base"]["ref"] = "release"
+    for event in (fork, foreign_head, non_default_base):
+        result = _authorize(
+            tmp_path,
+            ancestry_proofs=[],
+            changed_files=["uv.lock"],
+            commits=[_dependabot_commit()],
+            event=event,
+            trusted_base_files=["uv.lock"],
+        )
+        assert result.returncode != 0
+
+
+def test_authorization_rejects_non_web_flow_update_merge(tmp_path: Path) -> None:
+    """Reject a reopened update chain containing a maintainer-created merge.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+    """
+    commits = _update_chain()
+    commits[1]["committer"] = {"login": "maintainer"}
+    result = _authorize(
+        tmp_path,
+        ancestry_proofs=_update_chain_proofs(),
+        changed_files=["uv.lock"],
+        commits=commits,
+        event=_event(),
+        trusted_base_files=["uv.lock"],
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "ancestry_proofs",
+    [
+        [],
+        [{}, _ancestry_proof(BASE_SHA, "identical")],
+        [_ancestry_proof(FIRST_BASE_SHA), _ancestry_proof("9" * 40)],
+        [_ancestry_proof(FIRST_BASE_SHA, "diverged"), _ancestry_proof(BASE_SHA, "identical")],
+        [
+            {**_ancestry_proof(FIRST_BASE_SHA), "head_commit": "8" * 40},
+            _ancestry_proof(BASE_SHA, "identical"),
+        ],
+    ],
+)
+def test_authorization_rejects_incomplete_or_invalid_merge_ancestry(
+    tmp_path: Path, ancestry_proofs: list[dict[str, Any]]
+) -> None:
+    """Fail closed when any GitHub Update branch merge lacks current-base proof.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+        ancestry_proofs (list[dict[str, Any]]): Invalid compare API evidence.
+    """
+    result = _authorize(
+        tmp_path,
+        ancestry_proofs=ancestry_proofs,
+        changed_files=["uv.lock"],
+        commits=_update_chain(),
+        event=_event(),
+        trusted_base_files=["uv.lock"],
+    )
+
+    assert result.returncode != 0
+
+
+def test_authorization_requires_current_event_head_and_base(tmp_path: Path) -> None:
+    """Reject stale merge-parent and direct-commit event state.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+    """
+    stale_parent_chain = _update_chain()
+    stale_parent_chain[-1] = _update_commit(HEAD_SHA, FIRST_UPDATE_SHA, FIRST_BASE_SHA)
+    for commits, proofs in [
+        (stale_parent_chain, _update_chain_proofs()),
+        ([_dependabot_commit(DEPENDABOT_SHA)], []),
+    ]:
+        result = _authorize(
+            tmp_path,
+            ancestry_proofs=proofs,
+            changed_files=["uv.lock"],
+            commits=commits,
+            event=_event(),
+            trusted_base_files=["uv.lock"],
+        )
+        assert result.returncode != 0
 
 
 @pytest.mark.parametrize(
@@ -220,7 +399,7 @@ def test_actions_authorization_requires_trusted_allowed_files(
     """
     result = _authorize(
         tmp_path,
-        actor="dependabot[bot]",
+        ancestry_proofs=[],
         changed_files=[changed_file],
         commits=[_dependabot_commit()],
         event=_event("opened", "dependabot/github_actions/actions/checkout-7"),
@@ -228,3 +407,286 @@ def test_actions_authorization_requires_trusted_allowed_files(
     )
 
     assert (result.returncode == 0) is authorized
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    """Parse a checked-in GitHub Actions workflow into semantic YAML values.
+
+    Args:
+        name (str): Workflow filename.
+
+    Returns:
+        dict[str, Any]: Parsed workflow document.
+    """
+    document = yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the parsed workflow steps from a job.
+
+    Args:
+        job (dict[str, Any]): Parsed workflow job.
+
+    Returns:
+        list[dict[str, Any]]: Job steps.
+    """
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _step_with_run(job: dict[str, Any], marker: str) -> dict[str, Any]:
+    """Find a step by a required command fragment.
+
+    Args:
+        job (dict[str, Any]): Parsed workflow job.
+        marker (str): Command fragment identifying the step.
+
+    Returns:
+        dict[str, Any]: Matching workflow step.
+    """
+    return next(step for step in _steps(job) if marker in str(step.get("run", "")))
+
+
+def _step_with_major_action(job: dict[str, Any], action: str) -> dict[str, Any]:
+    """Find a step that invokes an action through a major-version reference.
+
+    Args:
+        job (dict[str, Any]): Parsed workflow job.
+        action (str): Action owner/name identifying the step.
+
+    Returns:
+        dict[str, Any]: Matching workflow step.
+    """
+    return next(
+        step
+        for step in _steps(job)
+        if re.fullmatch(rf"{re.escape(action)}@v\d+(?:\.\d+)*", str(step.get("uses", "")))
+    )
+
+
+def _step_with_activity(job: dict[str, Any], activity: str) -> dict[str, Any]:
+    """Find a coverage action step by its explicit activity.
+
+    Args:
+        job (dict[str, Any]): Parsed workflow job.
+        activity (str): Coverage action activity value.
+
+    Returns:
+        dict[str, Any]: Matching coverage action step.
+    """
+    return next(
+        step
+        for step in _steps(job)
+        if re.fullmatch(
+            r"py-cov-action/python-coverage-comment-action@v\d+(?:\.\d+)*",
+            str(step.get("uses", "")),
+        )
+        and step.get("with", {}).get("ACTIVITY") == activity
+    )
+
+
+def _job_with_run(document: dict[str, Any], marker: str) -> tuple[str, dict[str, Any]]:
+    """Find a workflow job by a command capability.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+        marker (str): Command fragment identifying the job.
+
+    Returns:
+        tuple[str, dict[str, Any]]: Workflow job key and parsed job.
+    """
+    return next(
+        (job_id, job)
+        for job_id, job in document["jobs"].items()
+        if any(marker in str(step.get("run", "")) for step in _steps(job))
+    )
+
+
+def _job_with_activity(document: dict[str, Any], activity: str) -> tuple[str, dict[str, Any]]:
+    """Find a workflow job by a coverage action activity.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+        activity (str): Coverage action activity value.
+
+    Returns:
+        tuple[str, dict[str, Any]]: Workflow job key and parsed job.
+    """
+    return next(
+        (job_id, job)
+        for job_id, job in document["jobs"].items()
+        if any(step.get("with", {}).get("ACTIVITY") == activity for step in _steps(job))
+    )
+
+
+def _assert_eligible_dependabot_condition(condition: object) -> None:
+    """Assert the provenance constraints required before trusted authorization.
+
+    Args:
+        condition (object): Parsed GitHub Actions expression.
+    """
+    value = str(condition)
+    for required_term in (
+        "repository.fork == false",
+        "pull_request.user.login == 'dependabot[bot]'",
+        "pull_request.head.repo.full_name == github.repository",
+        "pull_request.base.ref == github.event.repository.default_branch",
+    ):
+        assert required_term in value
+
+
+def _assert_dependabot_author_condition(condition: object) -> None:
+    """Assert that a workflow dispatches authorization for every Dependabot author.
+
+    Args:
+        condition (object): Parsed GitHub Actions expression.
+    """
+    value = str(condition)
+    assert "pull_request.user.login == 'dependabot[bot]'" in value
+    for disallowed_restriction in (
+        "repository.fork == false",
+        "pull_request.head.repo.full_name == github.repository",
+        "pull_request.base.ref == github.event.repository.default_branch",
+    ):
+        assert disallowed_restriction not in value
+
+
+def _assert_trusted_checkout_precedes_authorization(job: dict[str, Any]) -> None:
+    """Assert that only the credential-free base checkout precedes the helper run.
+
+    Args:
+        job (dict[str, Any]): Parsed workflow job.
+    """
+    authorization_step = _step_with_run(job, "dependabot-auto-merge.mjs")
+    authorization_index = _steps(job).index(authorization_step)
+    checkout = next(
+        step
+        for step in _steps(job)[:authorization_index]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+        and step.get("with", {}).get("ref") == "${{ github.event.pull_request.base.sha }}"
+    )
+    assert checkout["with"]["persist-credentials"] is False
+
+
+def test_dependabot_and_coverage_workflow_trust_contracts() -> None:
+    """Keep authorization inputs read-only and coverage comments in the checkout-free writer.
+
+    The assertions operate on parsed YAML structures and command dataflow, rather than
+    source formatting or step labels, so they protect the trust boundary across harmless
+    workflow cleanup.
+    """
+    auto_merge = _load_workflow("dependabot-auto-merge.yml")
+    pytest_check = _load_workflow("pytest_check.yml")
+    post_coverage = _load_workflow("pytest_post_coverage.yml")
+    authorization_id, authorization = _job_with_run(auto_merge, "dependabot-auto-merge.mjs")
+
+    assert authorization["permissions"] == {"contents": "read", "pull-requests": "read"}
+    _assert_dependabot_author_condition(authorization["if"])
+    _assert_trusted_checkout_precedes_authorization(authorization)
+    authorization_run = _step_with_run(authorization, "dependabot-auto-merge.mjs")["run"]
+    for required_dataflow in (
+        "pulls/${PR_NUMBER}/files",
+        "pulls/${PR_NUMBER}/commits",
+        "compare/",
+        "ancestry_proofs",
+    ):
+        assert required_dataflow in authorization_run
+    _, enable_auto_merge = _job_with_run(auto_merge, "gh pr merge --auto")
+    assert enable_auto_merge["needs"] == authorization_id
+    assert "if" not in enable_auto_merge
+    assert enable_auto_merge["permissions"] == {"contents": "write", "pull-requests": "write"}
+    _, disable_auto_merge = _job_with_run(auto_merge, "gh pr merge --disable-auto")
+    assert "failure()" in str(disable_auto_merge["if"])
+    assert "!cancelled()" in str(disable_auto_merge["if"])
+    _assert_eligible_dependabot_condition(disable_auto_merge["if"])
+    for job in auto_merge["jobs"].values():
+        permissions = job.get("permissions", {})
+        if "write" in permissions.values():
+            assert not any("actions/checkout@" in str(step.get("uses", "")) for step in _steps(job))
+
+    _, tests = _job_with_run(pytest_check, "uv run --locked --group pytest pytest")
+    assert tests["permissions"] == {"contents": "read", "pull-requests": "read"}
+    trusted_checkout = _step_with_major_action(tests, "actions/checkout")
+    assert trusted_checkout["with"] == {
+        "persist-credentials": False,
+        "ref": "${{ github.event.pull_request.base.sha }}",
+    }
+    authorizer = _step_with_run(tests, "dependabot-auto-merge.mjs")
+    for step in (trusted_checkout, authorizer):
+        condition = str(step["if"])
+        assert "github.event_name == 'pull_request'" in condition
+        assert "pull_request.user.login == 'dependabot[bot]'" in condition
+        for disallowed_restriction in (
+            "repository.fork == false",
+            "pull_request.head.repo.full_name == github.repository",
+            "pull_request.base.ref == github.event.repository.default_branch",
+        ):
+            assert disallowed_restriction not in condition
+    _assert_trusted_checkout_precedes_authorization(tests)
+    authorization_index = _steps(tests).index(authorizer)
+    head_checkout_index = next(
+        index
+        for index, step in enumerate(_steps(tests))
+        if re.fullmatch(r"actions/checkout@v\d+(?:\.\d+)*", str(step.get("uses", "")))
+        and step.get("with", {}).get("ref") == "${{ inputs.expected_sha || github.sha }}"
+    )
+    assert head_checkout_index > authorization_index
+    assert all(
+        "write" not in permissions.values()
+        for job in pytest_check["jobs"].values()
+        for permissions in [job.get("permissions", {})]
+    )
+    coverage = _step_with_activity(tests, "process_pr")
+    assert coverage["with"] == {
+        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+        "ACTIVITY": "process_pr",
+        "MINIMUM_GREEN": 90,
+        "MINIMUM_ORANGE": 70,
+    }
+    stored_coverage = next(
+        step for step in _steps(tests) if step.get("with", {}).get("name") == "python-coverage-data"
+    )
+    assert re.fullmatch(r"actions/upload-artifact@v\d+(?:\.\d+)*", str(stored_coverage["uses"]))
+    assert stored_coverage["if"] == "github.event_name == 'push'"
+    assert stored_coverage["with"] == {
+        "name": "python-coverage-data",
+        "path": ".coverage",
+        "include-hidden-files": True,
+        "retention-days": 1,
+    }
+
+    _, post_job = _job_with_activity(post_coverage, "post_comment")
+    assert post_job["permissions"] == {
+        "pull-requests": "write",
+        "contents": "read",
+        "actions": "read",
+    }
+    assert "workflow_run.event == 'pull_request'" in str(post_job["if"])
+    assert "workflow_run.conclusion == 'success'" in str(post_job["if"])
+    assert not any("actions/checkout@" in str(step.get("uses", "")) for step in _steps(post_job))
+    post = _step_with_activity(post_job, "post_comment")
+    assert post["with"]["GITHUB_PR_RUN_ID"] == "${{ github.event.workflow_run.id }}"
+
+    _, publisher = _job_with_activity(post_coverage, "save_coverage_data_files")
+    assert publisher["permissions"] == {"actions": "read", "contents": "write"}
+    for required_term in (
+        "workflow_run.event == 'push'",
+        "workflow_run.conclusion == 'success'",
+        "workflow_run.head_branch == github.event.repository.default_branch",
+    ):
+        assert required_term in str(publisher["if"])
+    checkout = _step_with_major_action(publisher, "actions/checkout")
+    assert checkout["with"] == {
+        "persist-credentials": False,
+        "ref": "${{ github.event.workflow_run.head_sha }}",
+    }
+    download = _step_with_run(publisher, "gh run download")
+    assert "${RUN_ID}" in download["run"]
+    assert "${REPOSITORY}" in download["run"]
+    assert "--name python-coverage-data" in download["run"]
+    published_coverage = _step_with_activity(publisher, "save_coverage_data_files")
+    assert published_coverage["with"]["MINIMUM_GREEN"] == 90
+    assert published_coverage["with"]["MINIMUM_ORANGE"] == 70

--- a/tests/test_dependabot_auto_merge_workflow.py
+++ b/tests/test_dependabot_auto_merge_workflow.py
@@ -1,125 +1,200 @@
-"""Tests for the Dependabot auto-merge workflow contracts."""
+"""Executable behavior tests for Dependabot auto-merge authorization."""
 
+import json
+import os
 from pathlib import Path
-import re
-import shlex
+import shutil
+import subprocess
 from typing import Any
 
-import yaml
+import pytest
 
-WORKFLOW_PATH = Path(__file__).parents[1] / ".github" / "workflows" / "dependabot-auto-merge.yml"
-TRUSTED_PULL_REQUEST_GUARD = (
-    "github.event.repository.fork == false && "
-    "github.event.pull_request.user.login == 'dependabot[bot]' && "
-    "github.event.pull_request.head.repo.full_name == github.repository && "
-    "github.event.pull_request.base.ref == github.event.repository.default_branch"
-)
-
-
-def _load_workflow() -> dict[str, Any]:
-    """Load the Dependabot workflow while normalizing YAML's boolean `on` key.
-
-    Returns:
-        dict[str, Any]: Parsed workflow document.
-    """
-    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
-    assert isinstance(document, dict)
-    if True in document:
-        document["on"] = document.pop(True)
-    return document
+AUTHORIZER = Path(__file__).parents[1] / ".github" / "scripts" / "dependabot-auto-merge.mjs"
+BASE_SHA = "4" * 40
+DEPENDABOT_SHA = "1" * 40
+HEAD_SHA = "5" * 40
+REPOSITORY = "Snuffy2/hass-opnsense"
+NODE = shutil.which("node")
 
 
-def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, Any]]:
-    """Index named steps in one workflow job.
+def _event(action: str, head_ref: str) -> dict[str, Any]:
+    """Build a same-repository Dependabot pull-request event fixture.
 
     Args:
-        document (dict[str, Any]): Parsed workflow document.
-        job_id (str): Workflow job identifier.
+        action (str): Pull-request event action.
+        head_ref (str): Dependabot branch name.
 
     Returns:
-        dict[str, dict[str, Any]]: Named workflow steps.
+        dict[str, Any]: Event consumed by the authorizer.
     """
-    job = document["jobs"][job_id]
-    assert isinstance(job, dict)
-    steps = job["steps"]
-    assert isinstance(steps, list)
-    return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
+    return {
+        "action": action,
+        "repository": {"default_branch": "main", "fork": False, "full_name": REPOSITORY},
+        "pull_request": {
+            "base": {"ref": "main", "sha": BASE_SHA},
+            "head": {"ref": head_ref, "repo": {"full_name": REPOSITORY}, "sha": HEAD_SHA},
+            "user": {"login": "dependabot[bot]"},
+        },
+    }
 
 
-def test_verify_job_guards_source_and_changed_file_allowlist() -> None:
-    """Require trusted Dependabot pull requests and the supported file allowlists."""
-    document = _load_workflow()
-    verify_job = document["jobs"]["verify-dependency-update"]
-    assert isinstance(verify_job, dict)
-    verify_guard = verify_job["if"]
-    assert isinstance(verify_guard, str)
-    for constraint in TRUSTED_PULL_REQUEST_GUARD.split(" && "):
-        assert constraint in verify_guard
-    assert "||" not in verify_guard
+def _dependabot_commit(sha: str = HEAD_SHA, *, verified: bool = True) -> dict[str, Any]:
+    """Build a Dependabot commit fixture.
 
-    verify_run = _named_steps(document, "verify-dependency-update")[
-        "Verify supported dependency update"
-    ]["run"]
-    assert isinstance(verify_run, str)
-    assert "changed_files=" in verify_run
-    assert "gh api --paginate" in verify_run
-    assert "uv)" in verify_run
-    assert "github_actions)" in verify_run
-    assert re.search(
-        r'\[\[\s*-n\s+"\$\{changed_files\}"\s*\]\]\s*\|\|\s*\{.*?'
-        r"\bexit\s+1\b.*?\}",
-        verify_run,
-        re.DOTALL,
+    Args:
+        sha (str): Commit SHA.
+        verified (bool): Whether GitHub verified the commit.
+
+    Returns:
+        dict[str, Any]: Commit data returned by the pull-request API.
+    """
+    return {
+        "author": {"login": "dependabot[bot]"},
+        "commit": {"verification": {"verified": verified}},
+        "parents": [],
+        "sha": sha,
+    }
+
+
+def _update_commit(previous: str) -> dict[str, Any]:
+    """Build a verified GitHub Update branch merge commit.
+
+    Args:
+        previous (str): SHA of the preceding Dependabot commit.
+
+    Returns:
+        dict[str, Any]: Commit data for the current-base merge.
+    """
+    return {
+        "author": {"login": "Snuffy2"},
+        "commit": {"verification": {"verified": True}},
+        "committer": {"login": "web-flow"},
+        "parents": [{"sha": previous}, {"sha": BASE_SHA}],
+        "sha": HEAD_SHA,
+    }
+
+
+def _authorize(
+    tmp_path: Path,
+    *,
+    actor: str,
+    changed_files: list[str],
+    commits: list[dict[str, Any]],
+    event: dict[str, Any],
+) -> subprocess.CompletedProcess[str]:
+    """Run the checked-in authorization command with API-shaped inputs.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+        actor (str): GitHub Actions actor.
+        changed_files (list[str]): Files reported by the pull-request API.
+        commits (list[dict[str, Any]]): Commit pages returned by the API.
+        event (dict[str, Any]): Pull-request event payload.
+
+    Returns:
+        subprocess.CompletedProcess[str]: Result from the authorizer process.
+
+    Raises:
+        RuntimeError: If Node.js is unavailable.
+    """
+    event_path = tmp_path / "event.json"
+    changed_files_path = tmp_path / "changed-files"
+    commits_path = tmp_path / "commits.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+    changed_files_path.write_text("\n".join(changed_files), encoding="utf-8")
+    commits_path.write_text(json.dumps([commits]), encoding="utf-8")
+    if NODE is None:
+        raise RuntimeError("Node.js is required to run the Dependabot authorizer.")
+    return subprocess.run(  # noqa: S603
+        [NODE, str(AUTHORIZER), str(event_path), str(changed_files_path), str(commits_path)],
+        check=False,
+        cwd=tmp_path,
+        env={**os.environ, "GITHUB_ACTOR": actor},
+        capture_output=True,
+        text=True,
     )
-    assert re.search(
-        r"\*\)\s*.*?unsupported ecosystem.*?\bexit\s+1\b",
-        verify_run,
-        re.DOTALL,
+
+
+@pytest.mark.parametrize(
+    ("changed_files", "authorized"),
+    [(["uv.lock"], True), (["pyproject.toml", "uv.lock"], False)],
+)
+def test_uv_authorization_requires_only_the_lockfile(
+    tmp_path: Path, changed_files: list[str], authorized: bool
+) -> None:
+    """Authorize direct uv updates only when their API file list is lockfile-only.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+        changed_files (list[str]): Files reported by the pull-request API.
+        authorized (bool): Whether the update should pass authorization.
+    """
+    result = _authorize(
+        tmp_path,
+        actor="dependabot[bot]",
+        changed_files=changed_files,
+        commits=[_dependabot_commit()],
+        event=_event("opened", "dependabot/uv/pytest-9.0.0"),
     )
-    assert '[[ "${changed_files}" == "uv.lock" ]]' in verify_run
-    assert r"grep -Ev '^\.github/workflows/[^/]+\.ya?ml$'" in verify_run
-    assert 'case "${PACKAGE_ECOSYSTEM}" in' in verify_run
+
+    assert (result.returncode == 0) is authorized
 
 
-def test_disable_job_repeats_failure_and_trusted_source_guards() -> None:
-    """Keep failure handling and trusted pull-request constraints on disable."""
-    document = _load_workflow()
-    disable_job = document["jobs"]["disable-auto-merge"]
-    assert isinstance(disable_job, dict)
-    disable_guard = disable_job["if"]
-    assert isinstance(disable_guard, str)
-    for token in (
-        "failure()",
-        "!cancelled()",
-        "needs.verify-dependency-update.result != 'success'",
-    ):
-        assert token in disable_guard
-    assert "||" not in disable_guard
-    for constraint in TRUSTED_PULL_REQUEST_GUARD.split(" && "):
-        assert constraint in disable_guard
+def test_authorization_accepts_only_verified_update_branch_history(tmp_path: Path) -> None:
+    """Accept a GitHub Update branch merge and reject an unverified base commit.
+
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+    """
+    valid = _authorize(
+        tmp_path,
+        actor="Snuffy2",
+        changed_files=["uv.lock"],
+        commits=[_dependabot_commit(DEPENDABOT_SHA), _update_commit(DEPENDABOT_SHA)],
+        event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+    )
+    invalid = _authorize(
+        tmp_path,
+        actor="Snuffy2",
+        changed_files=["uv.lock"],
+        commits=[
+            _dependabot_commit(DEPENDABOT_SHA, verified=False),
+            _update_commit(DEPENDABOT_SHA),
+        ],
+        event=_event("synchronize", "dependabot/uv/pytest-9.0.0"),
+    )
+
+    assert valid.returncode == 0
+    assert invalid.returncode != 0
 
 
-def test_merge_jobs_keep_write_permissions_and_head_commit_match() -> None:
-    """Preserve merge mutation permissions and the head SHA check."""
-    document = _load_workflow()
-    jobs = document["jobs"]
-    assert isinstance(jobs, dict)
-    for job_id in ("enable-auto-merge", "disable-auto-merge"):
-        job = jobs[job_id]
-        assert isinstance(job, dict)
-        assert job["needs"] == "verify-dependency-update"
-        assert job["permissions"] == {
-            "contents": "write",
-            "pull-requests": "write",
-        }
+@pytest.mark.parametrize(
+    ("changed_file", "trusted_file", "authorized"),
+    [
+        (".github/workflows/pytest_check.yml", ".github/workflows/pytest_check.yml", True),
+        (".github/workflows/nested/unsafe.yml", ".github/workflows/nested/unsafe.yml", False),
+    ],
+)
+def test_actions_authorization_requires_an_existing_top_level_file(
+    tmp_path: Path, changed_file: str, trusted_file: str, authorized: bool
+) -> None:
+    """Authorize only trusted-base top-level GitHub Actions workflow updates.
 
-    enable_run = _named_steps(document, "enable-auto-merge")["Enable auto-merge"]["run"]
-    assert isinstance(enable_run, str)
-    command = shlex.split(enable_run)
-    assert command[:3] == ["gh", "pr", "merge"]
-    assert {"--auto", "--squash"}.issubset(command)
-    assert "--match-head-commit" in command
-    match_head_index = command.index("--match-head-commit")
-    assert match_head_index + 1 < len(command)
-    assert command[match_head_index + 1] == "${HEAD_SHA}"
-    assert "${PR_URL}" in command
+    Args:
+        tmp_path (Path): Trusted base checkout fixture directory.
+        changed_file (str): File reported by the pull-request API.
+        trusted_file (str): Corresponding file present in the trusted checkout.
+        authorized (bool): Whether the update should pass authorization.
+    """
+    trusted_path = tmp_path / trusted_file
+    trusted_path.parent.mkdir(parents=True)
+    trusted_path.write_text("name: trusted\n", encoding="utf-8")
+    result = _authorize(
+        tmp_path,
+        actor="dependabot[bot]",
+        changed_files=[changed_file],
+        commits=[_dependabot_commit()],
+        event=_event("opened", "dependabot/github_actions/actions/checkout-7"),
+    )
+
+    assert (result.returncode == 0) is authorized

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1026,7 +1026,7 @@ def test_device_info_uses_legacy_parent_identifier(
     device_info = entity.device_info
 
     assert device_info is not None
-    assert device_info["via_device"] == (DOMAIN, "dev1")
+    assert dict(device_info)["via_device"] == (DOMAIN, "dev1")
     assert "via_device_id" not in device_info
     assert "default_name" not in device_info
     assert "default_manufacturer" not in device_info
@@ -1223,7 +1223,9 @@ async def test_async_internal_added_to_hass_creates_integration_device_for_exist
         connections={(dr.CONNECTION_NETWORK_MAC, mac_address)},
     )
     assert (
-        device_reg.async_get_device(connections={(dr.CONNECTION_NETWORK_MAC, mac_address)})
+        device_reg.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, mac_address), existing_entry.entry_id
+        )
         == existing_device
     )
     entity_reg = er.async_get(ph_hass)
@@ -1242,7 +1244,7 @@ async def test_async_internal_added_to_hass_creates_integration_device_for_exist
     device_id = ent.registry_entry.device_id
     assert device_id is not None
     linked_device = device_reg.async_get(device_id)
-    assert linked_device is not None
+    assert isinstance(linked_device, dr.DeviceEntry)
     assert linked_device.id != existing_device.id
     assert (dr.CONNECTION_NETWORK_MAC, mac_address) in linked_device.connections
     assert entry.entry_id in linked_device.config_entries

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -467,8 +467,8 @@ def test_release_gate_workflows_guard_and_checkout_the_exact_dispatch_sha(
             for step in steps.values()
             if isinstance(step.get("uses"), str)
             and step["uses"].split("@", 1)[0] == "actions/checkout"
+            and step.get("with", {}).get("ref") == "${{ inputs.expected_sha || github.sha }}"
         )
-        assert checkout["with"]["ref"] == "${{ inputs.expected_sha || github.sha }}"
         assert checkout["with"]["persist-credentials"] is False
 
     if workflow == "pytest_check.yml":

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -472,7 +472,7 @@ def test_release_gate_workflows_guard_and_checkout_the_exact_dispatch_sha(
         assert checkout["with"]["persist-credentials"] is False
 
     if workflow == "pytest_check.yml":
-        assert document["jobs"]["tests"]["permissions"] == {"contents": "read"}
-        assert document["jobs"]["coverage_publisher"]["if"].startswith(
-            "github.event_name != 'workflow_dispatch'"
-        )
+        assert document["jobs"]["tests"]["permissions"] == {
+            "contents": "read",
+            "pull-requests": "read",
+        }


### PR DESCRIPTION
## Summary

Standardize and harden Dependabot auto-merge authorization while keeping test and coverage publication on trusted workflow paths. This ensures dependency updates are validated against the current trusted base before untrusted branch content is checked out or auto-merged.

## What Changed

- Added a trusted-base authorization helper that verifies Dependabot provenance, supported dependency files, signed commit history, update-branch merge structure, and current-base ancestry.
- Reused that authorization before running pytest for Dependabot pull requests, while preserving the existing bot and release workflow gates.
- Split pull-request coverage comments from default-branch coverage publication so write-capable publication runs only from trusted completed workflows.
- Expanded workflow contract tests for direct updates, GitHub Update branch histories, ancestry proofs, allowed dependency scopes, and coverage publication behavior.

## Why

Dependabot pull requests can be updated through GitHub's Update branch action, which changes the triggering actor and commit history without necessarily introducing untrusted edits. The workflow now authorizes the actual repository, branch, files, signatures, and ancestry instead of relying on actor-only checks, while failing closed when any proof is incomplete.