### PR TITLE
Standardize guarded Home Assistant releases

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -21,10 +21,11 @@ pushing the candidate to a unique `release-validation/...` branch.
 
 It dispatches and verifies these exact candidate-SHA gates:
 
-- `linters.yml::Run Linters`
-- `pytest_check.yml::pytest and coverage report`
+- `pytest_check.yml::pytest check and post coverage`
+- `uv-lock-check.yml::Validate uv lock consistency`
 - `validate.yml::Hassfest Validation`
 - `validate.yml::HACS Validation`
+- `linters.yml::review`
 
 After every gate succeeds, the workflow atomically advances the default branch
 and replaces the tag with an annotated tag, using leases for both original

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,38 +1,38 @@
 # Releasing hass-opnsense
 
-## Normal release
+<!-- cspell:ignore Hassfest -->
 
-1. Merge the release-ready changes into the default branch.
-2. Create and publish a GitHub release targeted at that default branch, using a
-   valid `v`-prefixed tag. Tags containing only numeric components are stable;
-   tags with a suffix are prereleases. The tag initially points at the current
-   default-branch commit.
-3. The **Release** workflow runs on the published release event.
+## Stable releases
 
-For a stable release, the workflow validates the tag and release target,
-creates a deterministic version-only commit, builds and tests `opnsense.zip`,
-publishes the candidate to a temporary validation branch, and dispatches the
-immutable validation, pytest, and lint gates. Only their exact successful jobs
-allow a lease-guarded atomic promotion of the default branch and annotated tag.
-It then uploads `opnsense.zip` and adds the firmware compatibility note.
+1. Merge release-ready changes into the default branch, then publish a GitHub
+   Release with an unused valid `v`-prefixed stable tag targeting that branch.
+   The new tag and branch must initially name the same commit.
+2. The **Release** workflow creates one deterministic commit changing only
+   `manifest.json` and `const.py`, then builds and validates `opnsense.zip`.
+3. It publishes that candidate to a unique validation branch and dispatches its
+   exact SHA to HACS, Hassfest, pytest, and lint checks. After they pass, it
+   atomically advances the default branch and annotated tag, verifies both refs,
+   uploads the archive, and idempotently adds the firmware compatibility note.
 
-Prereleases build, validate, and upload the archive from the published tag but
-never mutate the default branch or move the tag. Their source must already have
-the matching manifest and `const.py` version.
+No personal access token is required. The workflow uses `GITHUB_TOKEN` with
+step-scoped access; branch protection remains active for promotion.
 
-No personal access token is needed. The workflow uses the scoped GitHub token
-only for the release API, temporary validation ref, gate dispatch, guarded
-promotion, and cleanup.
+## Prereleases
 
-## Recovery
+Publish an explicit unused prerelease tag whose `manifest.json` and `const.py`
+versions already match. The workflow builds and uploads `opnsense.zip` without
+creating a commit or moving a branch or tag. It also idempotently maintains the
+firmware compatibility note. Before upload, the default branch and tag must
+still resolve to the exact source selected by the published release.
 
-Do not force-move a tag or default branch after any failure. A failed stable
-release intentionally leaves its temporary validation branch for inspection;
-delete it only after determining that its candidate and CI evidence are no
-longer needed. Create a new correctly targeted release after fixing any source
-or workflow issue.
+## Failures and retries
 
-For an upload-only recovery, inspect the promoted annotated tag, version files,
-and archive before attaching `opnsense.zip` to the existing release. Preserve
-the firmware compatibility note using the firmware bounds from the tagged
-`custom_components/opnsense/const.py`.
+A failed stable validation retains its `release-validation/...` branch. Verify
+its exact SHA before deleting it; do not promote that commit directly or
+force-move its tag.
+
+If an upload fails after promotion, rerun the workflow only when the default
+branch and annotated tag still name the same one-parent `Release <tag>` commit,
+its only changed paths are the two version files, and regenerating those files
+from the parent produces identical contents. Otherwise, start a new release
+from current default-branch state.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,37 +2,65 @@
 
 <!-- cspell:ignore Hassfest -->
 
+## Prerequisites
+
+Publishing a GitHub Release is the only release trigger (`release: published`).
+Create it with a new `v`-prefixed tag targeting the repository default branch.
+At the start of the run, that tag and the default branch must name the same
+commit. Stable tags are numeric `v` versions with two, three, or four
+components; the prerelease setting must agree with the tag format. A
+prerelease archive must already contain its tag in both
+`custom_components/opnsense/manifest.json` and `const.py`.
+
 ## Stable releases
 
-1. Merge release-ready changes into the default branch, then publish a GitHub
-   Release with an unused valid `v`-prefixed stable tag targeting that branch.
-   The new tag and branch must initially name the same commit.
-2. The **Release** workflow creates one deterministic commit changing only
-   `manifest.json` and `const.py`, then builds and validates `opnsense.zip`.
-3. It publishes that candidate to a unique validation branch and dispatches its
-   exact SHA to HACS, Hassfest, pytest, and lint checks. After they pass, it
-   atomically advances the default branch and annotated tag, verifies both refs,
-   uploads the archive, and idempotently adds the firmware compatibility note.
+The workflow rechecks the default branch before running its trusted helpers,
+then creates a deterministic candidate commit that changes only those two
+version files. It builds and verifies `opnsense.zip` from that commit before
+pushing the candidate to a unique `release-validation/...` branch.
 
-No personal access token is required. The workflow uses `GITHUB_TOKEN` with
-step-scoped access; branch protection remains active for promotion.
+It dispatches and verifies these exact candidate-SHA gates:
+
+- `linters.yml::Run Linters`
+- `pytest_check.yml::pytest and coverage report`
+- `validate.yml::Hassfest Validation`
+- `validate.yml::HACS Validation`
+
+After every gate succeeds, the workflow atomically advances the default branch
+and replaces the tag with an annotated tag, using leases for both original
+refs. It fetches them again, requires both to resolve to the candidate, verifies
+the archive again, adds the OPNsense firmware-compatibility note if absent, and
+uploads the archive. The validation branch is deleted only after success.
 
 ## Prereleases
 
-Publish an explicit unused prerelease tag whose `manifest.json` and `const.py`
-versions already match. The workflow builds and uploads `opnsense.zip` without
-creating a commit or moving a branch or tag. It also idempotently maintains the
-firmware compatibility note. Before upload, the default branch and tag must
-still resolve to the exact source selected by the published release.
+A prerelease builds `opnsense.zip` directly from the published source. It does
+not create a candidate commit, dispatch release gates, create a validation
+branch, or move the branch or tag. Before upload, the workflow rechecks the
+original branch, tag object, and tag target; it verifies the archive and
+idempotently adds the firmware-compatibility note.
 
-## Failures and retries
+## Failures and recovery
 
-A failed stable validation retains its `release-validation/...` branch. Verify
-its exact SHA before deleting it; do not promote that commit directly or
-force-move its tag.
+The workflow stops if the target is not the default branch, the default branch
+moves, the tag identity changes, the tag kind is inconsistent, archive
+validation fails, a gate does not complete successfully for the dispatched
+SHA, or a guarded ref check fails. Do not promote a validation branch directly
+or force-move its tag.
 
-If an upload fails after promotion, rerun the workflow only when the default
-branch and annotated tag still name the same one-parent `Release <tag>` commit,
-its only changed paths are the two version files, and regenerating those files
-from the parent produces identical contents. Otherwise, start a new release
-from current default-branch state.
+If a stable run has created a validation branch, it remains after failure.
+Confirm its candidate SHA before removing it:
+
+```sh
+git fetch origin "refs/heads/<temporary-ref>:refs/remotes/origin/<temporary-ref>"
+git rev-parse "refs/remotes/origin/<temporary-ref>"
+git push --force-with-lease="refs/heads/<temporary-ref>:<candidate-sha>" origin --delete "<temporary-ref>"
+```
+
+If promotion reports an error, inspect both remote refs before retrying. Do
+not assume an atomic push left them unchanged; treat a branch/tag split as an
+incident. If upload fails after promotion, rerun only when the branch and tag
+still name the same one-parent `Release <tag>` commit, it changed only the two
+version files, and recreating those files from its parent is identical.
+Otherwise, publish a new release from current default-branch state without
+moving the original tag.

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1,5 +1,4 @@
 """Validate a release tag and prepare the integration version files."""
-# ruff: noqa: E501
 
 from __future__ import annotations
 
@@ -15,27 +14,8 @@ TAG_PATTERN = re.compile(
 )
 MANIFEST_VERSION_PATTERN = re.compile(r'("version"\s*:\s*)"[^"]*"')
 CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
-STABLE_TAG_PATTERN = re.compile(
-    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?$"
-)
-
-
-def _stable_tag_pattern(parts: tuple[int, ...]) -> re.Pattern[str]:
-    """Return the numeric release-tag pattern for permitted component counts."""
-    component = r"(?:0|[1-9][0-9]*)"
-    suffixes = "|".join(rf"(?:\.{component}){{{part - 1}}}" for part in sorted(parts))
-    return re.compile(rf"^v{component}(?:{suffixes})$")
-
-
-def _parse_stable_parts(value: str) -> tuple[int, ...]:
-    """Parse supported stable version component counts from workflow configuration."""
-    try:
-        parts = tuple(sorted({int(part) for part in value.split(",")}))
-    except ValueError as error:
-        raise ValueError("stable-parts must be comma-separated integers.") from error
-    if not parts or any(part < 2 or part > 4 for part in parts):
-        raise ValueError("stable-parts must contain values from 2 through 4.")
-    return parts
+_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
+STABLE_TAG_PATTERN = re.compile(rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}$")
 
 
 def validate_release_tag(tag: str) -> None:
@@ -52,21 +32,18 @@ def validate_release_tag(tag: str) -> None:
         raise ValueError(msg)
 
 
-def validate_release_request(
-    tag: str, prerelease: bool, stable_parts: tuple[int, ...] = (2, 3, 4)
-) -> None:
+def validate_release_request(tag: str, prerelease: bool) -> None:
     """Validate that a release tag agrees with the prerelease selection.
 
     Args:
         tag: Candidate release tag.
         prerelease: Whether the release should be treated as a prerelease.
-        stable_parts: Accepted numeric component counts for stable tags.
 
     Raises:
         ValueError: If the tag format and prerelease selection disagree.
     """
     validate_release_tag(tag)
-    tag_is_prerelease = _stable_tag_pattern(stable_parts).fullmatch(tag) is None
+    tag_is_prerelease = STABLE_TAG_PATTERN.fullmatch(tag) is None
     if tag_is_prerelease != prerelease:
         tag_kind = "Prerelease" if tag_is_prerelease else "Stable"
         required_value = str(tag_is_prerelease).lower()
@@ -74,15 +51,12 @@ def validate_release_request(
         raise ValueError(msg)
 
 
-def next_stable_release_tag(
-    tags: Iterable[str], bump_type: str, stable_parts: tuple[int, ...] = (2, 3, 4)
-) -> str:
+def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
     """Return the next stable tag after the highest released stable version.
 
     Args:
         tags: Candidate tag names from the release repository.
         bump_type: Requested stable version increment.
-        stable_parts: Accepted numeric component counts for stable tags.
 
     Returns:
         The next stable release tag.
@@ -98,7 +72,7 @@ def next_stable_release_tag(
         tuple(int(component) for component in tag.removeprefix("v").split("."))
         + (0,) * (4 - len(tag.removeprefix("v").split(".")))
         for tag in tags
-        if _stable_tag_pattern(stable_parts).fullmatch(tag) is not None
+        if STABLE_TAG_PATTERN.fullmatch(tag) is not None
     ]
     if not versions:
         msg = "No stable released tag found."
@@ -225,11 +199,6 @@ def main() -> int:
         "--component-path",
         help="Integration directory relative to --repository.",
     )
-    parser.add_argument(
-        "--stable-parts",
-        default="2,3,4",
-        help="Comma-separated stable release version component counts.",
-    )
     args = parser.parse_args()
 
     try:
@@ -241,17 +210,13 @@ def main() -> int:
                 msg = "Validation options cannot be used with --next-tag."
                 raise ValueError(msg)
             sys.stdout.write(
-                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag, _parse_stable_parts(args.stable_parts))}\n"
+                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag)}\n"
             )
         elif args.check_only:
             if args.expected_prerelease is None:
                 validate_release_tag(args.tag)
             else:
-                validate_release_request(
-                    args.tag,
-                    args.expected_prerelease == "true",
-                    _parse_stable_parts(args.stable_parts),
-                )
+                validate_release_request(args.tag, args.expected_prerelease == "true")
         else:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -9,12 +9,12 @@ from pathlib import Path
 import re
 import sys
 
+_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
 TAG_PATTERN = re.compile(
-    r"^v[0-9]+(?:\.[0-9]+){1,3}(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?(?:[A-Za-z]+[0-9]+)?$"
+    rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?(?:[A-Za-z]+[0-9]+)?$"
 )
 MANIFEST_VERSION_PATTERN = re.compile(r'("version"\s*:\s*)"[^"]*"')
 CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
-_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
 STABLE_TAG_PATTERN = re.compile(rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}$")
 
 

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -180,6 +180,12 @@ def main() -> int:
         choices=("true", "false"),
         help="Require the tag to match the workflow prerelease selection",
     )
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root whose version files should be validated or updated",
+    )
     args = parser.parse_args()
 
     try:
@@ -202,7 +208,7 @@ def main() -> int:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."
                 raise ValueError(msg)
-            update_release_versions(Path.cwd(), args.tag)
+            update_release_versions(args.repository, args.tag)
     except (OSError, ValueError) as error:
         parser.error(str(error))
 

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1,4 +1,5 @@
 """Validate a release tag and prepare the integration version files."""
+# ruff: noqa: E501
 
 from __future__ import annotations
 
@@ -17,7 +18,24 @@ CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
 STABLE_TAG_PATTERN = re.compile(
     r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?$"
 )
-NUMERIC_TAG_PATTERN = re.compile(r"^v[0-9]+(?:\.[0-9]+){1,3}$")
+
+
+def _stable_tag_pattern(parts: tuple[int, ...]) -> re.Pattern[str]:
+    """Return the numeric release-tag pattern for permitted component counts."""
+    component = r"(?:0|[1-9][0-9]*)"
+    suffixes = "|".join(rf"(?:\.{component}){{{part - 1}}}" for part in sorted(parts))
+    return re.compile(rf"^v{component}(?:{suffixes})$")
+
+
+def _parse_stable_parts(value: str) -> tuple[int, ...]:
+    """Parse supported stable version component counts from workflow configuration."""
+    try:
+        parts = tuple(sorted({int(part) for part in value.split(",")}))
+    except ValueError as error:
+        raise ValueError("stable-parts must be comma-separated integers.") from error
+    if not parts or any(part < 2 or part > 4 for part in parts):
+        raise ValueError("stable-parts must contain values from 2 through 4.")
+    return parts
 
 
 def validate_release_tag(tag: str) -> None:
@@ -34,18 +52,21 @@ def validate_release_tag(tag: str) -> None:
         raise ValueError(msg)
 
 
-def validate_release_request(tag: str, prerelease: bool) -> None:
+def validate_release_request(
+    tag: str, prerelease: bool, stable_parts: tuple[int, ...] = (2, 3, 4)
+) -> None:
     """Validate that a release tag agrees with the prerelease selection.
 
     Args:
         tag: Candidate release tag.
         prerelease: Whether the release should be treated as a prerelease.
+        stable_parts: Accepted numeric component counts for stable tags.
 
     Raises:
         ValueError: If the tag format and prerelease selection disagree.
     """
     validate_release_tag(tag)
-    tag_is_prerelease = NUMERIC_TAG_PATTERN.fullmatch(tag) is None
+    tag_is_prerelease = _stable_tag_pattern(stable_parts).fullmatch(tag) is None
     if tag_is_prerelease != prerelease:
         tag_kind = "Prerelease" if tag_is_prerelease else "Stable"
         required_value = str(tag_is_prerelease).lower()
@@ -53,12 +74,15 @@ def validate_release_request(tag: str, prerelease: bool) -> None:
         raise ValueError(msg)
 
 
-def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
+def next_stable_release_tag(
+    tags: Iterable[str], bump_type: str, stable_parts: tuple[int, ...] = (2, 3, 4)
+) -> str:
     """Return the next stable tag after the highest released stable version.
 
     Args:
         tags: Candidate tag names from the release repository.
         bump_type: Requested stable version increment.
+        stable_parts: Accepted numeric component counts for stable tags.
 
     Returns:
         The next stable release tag.
@@ -71,9 +95,10 @@ def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
         raise ValueError(msg)
 
     versions = [
-        tuple(int(component or 0) for component in match.groups())
+        tuple(int(component) for component in tag.removeprefix("v").split("."))
+        + (0,) * (4 - len(tag.removeprefix("v").split(".")))
         for tag in tags
-        if (match := STABLE_TAG_PATTERN.fullmatch(tag)) is not None
+        if _stable_tag_pattern(stable_parts).fullmatch(tag) is not None
     ]
     if not versions:
         msg = "No stable released tag found."
@@ -119,7 +144,7 @@ def _replace_version(
     return updated
 
 
-def update_release_versions(repository: Path, tag: str) -> None:
+def update_release_versions(repository: Path, tag: str, component_path: str | None = None) -> None:
     """Update manifest.json and const.py to the release tag.
 
     Both files are validated before either is written, preventing a partial update.
@@ -127,12 +152,22 @@ def update_release_versions(repository: Path, tag: str) -> None:
     Args:
         repository: Repository root containing the integration.
         tag: Requested release tag.
+        component_path: Integration directory relative to the repository.
 
     Raises:
         ValueError: If the tag or either version declaration is invalid.
     """
     validate_release_tag(tag)
-    integration = repository / "custom_components" / "opnsense"
+    if component_path is None:
+        components = [
+            path for path in (repository / "custom_components").iterdir() if path.is_dir()
+        ]
+        if len(components) != 1:
+            msg = "component-path is required unless the repository has one component."
+            raise ValueError(msg)
+        integration = components[0]
+    else:
+        integration = repository / component_path
     manifest_path = integration / "manifest.json"
     const_path = integration / "const.py"
 
@@ -186,6 +221,15 @@ def main() -> int:
         default=Path.cwd(),
         help="Repository root whose version files should be validated or updated",
     )
+    parser.add_argument(
+        "--component-path",
+        help="Integration directory relative to --repository.",
+    )
+    parser.add_argument(
+        "--stable-parts",
+        default="2,3,4",
+        help="Comma-separated stable release version component counts.",
+    )
     args = parser.parse_args()
 
     try:
@@ -197,18 +241,22 @@ def main() -> int:
                 msg = "Validation options cannot be used with --next-tag."
                 raise ValueError(msg)
             sys.stdout.write(
-                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag)}\n"
+                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag, _parse_stable_parts(args.stable_parts))}\n"
             )
         elif args.check_only:
             if args.expected_prerelease is None:
                 validate_release_tag(args.tag)
             else:
-                validate_release_request(args.tag, args.expected_prerelease == "true")
+                validate_release_request(
+                    args.tag,
+                    args.expected_prerelease == "true",
+                    _parse_stable_parts(args.stable_parts),
+                )
         else:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."
                 raise ValueError(msg)
-            update_release_versions(args.repository, args.tag)
+            update_release_versions(args.repository, args.tag, args.component_path)
     except (OSError, ValueError) as error:
         parser.error(str(error))
 

--- a/.github/scripts/verify_hacs_archive.py
+++ b/.github/scripts/verify_hacs_archive.py
@@ -1,0 +1,123 @@
+"""Validate a release HACS archive before it is uploaded."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import json
+from pathlib import PurePosixPath
+import stat
+import zipfile
+
+MAX_FILES = 1_000
+MAX_FILE_BYTES = 10 * 1024 * 1024
+MAX_EXPANDED_BYTES = 64 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+REQUIRED_FILES = frozenset({"manifest.json", "const.py"})
+
+
+class ArchiveError(ValueError):
+    """Raised when a release archive is not a safe integration archive."""
+
+
+def _validate_name(name: str) -> None:
+    """Reject archive member names that can escape the integration root.
+
+    Args:
+        name (str): Archive member filename.
+
+    Raises:
+        ArchiveError: If the filename is absolute, a directory, or traverses upward.
+    """
+    path = PurePosixPath(name)
+    if not name or path.is_absolute() or ".." in path.parts:
+        raise ArchiveError(f"Invalid archive member path: {name!r}")
+
+
+def _validate_regular_file(member: zipfile.ZipInfo) -> None:
+    """Reject symlinks and non-regular POSIX members when metadata is present.
+
+    Args:
+        member (zipfile.ZipInfo): ZIP member metadata to inspect.
+
+    Raises:
+        ArchiveError: If POSIX metadata identifies a non-regular member.
+    """
+    mode = member.external_attr >> 16
+    file_type = stat.S_IFMT(mode)
+    if file_type and not stat.S_ISREG(mode):
+        raise ArchiveError(f"Archive member is not a regular file: {member.filename!r}")
+
+
+def verify_archive(archive_path: str, release_tag: str) -> None:
+    """Verify HACS archive structure, resource bounds, and embedded versions.
+
+    Args:
+        archive_path (str): Path to the ZIP archive.
+        release_tag (str): Exact tag expected in the integration version files.
+
+    Raises:
+        ArchiveError: If the archive is unreadable, unsafe, or version-mismatched.
+    """
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            members = archive.infolist()
+            if not members or len(members) > MAX_FILES:
+                raise ArchiveError("Archive has an invalid number of files.")
+            names: set[str] = set()
+            expanded_bytes = 0
+            for member in members:
+                _validate_name(member.filename)
+                if member.filename in names:
+                    raise ArchiveError(f"Duplicate archive member: {member.filename!r}")
+                names.add(member.filename)
+                if member.is_dir():
+                    continue
+                _validate_regular_file(member)
+                if member.file_size > MAX_FILE_BYTES:
+                    raise ArchiveError(f"Archive member exceeds size limit: {member.filename!r}")
+                expanded_bytes += member.file_size
+                if expanded_bytes > MAX_EXPANDED_BYTES:
+                    raise ArchiveError("Archive expanded size exceeds limit.")
+                if member.file_size and member.compress_size == 0:
+                    raise ArchiveError(
+                        f"Archive member has invalid compression: {member.filename!r}"
+                    )
+                if (
+                    member.compress_size
+                    and member.file_size / member.compress_size > MAX_COMPRESSION_RATIO
+                ):
+                    raise ArchiveError(
+                        f"Archive member compression ratio is unsafe: {member.filename!r}"
+                    )
+            if not names >= REQUIRED_FILES:
+                raise ArchiveError("Archive does not contain required version files.")
+            manifest = json.loads(archive.read("manifest.json"))
+            if not isinstance(manifest, dict) or manifest.get("version") != release_tag:
+                raise ArchiveError("Archive manifest version does not match the release tag.")
+            const = archive.read("const.py").decode("utf-8")
+            if f'VERSION = "{release_tag}"' not in const.splitlines():
+                raise ArchiveError("Archive const.py version does not match the release tag.")
+    except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as error:
+        raise ArchiveError(f"Unable to validate release archive: {error}") from error
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run archive validation from the command line.
+
+    Args:
+        argv (Sequence[str] | None): Optional arguments excluding executable name.
+
+    Returns:
+        int: Zero after successful archive validation.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive")
+    parser.add_argument("release_tag")
+    args = parser.parse_args(argv)
+    verify_archive(args.archive, args.release_tag)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify_release_checks.py
+++ b/.github/scripts/verify_release_checks.py
@@ -6,6 +6,7 @@ import argparse
 from collections import defaultdict
 from collections.abc import Sequence
 import json
+from pathlib import Path
 import shutil
 import subprocess
 import sys
@@ -18,24 +19,13 @@ class GitHubCommandError(RuntimeError):
 
 
 def github_api(arguments: Sequence[str], expected_status: int | None = None) -> dict[str, Any]:
-    """Run a GitHub API request and parse its JSON response.
-
-    Args:
-        arguments: GitHub CLI API arguments.
-        expected_status: Optional required HTTP response status.
-
-    Returns:
-        Parsed JSON object response.
-
-    Raises:
-        GitHubCommandError: If the CLI, response status, or response shape is invalid.
-    """
+    """Run a GitHub API request and parse its JSON response."""
     executable = shutil.which("gh")
     if executable is None:
         raise GitHubCommandError("GitHub CLI executable is unavailable.")
     try:
         result = subprocess.run(  # noqa: S603 -- API arguments are constructed internally.
-            [executable, "api", *arguments],
+            [str(Path(executable)), "api", *arguments],
             check=False,
             capture_output=True,
             text=True,
@@ -63,20 +53,7 @@ def github_api(arguments: Sequence[str], expected_status: int | None = None) -> 
 
 
 def dispatch_workflow(repository: str, workflow: str, ref: str, sha: str) -> int:
-    """Dispatch one workflow for the validated temporary branch.
-
-    Args:
-        repository: GitHub owner and repository name.
-        workflow: Workflow filename.
-        ref: Temporary branch containing the candidate.
-        sha: Candidate commit SHA.
-
-    Returns:
-        The authoritative workflow run ID returned by GitHub.
-
-    Raises:
-        GitHubCommandError: If GitHub does not return a valid run ID.
-    """
+    """Dispatch one workflow for the validated temporary branch."""
     response = github_api(
         [
             "--include",
@@ -101,7 +78,7 @@ def dispatch_workflow(repository: str, workflow: str, ref: str, sha: str) -> int
 
 
 def verify_check_suite(repository: str, run: dict[str, Any], sha: str) -> None:
-    """Require the workflow run's GitHub Actions check suite to use the candidate SHA."""
+    """Require the run's check suite to be a GitHub Actions suite for the SHA."""
     suite_id = run.get("check_suite_id")
     if not isinstance(suite_id, int):
         raise GitHubCommandError("Workflow run did not expose a check suite ID.")
@@ -113,7 +90,7 @@ def verify_check_suite(repository: str, run: dict[str, Any], sha: str) -> None:
         or app.get("slug") != "github-actions"
     ):
         raise GitHubCommandError(
-            "Workflow run is not a GitHub Actions check suite for the candidate commit."
+            f"Workflow run is not a GitHub Actions check suite for candidate SHA {sha}."
         )
 
 
@@ -121,8 +98,10 @@ def verify_jobs(repository: str, run_id: int, required_checks: set[str]) -> None
     """Require every named job to have passed in the selected workflow run."""
     payload = github_api([f"repos/{repository}/actions/runs/{run_id}/jobs?per_page=100"])
     jobs = payload.get("jobs", [])
+    if not isinstance(jobs, list):
+        raise GitHubCommandError("Workflow jobs response did not include jobs.")
     total_count = payload.get("total_count")
-    if not isinstance(jobs, list) or not isinstance(total_count, int) or total_count > len(jobs):
+    if not isinstance(total_count, int) or total_count > len(jobs):
         raise GitHubCommandError("Workflow job list was truncated or unverifiable.")
     outcomes: dict[str, list[Any]] = defaultdict(list)
     for job in jobs:
@@ -164,7 +143,8 @@ def wait_for_workflow(
                 raise
             time.sleep(5)
             continue
-        if run.get("id") != expected_run_id:
+        run_id = run.get("id")
+        if run_id != expected_run_id:
             raise GitHubCommandError("Workflow run ID does not match the dispatch response.")
         if (
             run.get("workflow_id") != workflow_id
@@ -178,11 +158,11 @@ def wait_for_workflow(
             continue
         if run.get("conclusion") != "success":
             raise GitHubCommandError(
-                f"Workflow {workflow!r} run {expected_run_id} concluded {run.get('conclusion')!r}."
+                f"Workflow {workflow!r} run {run_id} concluded {run.get('conclusion')!r}."
             )
         verify_check_suite(repository, run, sha)
-        verify_jobs(repository, expected_run_id, required_checks)
-        return expected_run_id
+        verify_jobs(repository, run_id, required_checks)
+        return run_id
     raise GitHubCommandError(f"Timed out waiting for workflow {workflow!r}.")
 
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   linters:
-    name: Run Linters
+    name: review
     runs-on: ubuntu-latest
     steps:
       - name: Require expected release commit
@@ -42,7 +42,15 @@ jobs:
           ignore-nothing-to-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Run prek
+      - name: Run prek for pull requests and pushes
+        if: github.event_name != 'workflow_dispatch'
         uses: j178/prek-action@v2
         env:
           UV_LOCKED: "1"
+
+      - name: Validate locked prek without mutation
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          UV_LOCKED=1 uv run --locked prek run --all-files
+          test -z "$(git status --porcelain)"

--- a/.github/workflows/pytest_check.yml
+++ b/.github/workflows/pytest_check.yml
@@ -1,4 +1,4 @@
-name: pytest and coverage
+name: pytest check and post coverage
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests:
-    name: pytest and coverage report
+    name: pytest check and post coverage
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login == 'prek-autoupdate-bot' ||

--- a/.github/workflows/pytest_post_coverage.yml
+++ b/.github/workflows/pytest_post_coverage.yml
@@ -2,7 +2,7 @@ name: Post coverage Comment to PR
 
 on:
   workflow_run:
-    workflows: ['pytest and coverage']
+    workflows: ['pytest check and post coverage']
     types:
       - completed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,22 @@ jobs:
           resume=false
           if [[ "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
             if [[ "$(git rev-list --parents -n 1 "$target_sha" | wc -w)" -ne 2 ]] || \
+              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $'custom_components/opnsense/const.py\ncustom_components/opnsense/manifest.json' ]] || \
               [[ "$(jq -r .version custom_components/opnsense/manifest.json)" != "$RELEASE_TAG" ]] || \
               ! grep -Fx "VERSION = \"$RELEASE_TAG\"" custom_components/opnsense/const.py >/dev/null; then
               echo "Matching branch/tag release commit has invalid release contents." >&2
               exit 1
             fi
+            resume_dir="$(mktemp -d)"
+            mkdir -p "$resume_dir/custom_components/opnsense"
+            git show "$target_sha^:custom_components/opnsense/manifest.json" > \
+              "$resume_dir/custom_components/opnsense/manifest.json"
+            git show "$target_sha^:custom_components/opnsense/const.py" > \
+              "$resume_dir/custom_components/opnsense/const.py"
+            python3 .github/scripts/prepare_release.py --repository "$resume_dir" "$RELEASE_TAG"
+            cmp "$resume_dir/custom_components/opnsense/manifest.json" \
+              custom_components/opnsense/manifest.json
+            cmp "$resume_dir/custom_components/opnsense/const.py" custom_components/opnsense/const.py
             resume=true
             echo "candidate-sha=$target_sha" >> "$GITHUB_OUTPUT"
           fi
@@ -91,9 +102,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ARCHIVE: ${{ runner.temp }}/opnsense.zip
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET: ${{ steps.release.outputs.target }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
+          TAG_OID: ${{ steps.base.outputs.tag-oid }}
         run: |
           set -euo pipefail
-          git archive --format=zip --output="$RELEASE_ARCHIVE" \
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
             "HEAD:custom_components/opnsense"
           unzip -t "$RELEASE_ARCHIVE"
           [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
@@ -105,6 +119,12 @@ jobs:
           if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
             gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
           fi
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
           gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#opnsense.zip" --clobber
 
       - name: Create deterministic stable release commit B
@@ -135,7 +155,8 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          git archive --format=zip --output="$RELEASE_ARCHIVE" "HEAD:custom_components/opnsense"
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" \
+            --output="$RELEASE_ARCHIVE" "HEAD:custom_components/opnsense"
           unzip -t "$RELEASE_ARCHIVE"
           [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
           unzip -p "$RELEASE_ARCHIVE" const.py | grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
@@ -171,6 +192,7 @@ jobs:
 
       - name: Atomically advance target and guarded release tag
         if: github.event.release.prerelease == false && steps.base.outputs.resume != 'true'
+        id: promotion
         env:
           GH_TOKEN: ${{ github.token }}
           ORIGINAL_TAG_OID: ${{ steps.base.outputs.tag-oid }}
@@ -186,6 +208,7 @@ jobs:
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$ORIGINAL_TAG_OID" ]]
           [[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]
           git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG" HEAD
+          echo "tag-oid=$(git rev-parse "refs/tags/$RELEASE_TAG")" >> "$GITHUB_OUTPUT"
           git push --atomic \
             --force-with-lease="refs/heads/$RELEASE_TARGET:$TARGET_SHA" \
             --force-with-lease="refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" \
@@ -196,6 +219,7 @@ jobs:
         env:
           CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
+          PROMOTED_TAG_OID: ${{ steps.promotion.outputs.tag-oid || steps.base.outputs.tag-oid }}
           RELEASE_ARCHIVE: ${{ runner.temp }}/opnsense.zip
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
@@ -205,6 +229,7 @@ jobs:
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
           python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
           git diff --quiet -- custom_components/opnsense/manifest.json custom_components/opnsense/const.py
@@ -221,6 +246,8 @@ jobs:
         if: github.event.release.prerelease == false && success()
         env:
           GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
-          git push origin --delete "$TEMP_REF"
+          git push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA" \
+            origin --delete "$TEMP_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,11 @@ jobs:
       STABLE_TAG_PARTS: "2,3,4"
       FIRMWARE_NOTES: "true"
       REQUIRED_CHECKS: |
-        linters.yml::Run Linters
-        pytest_check.yml::pytest and coverage report
+        pytest_check.yml::pytest check and post coverage
+        uv-lock-check.yml::Validate uv lock consistency
         validate.yml::Hassfest Validation
         validate.yml::HACS Validation
+        linters.yml::review
     steps:
       - name: Require the default-branch release target
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       COMPONENT_PATH: custom_components/opnsense
       ARCHIVE_NAME: opnsense.zip
-      STABLE_TAG_PARTS: "2,3,4"
       FIRMWARE_NOTES: "true"
       REQUIRED_CHECKS: |
         pytest_check.yml::pytest check and post coverage
@@ -67,8 +66,7 @@ jobs:
           [[ "$target_sha" == "$trusted_sha" ]] || {
             echo "Default branch moved before trusted helper execution." >&2; exit 1; }
           python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" \
-            --stable-parts "$STABLE_TAG_PARTS" --check-only \
-            --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
+            --check-only --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
           tag_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{}")"
           tag_oid="$(git rev-parse "refs/tags/$RELEASE_TAG")"
           [[ "$target_sha" == "$tag_sha" ]] || {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,16 @@ jobs:
       contents: write
       statuses: read
     runs-on: ubuntu-latest
+    env:
+      COMPONENT_PATH: custom_components/opnsense
+      ARCHIVE_NAME: opnsense.zip
+      STABLE_TAG_PARTS: "2,3,4"
+      FIRMWARE_NOTES: "true"
+      REQUIRED_CHECKS: |
+        linters.yml::Run Linters
+        pytest_check.yml::pytest and coverage report
+        validate.yml::Hassfest Validation
+        validate.yml::HACS Validation
     steps:
       - name: Require the default-branch release target
         id: release
@@ -29,10 +39,8 @@ jobs:
           RELEASE_TARGET: ${{ github.event.release.target_commitish }}
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_TARGET" != "$DEFAULT_BRANCH" ]]; then
-            echo "Release target must be the default branch." >&2
-            exit 1
-          fi
+          [[ "$RELEASE_TARGET" == "$DEFAULT_BRANCH" ]] || {
+            echo "Release target must be the default branch." >&2; exit 1; }
           echo "target=$RELEASE_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Checkout trusted default-branch workflow revision
@@ -55,37 +63,33 @@ jobs:
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           target_sha="$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")"
-          if [[ "$target_sha" != "$trusted_sha" ]]; then
-            echo "Default branch moved before trusted helper execution." >&2
-            exit 1
-          fi
-          python3 .github/scripts/prepare_release.py --check-only \
+          [[ "$target_sha" == "$trusted_sha" ]] || {
+            echo "Default branch moved before trusted helper execution." >&2; exit 1; }
+          python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" \
+            --stable-parts "$STABLE_TAG_PARTS" --check-only \
             --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
           tag_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{}")"
           tag_oid="$(git rev-parse "refs/tags/$RELEASE_TAG")"
-          if [[ "$target_sha" != "$tag_sha" ]]; then
-            echo "Release tag and target branch must start at the same commit." >&2
-            exit 1
-          fi
+          [[ "$target_sha" == "$tag_sha" ]] || {
+            echo "Release tag and target branch must start at the same commit." >&2; exit 1; }
           resume=false
-          if [[ "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
+          if [[ "$IS_PRERELEASE" == false && \
+            "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
             if [[ "$(git rev-list --parents -n 1 "$target_sha" | wc -w)" -ne 2 ]] || \
-              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $'custom_components/opnsense/const.py\ncustom_components/opnsense/manifest.json' ]] || \
-              [[ "$(jq -r .version custom_components/opnsense/manifest.json)" != "$RELEASE_TAG" ]] || \
-              ! grep -Fx "VERSION = \"$RELEASE_TAG\"" custom_components/opnsense/const.py >/dev/null; then
+              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $(printf '%s/const.py\n%s/manifest.json' "$COMPONENT_PATH" "$COMPONENT_PATH") ]] || \
+              [[ "$(jq -r .version "$COMPONENT_PATH/manifest.json")" != "$RELEASE_TAG" ]] || \
+              ! grep -Fx "VERSION = \"$RELEASE_TAG\"" "$COMPONENT_PATH/const.py" >/dev/null; then
               echo "Matching branch/tag release commit has invalid release contents." >&2
               exit 1
             fi
             resume_dir="$(mktemp -d)"
-            mkdir -p "$resume_dir/custom_components/opnsense"
-            git show "$target_sha^:custom_components/opnsense/manifest.json" > \
-              "$resume_dir/custom_components/opnsense/manifest.json"
-            git show "$target_sha^:custom_components/opnsense/const.py" > \
-              "$resume_dir/custom_components/opnsense/const.py"
-            python3 .github/scripts/prepare_release.py --repository "$resume_dir" "$RELEASE_TAG"
-            cmp "$resume_dir/custom_components/opnsense/manifest.json" \
-              custom_components/opnsense/manifest.json
-            cmp "$resume_dir/custom_components/opnsense/const.py" custom_components/opnsense/const.py
+            mkdir -p "$resume_dir/$COMPONENT_PATH"
+            git show "$target_sha^:$COMPONENT_PATH/manifest.json" > "$resume_dir/$COMPONENT_PATH/manifest.json"
+            git show "$target_sha^:$COMPONENT_PATH/const.py" > "$resume_dir/$COMPONENT_PATH/const.py"
+            python3 .github/scripts/prepare_release.py --repository "$resume_dir" \
+              --component-path "$COMPONENT_PATH" "$RELEASE_TAG"
+            cmp "$resume_dir/$COMPONENT_PATH/manifest.json" "$COMPONENT_PATH/manifest.json"
+            cmp "$resume_dir/$COMPONENT_PATH/const.py" "$COMPONENT_PATH/const.py"
             resume=true
             echo "candidate-sha=$target_sha" >> "$GITHUB_OUTPUT"
           fi
@@ -99,67 +103,45 @@ jobs:
       - name: Build prerelease archive without mutating refs
         if: github.event.release.prerelease
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_ARCHIVE: ${{ runner.temp }}/opnsense.zip
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_TARGET: ${{ steps.release.outputs.target }}
-          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
-          TAG_OID: ${{ steps.base.outputs.tag-oid }}
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
         run: |
           set -euo pipefail
-          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
-            "HEAD:custom_components/opnsense"
-          unzip -t "$RELEASE_ARCHIVE"
-          [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
-          unzip -p "$RELEASE_ARCHIVE" const.py | grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
-          opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' custom_components/opnsense/const.py | cut -d '"' -f2)"
-          opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' custom_components/opnsense/const.py | cut -d '"' -f2)"
-          firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
-          release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
-          if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
-            gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
-          fi
-          git fetch --force --no-tags origin \
-            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
-            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
-          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
-          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
-          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#opnsense.zip" --clobber
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" \
+            --output="$RELEASE_ARCHIVE" "HEAD:$COMPONENT_PATH"
 
       - name: Create deterministic stable release commit B
         if: github.event.release.prerelease == false
         id: candidate
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           RESUME: ${{ steps.base.outputs.resume }}
           RESUME_SHA: ${{ steps.base.outputs.candidate-sha }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if [[ "$RESUME" == true ]]; then
             echo "sha=$RESUME_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
-          git add custom_components/opnsense/manifest.json custom_components/opnsense/const.py
+          python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" "$RELEASE_TAG"
+          git add "$COMPONENT_PATH/manifest.json" "$COMPONENT_PATH/const.py"
           git diff --cached --check
+          [[ "$(git diff --cached --name-only)" == $(printf '%s/const.py\n%s/manifest.json' "$COMPONENT_PATH" "$COMPONENT_PATH") ]] || {
+            echo "Release transform changed an unexpected path." >&2; exit 1; }
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Release $RELEASE_TAG"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build and test HACS archive from B
+      - name: Build and verify release archive
         if: github.event.release.prerelease == false
         env:
-          RELEASE_ARCHIVE: ${{ runner.temp }}/opnsense.zip
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" \
-            --output="$RELEASE_ARCHIVE" "HEAD:custom_components/opnsense"
-          unzip -t "$RELEASE_ARCHIVE"
-          [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
-          unzip -p "$RELEASE_ARCHIVE" const.py | grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
+            --output="$RELEASE_ARCHIVE" "HEAD:$COMPONENT_PATH"
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
 
       - name: Publish B to an isolated validation branch
         if: github.event.release.prerelease == false
@@ -183,12 +165,13 @@ jobs:
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
           set -euo pipefail
+          required_check_args=()
+          while IFS= read -r required_check; do
+            [[ -z "$required_check" ]] || required_check_args+=(--required-check "$required_check")
+          done <<< "$REQUIRED_CHECKS"
           python3 .github/scripts/verify_release_checks.py \
             --repository "$GITHUB_REPOSITORY" --ref "$TEMP_REF" --sha "$CANDIDATE_SHA" \
-            --required-check 'validate.yml::HACS Validation' \
-            --required-check 'validate.yml::Hassfest Validation' \
-            --required-check 'pytest_check.yml::pytest and coverage report' \
-            --required-check 'linters.yml::Run Linters'
+            "${required_check_args[@]}"
 
       - name: Atomically advance target and guarded release tag
         if: github.event.release.prerelease == false && steps.base.outputs.resume != 'true'
@@ -198,29 +181,31 @@ jobs:
           ORIGINAL_TAG_OID: ${{ steps.base.outputs.tag-oid }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
-          TARGET_SHA: ${{ steps.base.outputs.target-sha }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
         run: |
           set -euo pipefail
           git fetch --force --no-tags origin \
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$TARGET_SHA" ]]
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$ORIGINAL_TAG_OID" ]]
-          [[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]
+          [[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]
           git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG" HEAD
           echo "tag-oid=$(git rev-parse "refs/tags/$RELEASE_TAG")" >> "$GITHUB_OUTPUT"
+          gh auth setup-git --hostname github.com
           git push --atomic \
-            --force-with-lease="refs/heads/$RELEASE_TARGET:$TARGET_SHA" \
+            --force-with-lease="refs/heads/$RELEASE_TARGET:$SOURCE_SHA" \
             --force-with-lease="refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" \
-            origin "HEAD:refs/heads/$RELEASE_TARGET" "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            origin "HEAD:refs/heads/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
 
-      - name: Verify release identity and upload B archive
+      - name: Verify release identity and upload verified archive
         if: github.event.release.prerelease == false
         env:
           CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           PROMOTED_TAG_OID: ${{ steps.promotion.outputs.tag-oid || steps.base.outputs.tag-oid }}
-          RELEASE_ARCHIVE: ${{ runner.temp }}/opnsense.zip
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
         run: |
@@ -231,16 +216,58 @@ jobs:
           [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
-          python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
-          git diff --quiet -- custom_components/opnsense/manifest.json custom_components/opnsense/const.py
-          opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' custom_components/opnsense/const.py | cut -d '"' -f2)"
-          opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' custom_components/opnsense/const.py | cut -d '"' -f2)"
-          firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
-          release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
-          if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
-            gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
+          if [[ "$FIRMWARE_NOTES" == true ]]; then
+            opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
+            release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+            if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
+              gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
+            fi
           fi
-          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#opnsense.zip" --clobber
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
+          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#$ARCHIVE_NAME" --clobber
+
+      - name: Verify prerelease identity and upload archive
+        if: github.event.release.prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET: ${{ steps.release.outputs.target }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
+          TAG_OID: ${{ steps.base.outputs.tag-oid }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
+          if [[ "$FIRMWARE_NOTES" == true ]]; then
+            opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
+            release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+            if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
+              gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
+            fi
+          fi
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
+          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#$ARCHIVE_NAME" --clobber
 
       - name: Delete validated temporary branch
         if: github.event.release.prerelease == false && success()
@@ -249,5 +276,6 @@ jobs:
           CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
+          gh auth setup-git --hostname github.com
           git push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA" \
             origin --delete "$TEMP_REF"

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Immutable commit SHA required by release orchestration
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,9 +20,18 @@ jobs:
     name: Validate uv lock consistency
     runs-on: ubuntu-latest
     steps:
+      - name: Require expected release commit
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$WORKFLOW_SHA" = "$EXPECTED_SHA"
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.expected_sha || github.sha }}
           persist-credentials: false
 
       - name: Setup uv

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,4 +57,3 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
-          ignore: brands

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,3 +57,4 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+          ignore: brands

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -98,59 +98,36 @@ def test_validate_release_request_rejects_mismatched_classification(
         prepare_release.validate_release_request(tag, prerelease)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [("v1.2", (2,)), ("v1.2.3", (3,)), ("v1.2.3.4", (4,))],
-)
-def test_validate_release_request_honors_configured_numeric_component_counts(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
-    """Accept each configured stable numeric component count.
+@pytest.mark.parametrize("tag", ["v1.2", "v1.2.3", "v1.2.3.4"])
+def test_validate_release_request_accepts_fixed_numeric_component_counts(tag: str) -> None:
+    """Accept every supported fixed numeric stable-tag length.
 
     Args:
         tag (str): Numeric release tag under test.
-        stable_parts (tuple[int, ...]): Configured stable component count.
     """
-    prepare_release.validate_release_request(tag, False, stable_parts)
+    prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [
-        ("v01.2", (2,)),
-        ("v1.02.3", (3,)),
-        ("v1.2.03", (3,)),
-        ("v1.2.3.04", (4,)),
-    ],
-)
-def test_validate_release_request_rejects_leading_zero_components(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
+@pytest.mark.parametrize("tag", ["v01.2", "v1.02.3", "v1.2.03", "v1.2.3.04"])
+def test_validate_release_request_rejects_leading_zero_components(tag: str) -> None:
     """Reject stable tags with leading zeros at every supported length.
 
     Args:
         tag (str): Stable tag containing a leading-zero component.
-        stable_parts (tuple[int, ...]): Configured stable component count.
     """
     with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False, stable_parts)
+        prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [("v1.2.3", (2,)), ("v1.2", (3,)), ("v1.2.3.4", (3,))],
-)
-def test_validate_release_request_rejects_unconfigured_component_counts(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
-    """Treat a valid but unconfigured numeric length as prerelease.
+@pytest.mark.parametrize("tag", ["v1", "v1.2.3.4.5"])
+def test_validate_release_request_rejects_unsupported_numeric_lengths(tag: str) -> None:
+    """Reject numeric tags outside the fixed two- through four-part range.
 
     Args:
-        tag (str): Numeric release tag with an unsupported configured length.
-        stable_parts (tuple[int, ...]): Configured stable component counts.
+        tag (str): Numeric tag using an unsupported component count.
     """
-    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False, stable_parts)
+    with pytest.raises(ValueError, match="Invalid release tag"):
+        prepare_release.validate_release_request(tag, False)
 
 
 @pytest.mark.parametrize(
@@ -238,21 +215,17 @@ def test_next_tag_cli_reads_tags_from_standard_input(
     assert capsys.readouterr().out == "v0.9.0\n"
 
 
-def test_next_tag_cli_honors_configured_stable_component_counts(
+def test_next_tag_cli_considers_fixed_component_counts(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Use the workflow stable-parts setting when selecting the next tag.
+    """Use supported two- through four-part tags when selecting the next tag.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
         capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
     """
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [str(SCRIPT_PATH), "--next-tag", "patch", "--stable-parts", "3"],
-    )
-    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2.3\nv1.2.3.4\n"))
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--next-tag", "patch"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2\nv1.2.3\nv1.2.3.4\n"))
 
     assert prepare_release.main() == 0
     assert capsys.readouterr().out == "v1.2.4\n"
@@ -297,36 +270,6 @@ def test_main_rejects_invalid_option_combinations(
     assert expected_message in capsys.readouterr().err
 
 
-def test_main_rejects_invalid_stable_parts(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Reject stable-parts values outside the configured version range.
-
-    Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
-        capsys (pytest.CaptureFixture[str]): Fixture for capturing parser errors.
-    """
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            str(SCRIPT_PATH),
-            "--check-only",
-            "--expected-prerelease",
-            "false",
-            "--stable-parts",
-            "1,5",
-            INITIAL_TAG,
-        ],
-    )
-
-    with pytest.raises(SystemExit) as error:
-        prepare_release.main()
-
-    assert error.value.code == 2
-    assert "stable-parts must contain values from 2 through 4" in capsys.readouterr().err
-
-
 def test_check_only_cli_preserves_positional_tag_contract(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -366,13 +309,15 @@ def test_check_only_cli_rejects_prerelease_input_mismatch(
         prepare_release.main()
 
 
-def test_check_only_cli_accepts_configured_component_count(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("tag", ["v1.2", "v1.2.3", "v1.2.3.4"])
+def test_check_only_cli_accepts_fixed_component_counts(
+    monkeypatch: pytest.MonkeyPatch, tag: str
 ) -> None:
-    """Accept a stable tag whose component count is explicitly configured.
+    """Accept each fixed stable component count through the CLI contract.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        tag (str): Stable tag using a supported component count.
     """
     monkeypatch.setattr(
         sys,
@@ -382,9 +327,7 @@ def test_check_only_cli_accepts_configured_component_count(
             "--check-only",
             "--expected-prerelease",
             "false",
-            "--stable-parts",
-            "2",
-            "v1.2",
+            tag,
         ],
     )
 

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -108,15 +108,32 @@ def test_validate_release_request_accepts_fixed_numeric_component_counts(tag: st
     prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize("tag", ["v01.2", "v1.02.3", "v1.2.03", "v1.2.3.04"])
-def test_validate_release_request_rejects_leading_zero_components(tag: str) -> None:
-    """Reject stable tags with leading zeros at every supported length.
+@pytest.mark.parametrize(
+    ("tag", "prerelease"),
+    [
+        ("v01.2", False),
+        ("v01.2", True),
+        ("v1.02.3", False),
+        ("v1.02.3", True),
+        ("v1.2.03", False),
+        ("v1.2.03", True),
+        ("v1.2.3.04", False),
+        ("v1.2.3.04", True),
+        ("v01.2-beta.1", False),
+        ("v01.2-beta.1", True),
+    ],
+)
+def test_validate_release_request_rejects_leading_zero_components(
+    tag: str, prerelease: bool
+) -> None:
+    """Reject malformed numeric bases regardless of prerelease selection.
 
     Args:
-        tag (str): Stable tag containing a leading-zero component.
+        tag (str): Tag containing a leading-zero numeric component.
+        prerelease (bool): Requested release classification.
     """
-    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False)
+    with pytest.raises(ValueError, match="Invalid release tag"):
+        prepare_release.validate_release_request(tag, prerelease)
 
 
 @pytest.mark.parametrize("tag", ["v1", "v1.2.3.4.5"])

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -15,13 +15,23 @@ assert SCRIPT_SPEC.loader is not None
 prepare_release = importlib.util.module_from_spec(SCRIPT_SPEC)
 SCRIPT_SPEC.loader.exec_module(prepare_release)
 
+INITIAL_TAG = "v1.2.3"
+RELEASE_TAG = "v1.2.4"
+COMPONENT_PATH = "custom_components/example"
+
 
 @pytest.mark.parametrize(
     "tag",
-    ["v1.0.6", "v1.1.0-beta.1", "v0.6.5.1", "v1.0.0b1"],
+    [
+        "v1.2",
+        "v1.2.3",
+        "v1.2.3.4",
+        "v1.2.3-beta.1",
+        "v1.2.3b1",
+    ],
 )
 def test_validate_release_tag_accepts_supported_formats(tag: str) -> None:
-    """Accept supported release tag formats.
+    """Accept supported stable and prerelease tag formats.
 
     Args:
         tag (str): Supported release tag under test.
@@ -31,10 +41,10 @@ def test_validate_release_tag_accepts_supported_formats(tag: str) -> None:
 
 @pytest.mark.parametrize(
     "tag",
-    ["", "1.0.6", "v1", "v1.0.6 beta", "v1.0.6;echo-bad"],
+    ["", "1.2.3", "v1", "v1.2.3 beta", "v1.2.3;echo-bad"],
 )
 def test_validate_release_tag_rejects_unsupported_formats(tag: str) -> None:
-    """Reject malformed release tags.
+    """Reject malformed release tags before they reach release commands.
 
     Args:
         tag (str): Unsupported release tag under test.
@@ -46,10 +56,11 @@ def test_validate_release_tag_rejects_unsupported_formats(tag: str) -> None:
 @pytest.mark.parametrize(
     ("tag", "prerelease"),
     [
-        ("v1.0.6", False),
-        ("v0.6.5.1", False),
-        ("v1.1.0-beta.1", True),
-        ("v1.0.0b1", True),
+        ("v1.2", False),
+        ("v1.2.3", False),
+        ("v1.2.3.4", False),
+        ("v1.2.3-beta.1", True),
+        ("v1.2.3b1", True),
     ],
 )
 def test_validate_release_request_accepts_matching_classification(
@@ -67,10 +78,10 @@ def test_validate_release_request_accepts_matching_classification(
 @pytest.mark.parametrize(
     ("tag", "prerelease", "message"),
     [
-        ("v1.1.0-beta.1", False, "Prerelease tag.*requires prerelease=true"),
-        ("v1.0.0b1", False, "Prerelease tag.*requires prerelease=true"),
-        ("v1.0.6", True, "Stable tag.*requires prerelease=false"),
-        ("v0.6.5.1", True, "Stable tag.*requires prerelease=false"),
+        ("v1.2.3-beta.1", False, "Prerelease tag.*requires prerelease=true"),
+        ("v1.2.3b1", False, "Prerelease tag.*requires prerelease=true"),
+        ("v1.2.3", True, "Stable tag.*requires prerelease=false"),
+        ("v1.2.3.4", True, "Stable tag.*requires prerelease=false"),
     ],
 )
 def test_validate_release_request_rejects_mismatched_classification(
@@ -94,7 +105,7 @@ def test_validate_release_request_rejects_mismatched_classification(
 def test_validate_release_request_honors_configured_numeric_component_counts(
     tag: str, stable_parts: tuple[int, ...]
 ) -> None:
-    """Accept only the configured numeric component count as stable.
+    """Accept each configured stable numeric component count.
 
     Args:
         tag (str): Numeric release tag under test.
@@ -103,17 +114,43 @@ def test_validate_release_request_honors_configured_numeric_component_counts(
     prepare_release.validate_release_request(tag, False, stable_parts)
 
 
-@pytest.mark.parametrize("stable_parts", [(2, 3, 4), (3,)])
-def test_validate_release_request_rejects_leading_zero_numeric_components(
-    stable_parts: tuple[int, ...],
+@pytest.mark.parametrize(
+    ("tag", "stable_parts"),
+    [
+        ("v01.2", (2,)),
+        ("v1.02.3", (3,)),
+        ("v1.2.03", (3,)),
+        ("v1.2.3.04", (4,)),
+    ],
+)
+def test_validate_release_request_rejects_leading_zero_components(
+    tag: str, stable_parts: tuple[int, ...]
 ) -> None:
-    """Reject numeric stable tags with leading zero components.
+    """Reject stable tags with leading zeros at every supported length.
 
     Args:
+        tag (str): Stable tag containing a leading-zero component.
+        stable_parts (tuple[int, ...]): Configured stable component count.
+    """
+    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
+        prepare_release.validate_release_request(tag, False, stable_parts)
+
+
+@pytest.mark.parametrize(
+    ("tag", "stable_parts"),
+    [("v1.2.3", (2,)), ("v1.2", (3,)), ("v1.2.3.4", (3,))],
+)
+def test_validate_release_request_rejects_unconfigured_component_counts(
+    tag: str, stable_parts: tuple[int, ...]
+) -> None:
+    """Treat a valid but unconfigured numeric length as prerelease.
+
+    Args:
+        tag (str): Numeric release tag with an unsupported configured length.
         stable_parts (tuple[int, ...]): Configured stable component counts.
     """
     with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request("v01.02.003", False, stable_parts)
+        prepare_release.validate_release_request(tag, False, stable_parts)
 
 
 @pytest.mark.parametrize(
@@ -123,7 +160,7 @@ def test_validate_release_request_rejects_leading_zero_numeric_components(
 def test_next_stable_release_tag_uses_highest_stable_version(
     bump_type: str, expected_tag: str
 ) -> None:
-    """Ignore prereleases while incrementing the highest stable release.
+    """Ignore prereleases and malformed tags when incrementing the highest stable release.
 
     Args:
         bump_type (str): Requested version increment.
@@ -136,6 +173,8 @@ def test_next_stable_release_tag_uses_highest_stable_version(
         "v1.0.5b1",
         "invalid",
         "v0.99.99",
+        "v1.0.5-rc.1",
+        "v1.0.5",
     ]
 
     assert prepare_release.next_stable_release_tag(tags, bump_type) == expected_tag
@@ -145,7 +184,7 @@ def test_next_stable_release_tag_uses_highest_stable_version(
     ("tags", "bump_type", "expected_tag"),
     [
         (["v1.0.5", "v1.0.5.1"], "patch", "v1.0.6"),
-        (["v1.0.5", "v1.0.5.1"], "minor", "v1.1.0"),
+        (["v1.0.0", "v1.0.5.1"], "minor", "v1.1.0"),
         (["v1.9.9", "v2.0.0.1"], "major", "v3.0.0"),
     ],
 )
@@ -186,7 +225,7 @@ def test_next_stable_release_tag_rejects_invalid_requests(
 def test_next_tag_cli_reads_tags_from_standard_input(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Print the next stable tag without writing version files.
+    """Print the next stable tag without writing integration version files.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
@@ -199,18 +238,38 @@ def test_next_tag_cli_reads_tags_from_standard_input(
     assert capsys.readouterr().out == "v0.9.0\n"
 
 
+def test_next_tag_cli_honors_configured_stable_component_counts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Use the workflow stable-parts setting when selecting the next tag.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(SCRIPT_PATH), "--next-tag", "patch", "--stable-parts", "3"],
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2.3\nv1.2.3.4\n"))
+
+    assert prepare_release.main() == 0
+    assert capsys.readouterr().out == "v1.2.4\n"
+
+
 @pytest.mark.parametrize(
     ("arguments", "expected_message"),
     [
         ((), "Provide exactly one release tag"),
-        (("v1.0.6", "--next-tag", "patch"), "Provide exactly one release tag"),
+        ((INITIAL_TAG, "--next-tag", "patch"), "Provide exactly one release tag"),
         (("--next-tag", "patch", "--check-only"), "Validation options"),
         (
             ("--next-tag", "patch", "--expected-prerelease", "false"),
             "Validation options",
         ),
         (
-            ("v1.0.6", "--expected-prerelease", "false"),
+            (INITIAL_TAG, "--expected-prerelease", "false"),
             "--expected-prerelease requires --check-only",
         ),
     ],
@@ -238,10 +297,55 @@ def test_main_rejects_invalid_option_combinations(
     assert expected_message in capsys.readouterr().err
 
 
-def test_check_only_cli_accepts_matching_expected_prerelease(
+def test_main_rejects_invalid_stable_parts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reject stable-parts values outside the configured version range.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing parser errors.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--check-only",
+            "--expected-prerelease",
+            "false",
+            "--stable-parts",
+            "1,5",
+            INITIAL_TAG,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        prepare_release.main()
+
+    assert error.value.code == 2
+    assert "stable-parts must contain values from 2 through 4" in capsys.readouterr().err
+
+
+def test_check_only_cli_preserves_positional_tag_contract(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Validate an explicit positional tag without writing files.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
+    """
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--check-only", INITIAL_TAG])
+
+    assert prepare_release.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_check_only_cli_rejects_prerelease_input_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Accept the release workflow's stable check-only validation request.
+    """Reject a prerelease tag when the workflow input marks it stable.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
@@ -254,66 +358,163 @@ def test_check_only_cli_accepts_matching_expected_prerelease(
             "--check-only",
             "--expected-prerelease",
             "false",
-            "v1.0.6",
+            "v1.2.3-beta.1",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        prepare_release.main()
+
+
+def test_check_only_cli_accepts_configured_component_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept a stable tag whose component count is explicitly configured.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--check-only",
+            "--expected-prerelease",
+            "false",
+            "--stable-parts",
+            "2",
+            "v1.2",
         ],
     )
 
     assert prepare_release.main() == 0
 
 
-def _write_version_files(repository: Path, const_content: str | None = None) -> tuple[Path, Path]:
+def _write_version_files(
+    repository: Path,
+    *,
+    manifest_content: str | None = None,
+    const_content: str | None = None,
+) -> tuple[Path, Path]:
     """Create representative integration version files.
 
     Args:
         repository (Path): Temporary repository root.
+        manifest_content (str | None): Optional manifest.json content override.
         const_content (str | None): Optional const.py content override.
 
     Returns:
         tuple[Path, Path]: Paths to manifest.json and const.py.
     """
-    integration = repository / "custom_components" / "opnsense"
+    integration = repository / COMPONENT_PATH
     integration.mkdir(parents=True)
     manifest_path = integration / "manifest.json"
     const_path = integration / "const.py"
     manifest_path.write_text(
-        '{\n  "domain": "opnsense",\n  "version" : "v1.0.5"\n}\n',
+        manifest_content or '{\n  "domain": "example",\n  "version" : "v1.2.3"\n}\n',
         encoding="utf-8",
     )
     const_path.write_text(
-        const_content or 'VERSION = "v1.0.5"\nOTHER_VERSION = "v1.0.0"\n',
+        const_content or 'VERSION = "v1.2.3"\nOTHER_VERSION = "v1.0.0"\n',
         encoding="utf-8",
     )
     return manifest_path, const_path
 
 
 def test_update_release_versions_updates_only_release_declarations(tmp_path: Path) -> None:
-    """Update both version declarations without changing unrelated versions.
+    """Update both release declarations without changing unrelated versions.
 
     Args:
         tmp_path (Path): Temporary repository root.
     """
     manifest_path, const_path = _write_version_files(tmp_path)
 
-    prepare_release.update_release_versions(tmp_path, "v1.0.6")
+    prepare_release.update_release_versions(tmp_path, RELEASE_TAG, COMPONENT_PATH)
 
-    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == "v1.0.6"
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == RELEASE_TAG
     assert const_path.read_text(encoding="utf-8") == (
-        'VERSION = "v1.0.6"\nOTHER_VERSION = "v1.0.0"\n'
+        f'VERSION = "{RELEASE_TAG}"\nOTHER_VERSION = "v1.0.0"\n'
     )
 
 
-def test_update_release_versions_does_not_partially_write(tmp_path: Path) -> None:
+def test_default_cli_updates_versions_in_working_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Update both version files through the workflow's default CLI path.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments and
+            the process working directory.
+        tmp_path (Path): Temporary repository root.
+    """
+    manifest_path, const_path = _write_version_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), RELEASE_TAG])
+
+    assert prepare_release.main() == 0
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == RELEASE_TAG
+    assert const_path.read_text(encoding="utf-8") == (
+        f'VERSION = "{RELEASE_TAG}"\nOTHER_VERSION = "v1.0.0"\n'
+    )
+
+
+def test_default_cli_rejects_expected_prerelease_without_check_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject the prerelease option when version preparation is requested.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments and
+            the process working directory.
+        tmp_path (Path): Temporary repository root.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI errors.
+    """
+    manifest_path, const_path = _write_version_files(tmp_path)
+    original_manifest = manifest_path.read_text(encoding="utf-8")
+    original_const = const_path.read_text(encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(SCRIPT_PATH), "--expected-prerelease", "false", RELEASE_TAG],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        prepare_release.main()
+
+    assert "--expected-prerelease requires --check-only" in capsys.readouterr().err
+    assert manifest_path.read_text(encoding="utf-8") == original_manifest
+    assert const_path.read_text(encoding="utf-8") == original_const
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param({"const_content": 'DOMAIN = "example"\n'}, id="const-missing"),
+        pytest.param(
+            {"manifest_content": '{\n  "domain": "example"\n}\n'},
+            id="manifest-missing",
+        ),
+    ],
+)
+def test_update_release_versions_does_not_partially_write(
+    tmp_path: Path, failure: dict[str, str]
+) -> None:
     """Leave both files unchanged when either declaration is missing.
 
     Args:
         tmp_path (Path): Temporary repository root.
+        failure (dict[str, str]): Version-file content that should fail validation.
     """
-    manifest_path, const_path = _write_version_files(tmp_path, 'DOMAIN = "opnsense"\n')
+    manifest_path, const_path = _write_version_files(tmp_path, **failure)
     original_manifest = manifest_path.read_text(encoding="utf-8")
     original_const = const_path.read_text(encoding="utf-8")
 
     with pytest.raises(ValueError, match="Expected one version declaration"):
-        prepare_release.update_release_versions(tmp_path, "v1.0.6")
+        prepare_release.update_release_versions(tmp_path, RELEASE_TAG, COMPONENT_PATH)
 
     assert manifest_path.read_text(encoding="utf-8") == original_manifest
     assert const_path.read_text(encoding="utf-8") == original_const

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -88,6 +88,35 @@ def test_validate_release_request_rejects_mismatched_classification(
 
 
 @pytest.mark.parametrize(
+    ("tag", "stable_parts"),
+    [("v1.2", (2,)), ("v1.2.3", (3,)), ("v1.2.3.4", (4,))],
+)
+def test_validate_release_request_honors_configured_numeric_component_counts(
+    tag: str, stable_parts: tuple[int, ...]
+) -> None:
+    """Accept only the configured numeric component count as stable.
+
+    Args:
+        tag (str): Numeric release tag under test.
+        stable_parts (tuple[int, ...]): Configured stable component count.
+    """
+    prepare_release.validate_release_request(tag, False, stable_parts)
+
+
+@pytest.mark.parametrize("stable_parts", [(2, 3, 4), (3,)])
+def test_validate_release_request_rejects_leading_zero_numeric_components(
+    stable_parts: tuple[int, ...],
+) -> None:
+    """Reject numeric stable tags with leading zero components.
+
+    Args:
+        stable_parts (tuple[int, ...]): Configured stable component counts.
+    """
+    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
+        prepare_release.validate_release_request("v01.02.003", False, stable_parts)
+
+
+@pytest.mark.parametrize(
     ("bump_type", "expected_tag"),
     [("patch", "v1.0.6"), ("minor", "v1.1.0"), ("major", "v2.0.0")],
 )

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,515 @@
+"""Tests for published-release workflow contracts."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+import yaml
+
+PROCESS_RUN = subprocess.run
+WORKFLOW_ROOT = Path(__file__).parents[1] / ".github" / "workflows"
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "verify_release_checks.py"
+LINT_WORKFLOW = (
+    "prek-autofix-review.yml"
+    if (WORKFLOW_ROOT / "prek-autofix-review.yml").exists()
+    else "linters.yml"
+)
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    """Load one workflow with normalized trigger keys for semantic checks.
+
+    Args:
+        name (str): Workflow filename.
+
+    Returns:
+        dict[str, Any]: Parsed workflow document.
+    """
+    document = yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    if True in document:
+        document["on"] = document.pop(True)
+    return document
+
+
+def _workflow_events(document: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed workflow trigger map.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+
+    Returns:
+        dict[str, Any]: Workflow event configuration.
+    """
+    events = document["on"]
+    assert isinstance(events, dict)
+    return events
+
+
+def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, Any]]:
+    """Index named steps for stable semantic assertions.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+        job_id (str): Workflow job identifier.
+
+    Returns:
+        dict[str, dict[str, Any]]: Named steps in the selected job.
+    """
+    job = document["jobs"][job_id]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
+
+
+def _release_environment() -> dict[str, str]:
+    """Read release fixture settings from the repository workflow.
+
+    Returns:
+        dict[str, str]: Environment values required by the extracted shell fixtures.
+    """
+    document = _load_workflow("release.yml")
+    environment = document["jobs"]["release"]["env"]
+    assert isinstance(environment, dict)
+    return {
+        "ARCHIVE_NAME": str(environment["ARCHIVE_NAME"]),
+        "COMPONENT_PATH": str(environment["COMPONENT_PATH"]),
+        "FIRMWARE_NOTES": str(environment["FIRMWARE_NOTES"]),
+        "STABLE_TAG_PARTS": str(environment["STABLE_TAG_PARTS"]),
+    }
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    """Run one Git command in a temporary release-fixture repository.
+
+    Args:
+        repository (Path): Fixture repository.
+        *arguments (str): Arguments following the Git executable.
+
+    Returns:
+        str: Standard output from the successful command.
+    """
+    return PROCESS_RUN(
+        ["git", *arguments],
+        check=True,
+        cwd=repository,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
+    """Create a pushed tag whose release-subject commit also changes a third path.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+        tag (str): Release tag used by the fixture.
+
+    Returns:
+        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
+    """
+    remote = tmp_path / "remote.git"
+    repository = tmp_path / "repository"
+    PROCESS_RUN(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    _git(tmp_path, "init", "-b", "main", str(repository))
+    _git(repository, "config", "user.name", "Release Test")
+    _git(repository, "config", "user.email", "release-test@example.invalid")
+    release_environment = _release_environment()
+    component_path = release_environment["COMPONENT_PATH"]
+    integration = repository / component_path
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
+    const = 'VERSION = "v0.0.0"\n'
+    if release_environment["FIRMWARE_NOTES"] == "true":
+        const += 'OPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n'
+    (integration / "const.py").write_text(const, encoding="utf-8")
+    helper = repository / ".github" / "scripts"
+    helper.mkdir(parents=True)
+    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
+    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "Initial component")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "-u", "origin", "main")
+    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
+    const = f'VERSION = "{tag}"\n'
+    if release_environment["FIRMWARE_NOTES"] == "true":
+        const += 'OPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n'
+    (integration / "const.py").write_text(const, encoding="utf-8")
+    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", f"Release {tag}")
+    source_sha = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "tag", "-a", tag, "-m", tag)
+    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
+    _git(repository, "push", "origin", "main", tag)
+    return repository, source_sha, tag_oid
+
+
+def _run_workflow_shell(
+    repository: Path, run: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run an extracted workflow shell block in a release fixture.
+
+    Args:
+        repository (Path): Fixture repository.
+        run (str): Workflow step shell content.
+        environment (dict[str, str]): Step-specific environment values.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed workflow shell process.
+    """
+    release_environment = _release_environment()
+    workflow_environment = {
+        **release_environment,
+    }
+    return PROCESS_RUN(
+        ["bash", "-c", run],
+        cwd=repository,
+        env={**os.environ, **workflow_environment, **environment},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a deterministic GitHub CLI stub that records release mutations.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+
+    Returns:
+        tuple[Path, Path]: Stub binary directory and its command log path.
+    """
+    binary_dir = tmp_path / "bin"
+    binary_dir.mkdir()
+    log_path = tmp_path / "gh.log"
+    gh = binary_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
+        'if [[ "$1 $2" == "release view" ]]; then\n'
+        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return binary_dir, log_path
+
+
+def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
+    """Keep archive-only prereleases outside stable resume provenance validation.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3-beta.1"
+    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
+    steps = _named_steps(_load_workflow("release.yml"), "release")
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        steps["Validate trusted release metadata and immutable starting refs"]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "true",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode == 0, base.stderr
+    assert "resume=false" in output.read_text(encoding="utf-8")
+    binary_dir, log_path = _stub_gh(tmp_path)
+    archive = tmp_path / _release_environment()["ARCHIVE_NAME"]
+    prerelease = _run_workflow_shell(
+        repository,
+        steps["Build prerelease archive without mutating refs"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+
+    assert prerelease.returncode == 0, prerelease.stderr
+    assert archive.is_file()
+    upload = _run_workflow_shell(
+        repository,
+        steps["Verify prerelease identity and upload archive"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+    assert upload.returncode == 0, upload.stderr
+    assert "release upload" in log_path.read_text(encoding="utf-8")
+
+
+def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
+    """Reject stable retry candidates whose version transform changed a third path.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3"
+    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        _named_steps(_load_workflow("release.yml"), "release")[
+            "Validate trusted release metadata and immutable starting refs"
+        ]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "false",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode != 0
+    assert "invalid release contents" in base.stderr
+
+
+def test_release_workflow_has_published_trigger_and_stable_prerelease_split() -> None:
+    """Keep release promotion event-driven with distinct stable and prerelease paths."""
+    document = _load_workflow("release.yml")
+    events = _workflow_events(document)
+    assert events == {"release": {"types": ["published"]}}
+
+    steps = _named_steps(document, "release")
+    assert steps["Build prerelease archive without mutating refs"]["if"] == (
+        "github.event.release.prerelease"
+    )
+    assert steps["Create deterministic stable release commit B"]["if"] == (
+        "github.event.release.prerelease == false"
+    )
+    assert steps["Atomically advance target and guarded release tag"]["if"] == (
+        "github.event.release.prerelease == false && steps.base.outputs.resume != 'true'"
+    )
+
+    dispatch_run = steps["Dispatch and verify immutable release gates"]["run"]
+    assert "--workflow" not in dispatch_run
+    assert '"${required_check_args[@]}"' in dispatch_run
+    assert document["jobs"]["release"]["env"]["REQUIRED_CHECKS"].splitlines() == [
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
+    ]
+
+
+def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() -> None:
+    """Require guarded branch/tag promotion, explicit resume state, and cleanup on success."""
+    document = _load_workflow("release.yml")
+    steps = _named_steps(document, "release")
+    promotion = steps["Atomically advance target and guarded release tag"]
+    promotion_run = promotion["run"]
+    assert "push --atomic" in promotion_run
+    assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion_run
+    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion_run
+    assert '[[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]' in promotion_run
+    assert 'git push origin "refs/tags/$RELEASE_TAG"' not in promotion_run
+    assert '[[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]' in (
+        promotion_run
+    )
+
+    candidate_run = steps["Create deterministic stable release commit B"]["run"]
+    assert 'if [[ "$RESUME" == true ]]' in candidate_run
+    assert 'echo "sha=$RESUME_SHA"' in candidate_run
+    cleanup = steps["Delete validated temporary branch"]
+    assert cleanup["if"] == "github.event.release.prerelease == false && success()"
+    assert 'push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA"' in cleanup["run"]
+
+
+def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None:
+    """Require default-target validation, credential-free checkout, and step-scoped tokens."""
+    document = _load_workflow("release.yml")
+    job = document["jobs"]["release"]
+    assert job["permissions"] == {
+        "actions": "write",
+        "checks": "read",
+        "contents": "write",
+        "statuses": "read",
+    }
+    steps = _named_steps(document, "release")
+    target = steps["Require the default-branch release target"]
+    assert '"$RELEASE_TARGET" == "$DEFAULT_BRANCH"' in target["run"]
+    assert target["env"] == {
+        "DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
+        "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
+    }
+    checkout = steps["Checkout trusted default-branch workflow revision"]
+    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+    assert checkout["with"]["persist-credentials"] is False
+
+    token_steps = {
+        name: step
+        for name, step in steps.items()
+        if name
+        in {
+            "Publish B to an isolated validation branch",
+            "Dispatch and verify immutable release gates",
+            "Atomically advance target and guarded release tag",
+            "Verify release identity and upload verified archive",
+            "Verify prerelease identity and upload archive",
+            "Delete validated temporary branch",
+        }
+    }
+    for step in token_steps.values():
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+
+
+def test_release_workflow_uses_scoped_github_cli_credentials_for_git_pushes() -> None:
+    """Authenticate release pushes without persisting checkout credentials."""
+    document = _load_workflow("release.yml")
+    steps = _named_steps(document, "release")
+    push_step_names = (
+        "Publish B to an isolated validation branch",
+        "Atomically advance target and guarded release tag",
+        "Delete validated temporary branch",
+    )
+
+    for step_name in push_step_names:
+        step = steps[step_name]
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+        assert "extraheader" not in step["run"].lower()
+        assert "gh auth setup-git --hostname github.com" in step["run"]
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW],
+)
+def test_release_dispatch_guards_require_lowercase_sha_and_match_workflow_sha(
+    workflow_name: str,
+) -> None:
+    """Validate the exact lowercase 40-hex guard used for release dispatches.
+
+    Args:
+        workflow_name (str): Workflow filename under test.
+    """
+    document = _load_workflow(workflow_name)
+    required_names = {
+        value.partition("::")[2]
+        for value in _load_workflow("release.yml")["jobs"]["release"]["env"][
+            "REQUIRED_CHECKS"
+        ].splitlines()
+        if value.partition("::")[0] == workflow_name
+    }
+    candidate_jobs = [
+        (job_id, job)
+        for job_id, job in document["jobs"].items()
+        if isinstance(job, dict) and job.get("name", job_id) in required_names
+    ]
+    assert {job.get("name", job_id) for job_id, job in candidate_jobs} == required_names
+    for _job_id, job in candidate_jobs:
+        steps = job["steps"]
+        guard = next(
+            step
+            for step in steps
+            if isinstance(step, dict) and step.get("name") == "Require expected release commit"
+        )
+        assert guard["run"] == (
+            '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]\ntest "$WORKFLOW_SHA" = "$EXPECTED_SHA"\n'
+        )
+        assert guard["env"]["EXPECTED_SHA"] == "${{ inputs.expected_sha }}"
+        assert guard["env"]["WORKFLOW_SHA"] == "${{ github.sha }}"
+
+
+def test_dispatch_pytest_job_is_read_only_and_preserves_required_check_name() -> None:
+    """Run release-dispatched pytest with read-only contents and the required job name."""
+    document = _load_workflow("pytest_check.yml")
+    pytest_job = next(
+        job
+        for job in document["jobs"].values()
+        if isinstance(job, dict) and job.get("name") == "pytest check and post coverage"
+    )
+    assert pytest_job["permissions"]["contents"] == "read"
+    assert pytest_job["name"] == "pytest check and post coverage"
+    assert (
+        _workflow_events(document)["workflow_dispatch"]["inputs"]["expected_sha"]["required"]
+        is True
+    )
+    pytest_run = next(
+        step
+        for step in pytest_job["steps"]
+        if "uv run --locked --group pytest pytest" in step.get("run", "")
+    )
+    assert "uv run --locked --group pytest pytest" in pytest_run["run"]
+    checkout = next(
+        step
+        for step in pytest_job["steps"]
+        if (
+            isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("actions/checkout@v")
+            and "inputs.expected_sha" in step.get("with", {}).get("ref", "")
+        )
+    )
+    assert checkout["with"]["persist-credentials"] is False
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["validate.yml", "pytest_check.yml", LINT_WORKFLOW],
+)
+def test_release_gate_workflows_retain_normal_triggers_and_expected_sha_dispatch(
+    workflow_name: str,
+) -> None:
+    """Keep PR/push validation while allowing release dispatches to pin one SHA.
+
+    Args:
+        workflow_name (str): Workflow filename under test.
+    """
+    document = _load_workflow(workflow_name)
+    events = _workflow_events(document)
+    assert "pull_request" in events
+    dispatch = events["workflow_dispatch"]
+    assert dispatch["inputs"]["expected_sha"]["required"] is True
+
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+    guarded_jobs = []
+    for job in jobs.values():
+        assert isinstance(job, dict)
+        steps = job["steps"]
+        has_guard = any(
+            isinstance(step, dict)
+            and '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]' in step.get("run", "")
+            for step in steps
+        )
+        if has_guard:
+            guarded_jobs.append(job)
+    assert guarded_jobs
+    for job in guarded_jobs:
+        checkout = next(
+            step
+            for step in job["steps"]
+            if isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("actions/checkout@v")
+            and "inputs.expected_sha || github.sha" in step.get("with", {}).get("ref", "")
+        )
+        assert checkout["with"]["persist-credentials"] is False

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -79,7 +79,6 @@ def _release_environment() -> dict[str, str]:
         "ARCHIVE_NAME": str(environment["ARCHIVE_NAME"]),
         "COMPONENT_PATH": str(environment["COMPONENT_PATH"]),
         "FIRMWARE_NOTES": str(environment["FIRMWARE_NOTES"]),
-        "STABLE_TAG_PARTS": str(environment["STABLE_TAG_PARTS"]),
     }
 
 

--- a/tests/test_verify_hacs_archive.py
+++ b/tests/test_verify_hacs_archive.py
@@ -1,0 +1,303 @@
+"""Tests for HACS release archive validation."""
+
+from collections.abc import Sequence
+import importlib.util
+import json
+from pathlib import Path
+import stat
+import struct
+import zipfile
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "verify_hacs_archive.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("verify_hacs_archive", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+archive_verifier = importlib.util.module_from_spec(SCRIPT_SPEC)
+SCRIPT_SPEC.loader.exec_module(archive_verifier)
+
+RELEASE_TAG = "v1.2.3"
+
+
+def _archive(
+    path: Path,
+    extra: Sequence[tuple[str | zipfile.ZipInfo, bytes | str]] | None = None,
+    *,
+    manifest: bytes | str | None = None,
+    const: bytes | str | None = None,
+    compression: int = zipfile.ZIP_STORED,
+) -> None:
+    """Build a small archive with valid version files and optional members.
+
+    Args:
+        path (Path): Destination ZIP path.
+        extra (Sequence[tuple[str | zipfile.ZipInfo, bytes | str]] | None): Optional members.
+        manifest (bytes | str | None): Optional manifest.json contents.
+        const (bytes | str | None): Optional const.py contents.
+        compression (int): ZIP compression method for string-named members.
+    """
+    members: list[tuple[str | zipfile.ZipInfo, bytes | str]] = [
+        (
+            "manifest.json",
+            manifest if manifest is not None else json.dumps({"version": RELEASE_TAG}).encode(),
+        ),
+        ("const.py", const if const is not None else f'VERSION = "{RELEASE_TAG}"\n'),
+    ]
+    members.extend(extra or [])
+    with zipfile.ZipFile(path, "w", compression=compression) as output:
+        for name, contents in members:
+            output.writestr(name, contents)
+
+
+def _set_compressed_size(path: Path, member_name: str, compressed_size: int) -> None:
+    """Corrupt one central-directory size field for a malformed archive fixture.
+
+    Args:
+        path (Path): ZIP archive to modify.
+        member_name (str): Member whose central-directory record is changed.
+        compressed_size (int): Replacement compressed-size field.
+
+    Raises:
+        AssertionError: If the requested member is not present in the archive.
+    """
+    data = bytearray(path.read_bytes())
+    offset = 0
+    while (offset := data.find(b"PK\x01\x02", offset)) >= 0:
+        name_length = struct.unpack_from("<H", data, offset + 28)[0]
+        name_start = offset + 46
+        name = bytes(data[name_start : name_start + name_length]).decode()
+        if name == member_name:
+            struct.pack_into("<I", data, offset + 20, compressed_size)
+            path.write_bytes(data)
+            return
+        offset += 1
+    raise AssertionError(f"Archive member not found: {member_name}")
+
+
+def test_verify_archive_accepts_a_real_zip_artifact(tmp_path: Path) -> None:
+    """Accept a normal integration archive produced for the release tag.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "integration.zip"
+    _archive(archive)
+
+    archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.main([str(archive), RELEASE_TAG]) == 0
+
+
+def test_verify_archive_allows_safe_directory_entries(tmp_path: Path) -> None:
+    """Allow directories emitted by git archive while validating their contents.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "directory.zip"
+    _archive(archive, [("client/", b""), ("client/module.py", b"VALUE = 1\n")])
+
+    archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize(
+    "member", ["", "/absolute.py", "../manifest.json", "nested/../../const.py"]
+)
+def test_verify_archive_rejects_unsafe_member_paths(tmp_path: Path, member: str) -> None:
+    """Reject empty, absolute, and traversal member paths.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        member (str): Unsafe archive member path.
+    """
+    archive = tmp_path / "unsafe.zip"
+    _archive(archive, [(member, b"unsafe")])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Invalid archive member path"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_duplicate_members(tmp_path: Path) -> None:
+    """Reject duplicate member names before an archive is uploaded.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "duplicate.zip"
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        _archive(archive, [("const.py", f'VERSION = "{RELEASE_TAG}"\n')])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Duplicate archive member"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("file_type", [stat.S_IFLNK, stat.S_IFIFO])
+def test_verify_archive_rejects_non_regular_members(tmp_path: Path, file_type: int) -> None:
+    """Reject symlink and other non-regular POSIX members.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        file_type (int): POSIX type encoded in the ZIP member metadata.
+    """
+    archive = tmp_path / "non-regular.zip"
+    info = zipfile.ZipInfo("linked.py")
+    info.external_attr = (file_type | 0o644) << 16
+    _archive(archive, [(info, b"const.py")])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="not a regular file"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_empty_and_oversized_file_lists(tmp_path: Path) -> None:
+    """Reject empty archives and archives above the member-count bound.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    empty = tmp_path / "empty.zip"
+    with zipfile.ZipFile(empty, "w"):
+        pass
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid number of files"):
+        archive_verifier.verify_archive(str(empty), RELEASE_TAG)
+
+    oversized = tmp_path / "many-files.zip"
+    extras = [(f"payload-{index}.txt", b"") for index in range(archive_verifier.MAX_FILES)]
+    _archive(oversized, extras)
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid number of files"):
+        archive_verifier.verify_archive(str(oversized), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_oversized_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject a member above the configured per-file size bound.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture reducing the test-only bound.
+    """
+    archive = tmp_path / "oversized-member.zip"
+    _archive(archive, [("payload.bin", b"x" * 9)])
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_FILE_BYTES", 8)
+        with pytest.raises(archive_verifier.ArchiveError, match="size limit"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_FILE_BYTES == 10 * 1024 * 1024
+
+
+def test_verify_archive_rejects_expansion_beyond_cap_with_isolated_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject 72 expanded bytes against a test-only 64-byte cap.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture isolating the reduced cap.
+    """
+    archive = tmp_path / "expanded.zip"
+    _archive(archive, [("payload.bin", b"x" * 72)])
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_EXPANDED_BYTES", 64)
+        with pytest.raises(archive_verifier.ArchiveError, match="expanded size"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_EXPANDED_BYTES == 64 * 1024 * 1024
+
+
+def test_verify_archive_rejects_unsafe_compression_ratio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject highly compressible members above the configured ratio.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture reducing the test-only ratio.
+    """
+    archive = tmp_path / "compressed.zip"
+    _archive(archive, [("payload.bin", b"x" * 1_024)], compression=zipfile.ZIP_DEFLATED)
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_COMPRESSION_RATIO", 2)
+        with pytest.raises(archive_verifier.ArchiveError, match="compression ratio"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_COMPRESSION_RATIO == 100
+
+
+def test_verify_archive_rejects_nonzero_file_with_zero_compressed_size(tmp_path: Path) -> None:
+    """Reject a malformed member claiming no compressed bytes for payload data.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "zero-compression.zip"
+    _archive(archive, [("payload.bin", b"payload")])
+    _set_compressed_size(archive, "payload.bin", 0)
+
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid compression"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("missing", ["manifest.json", "const.py"])
+def test_verify_archive_rejects_missing_version_files(tmp_path: Path, missing: str) -> None:
+    """Reject archives missing either required version file.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        missing (str): Required member omitted from the archive.
+    """
+    archive = tmp_path / f"missing-{missing.replace('.', '-')}.zip"
+    members = {
+        "manifest.json": json.dumps({"version": RELEASE_TAG}),
+        "const.py": f'VERSION = "{RELEASE_TAG}"\n',
+    }
+    with zipfile.ZipFile(archive, "w") as output:
+        for name, contents in members.items():
+            if name != missing:
+                output.writestr(name, contents)
+
+    with pytest.raises(archive_verifier.ArchiveError, match="required version files"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_manifest_and_const_version_mismatches(tmp_path: Path) -> None:
+    """Reject manifest and const.py versions that differ from the release tag.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    manifest_mismatch = tmp_path / "manifest-mismatch.zip"
+    _archive(manifest_mismatch)
+    with pytest.raises(archive_verifier.ArchiveError, match="manifest version"):
+        archive_verifier.verify_archive(str(manifest_mismatch), "v1.2.4")
+
+    const_mismatch = tmp_path / "const-mismatch.zip"
+    _archive(const_mismatch, const='VERSION = "v1.2.4"\n')
+    with pytest.raises(archive_verifier.ArchiveError, match=r"const\.py version"):
+        archive_verifier.verify_archive(str(const_mismatch), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_invalid_const_encoding(tmp_path: Path) -> None:
+    """Wrap invalid const.py encoding as an archive validation failure.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "invalid-encoding.zip"
+    _archive(archive, const=b"\xff")
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Unable to validate"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("archive_name", ["missing.zip", "broken.zip"])
+def test_verify_archive_rejects_unreadable_archives(tmp_path: Path, archive_name: str) -> None:
+    """Wrap missing and malformed ZIP files as archive validation failures.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        archive_name (str): Missing or malformed archive filename.
+    """
+    archive = tmp_path / archive_name
+    if archive_name == "broken.zip":
+        archive.write_bytes(b"not a zip archive")
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Unable to validate"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -1,11 +1,9 @@
-"""Tests for immutable release-check verification and workflow contracts."""
+"""Tests for immutable release check verification and workflow contracts."""
 
 from collections.abc import Sequence
 import importlib.util
 import json
-import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 from types import SimpleNamespace
@@ -23,296 +21,35 @@ SCRIPT_SPEC.loader.exec_module(verify)
 
 WORKFLOW_ROOT = Path(__file__).parents[1] / ".github" / "workflows"
 REPOSITORY = "owner/repository"
-REF = "release-validation/v1.0.6-123-1"
+REF = "release-validation/v3.0.1-123-1"
 SHA = "a" * 40
+LINT_WORKFLOW = (
+    "prek-autofix-review.yml"
+    if (WORKFLOW_ROOT / "prek-autofix-review.yml").exists()
+    else "linters.yml"
+)
 
 
-def _load_workflow(name: str) -> dict[str, Any]:
-    """Load a workflow while normalizing YAML's boolean `on` key.
-
-    Args:
-        name (str): Workflow filename.
+def _required_check_values() -> list[str]:
+    """Read the release gate manifest from the caller workflow.
 
     Returns:
-        dict[str, Any]: Parsed workflow document.
+        list[str]: Ordered workflow and job gate declarations.
     """
-    document = yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
+    document = yaml.safe_load((WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8"))
     assert isinstance(document, dict)
     if True in document:
         document["on"] = document.pop(True)
-    return document
+    environment = document["jobs"]["release"]["env"]
+    assert isinstance(environment, dict)
+    values = str(environment["REQUIRED_CHECKS"]).splitlines()
+    return [value for value in values if value]
 
 
-def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, Any]]:
-    """Index named steps in one workflow job.
-
-    Args:
-        document (dict[str, Any]): Parsed workflow document.
-        job_id (str): Workflow job identifier.
-
-    Returns:
-        dict[str, dict[str, Any]]: Named workflow steps.
-    """
-    job = document["jobs"][job_id]
-    assert isinstance(job, dict)
-    steps = job["steps"]
-    assert isinstance(steps, list)
-    return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
-
-
-def _git(repository: Path, *arguments: str) -> str:
-    """Run one Git command in a temporary release-fixture repository.
-
-    Args:
-        repository (Path): Fixture repository.
-        *arguments (str): Arguments following the Git executable.
-
-    Returns:
-        str: Standard output from the successful command.
-    """
-    return subprocess.run(  # noqa: S603 -- test arguments are fixed by fixture helpers.
-        ["git", *arguments],  # noqa: S607 -- Git is the fixed test executable.
-        check=True,
-        cwd=repository,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-
-
-def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
-    """Create a pushed tag whose release-subject commit also changes a third path.
-
-    Args:
-        tmp_path (Path): Pytest temporary directory.
-        tag (str): Release tag used by the fixture.
-
-    Returns:
-        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
-    """
-    remote = tmp_path / "remote.git"
-    repository = tmp_path / "repository"
-    subprocess.run(  # noqa: S603 -- test-only fixture repository initialization.
-        ["git", "init", "--bare", str(remote)],  # noqa: S607 -- test fixture executable.
-        check=True,
-        capture_output=True,
-    )
-    _git(tmp_path, "init", "-b", "main", str(repository))
-    _git(repository, "config", "user.name", "Release Test")
-    _git(repository, "config", "user.email", "release-test@example.invalid")
-    integration = repository / "custom_components" / "opnsense"
-    integration.mkdir(parents=True)
-    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
-    (integration / "const.py").write_text(
-        'VERSION = "v0.0.0"\nOPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n',
-        encoding="utf-8",
-    )
-    helper = repository / ".github" / "scripts"
-    helper.mkdir(parents=True)
-    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
-    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "Initial component")
-    _git(repository, "remote", "add", "origin", str(remote))
-    _git(repository, "push", "-u", "origin", "main")
-    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
-    (integration / "const.py").write_text(
-        f'VERSION = "{tag}"\nOPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n',
-        encoding="utf-8",
-    )
-    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", f"Release {tag}")
-    source_sha = _git(repository, "rev-parse", "HEAD")
-    _git(repository, "tag", "-a", tag, "-m", tag)
-    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
-    _git(repository, "push", "origin", "main", tag)
-    return repository, source_sha, tag_oid
-
-
-def _run_workflow_shell(
-    repository: Path, run: str, environment: dict[str, str]
-) -> subprocess.CompletedProcess[str]:
-    """Run an extracted workflow shell block in a release fixture.
-
-    Args:
-        repository (Path): Fixture repository.
-        run (str): Workflow step shell content.
-        environment (dict[str, str]): Step-specific environment values.
-
-    Returns:
-        subprocess.CompletedProcess[str]: The completed workflow shell process.
-    """
-    component = next(
-        path.name for path in (repository / "custom_components").iterdir() if path.is_dir()
-    )
-    workflow_environment = {
-        "ARCHIVE_NAME": f"{component}.zip",
-        "COMPONENT_PATH": f"custom_components/{component}",
-        "FIRMWARE_NOTES": str(component == "opnsense").lower(),
-        "STABLE_TAG_PARTS": "2,3,4",
-    }
-    return subprocess.run(  # noqa: S603 -- extracted trusted workflow shell is under test.
-        ["bash", "-c", run],  # noqa: S607 -- test shell for extracted workflow source.
-        cwd=repository,
-        env={**os.environ, **workflow_environment, **environment},
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-
-def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
-    """Create a deterministic GitHub CLI stub that records release mutations.
-
-    Args:
-        tmp_path (Path): Pytest temporary directory.
-
-    Returns:
-        tuple[Path, Path]: Stub binary directory and its command log path.
-    """
-    binary_dir = tmp_path / "bin"
-    binary_dir.mkdir()
-    log_path = tmp_path / "gh.log"
-    gh = binary_dir / "gh"
-    gh.write_text(
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
-        'if [[ "$1 $2" == "release view" ]]; then\n'
-        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
-        "fi\n",
-        encoding="utf-8",
-    )
-    gh.chmod(0o755)
-    return binary_dir, log_path
-
-
-def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
-    """Keep archive-only prereleases outside stable resume provenance validation.
-
-    Args:
-        tmp_path (Path): Temporary fixture directory.
-    """
-    tag = "v1.2.3-beta.1"
-    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
-    steps = _named_steps(_load_workflow("release.yml"), "release")
-    output = tmp_path / "base-output"
-    base = _run_workflow_shell(
-        repository,
-        steps["Validate trusted release metadata and immutable starting refs"]["run"],
-        {
-            "GITHUB_OUTPUT": str(output),
-            "IS_PRERELEASE": "true",
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-        },
-    )
-
-    assert base.returncode == 0, base.stderr
-    assert "resume=false" in output.read_text(encoding="utf-8")
-    binary_dir, log_path = _stub_gh(tmp_path)
-    archive = tmp_path / "opnsense.zip"
-    prerelease = _run_workflow_shell(
-        repository,
-        steps["Build prerelease archive without mutating refs"]["run"],
-        {
-            "GH_LOG": str(log_path),
-            "GH_TOKEN": "test-token",
-            "PATH": f"{binary_dir}:{os.environ['PATH']}",
-            "RELEASE_ARCHIVE": str(archive),
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-            "SOURCE_SHA": source_sha,
-            "TAG_OID": tag_oid,
-        },
-    )
-
-    assert prerelease.returncode == 0, prerelease.stderr
-    assert archive.is_file()
-    upload = _run_workflow_shell(
-        repository,
-        steps["Verify prerelease identity and upload archive"]["run"],
-        {
-            "GH_LOG": str(log_path),
-            "GH_TOKEN": "test-token",
-            "PATH": f"{binary_dir}:{os.environ['PATH']}",
-            "RELEASE_ARCHIVE": str(archive),
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-            "SOURCE_SHA": source_sha,
-            "TAG_OID": tag_oid,
-        },
-    )
-    assert upload.returncode == 0, upload.stderr
-    assert "release upload" in log_path.read_text(encoding="utf-8")
-
-
-def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
-    """Reject stable retry candidates whose version transform changed a third path.
-
-    Args:
-        tmp_path (Path): Temporary fixture directory.
-    """
-    tag = "v1.2.3"
-    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
-    output = tmp_path / "base-output"
-    base = _run_workflow_shell(
-        repository,
-        _named_steps(_load_workflow("release.yml"), "release")[
-            "Validate trusted release metadata and immutable starting refs"
-        ]["run"],
-        {
-            "GITHUB_OUTPUT": str(output),
-            "IS_PRERELEASE": "false",
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-        },
-    )
-
-    assert base.returncode != 0
-    assert "invalid release contents" in base.stderr
-
-
-def test_prerelease_ref_mismatch_does_not_edit_or_upload_release(tmp_path: Path) -> None:
-    """Fail before any GitHub release mutation when the source branch advances.
-
-    Args:
-        tmp_path (Path): Temporary fixture directory.
-    """
-    tag = "v1.2.3-beta.1"
-    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
-    (repository / "advanced.txt").write_text("moved branch\n", encoding="utf-8")
-    _git(repository, "add", "advanced.txt")
-    _git(repository, "commit", "-m", "Advance main")
-    _git(repository, "push", "origin", "HEAD:main")
-    _git(repository, "checkout", "--detach", source_sha)
-    binary_dir, log_path = _stub_gh(tmp_path)
-    archive = tmp_path / "opnsense.zip"
-    prerelease = _run_workflow_shell(
-        repository,
-        _named_steps(_load_workflow("release.yml"), "release")[
-            "Verify prerelease identity and upload archive"
-        ]["run"],
-        {
-            "GH_LOG": str(log_path),
-            "GH_TOKEN": "test-token",
-            "PATH": f"{binary_dir}:{os.environ['PATH']}",
-            "RELEASE_ARCHIVE": str(archive),
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-            "SOURCE_SHA": source_sha,
-            "TAG_OID": tag_oid,
-        },
-    )
-
-    assert prerelease.returncode != 0
-    assert not log_path.exists()
-
-
-def test_dispatch_workflow_uses_expected_ref_sha_and_authoritative_run_id(
+def test_dispatch_workflow_sends_ref_and_expected_sha(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Send the candidate identity and accept only GitHub's returned run ID.
+    """Dispatch the named workflow for exactly the candidate ref and SHA.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing the API helper.
@@ -326,58 +63,162 @@ def test_dispatch_workflow_uses_expected_ref_sha_and_authoritative_run_id(
     monkeypatch.setattr(verify, "github_api", fake_api)
 
     assert verify.dispatch_workflow(REPOSITORY, "validate.yml", REF, SHA) == 42
-    arguments, status = calls[0]
-    assert status == 200
+
+    assert len(calls) == 1
+    arguments, expected_status = calls[0]
+    assert expected_status == 200
+    assert arguments[arguments.index("--method") + 1] == "POST"
     assert f"repos/{REPOSITORY}/actions/workflows/validate.yml/dispatches" in arguments
     assert f"ref={REF}" in arguments
     assert f"inputs[expected_sha]={SHA}" in arguments
+    assert "Accept: application/vnd.github+json" in arguments
+    assert "X-GitHub-Api-Version: 2026-03-10" in arguments
 
 
-@pytest.mark.parametrize("run_id", [None, 0, -1, True, "42"])
-def test_dispatch_workflow_rejects_missing_or_invalid_run_id(
-    monkeypatch: pytest.MonkeyPatch, run_id: object
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {"workflow_run_id": None},
+        {"workflow_run_id": 0},
+        {"workflow_run_id": -1},
+        {"workflow_run_id": True},
+        {"workflow_run_id": "42"},
+    ],
+)
+def test_dispatch_workflow_rejects_invalid_authoritative_run_id(
+    monkeypatch: pytest.MonkeyPatch, response: dict[str, Any]
 ) -> None:
-    """Fail closed when the dispatch response is not an authoritative run ID.
+    """Fail closed when dispatch omits or corrupts the authoritative run ID.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing the API helper.
-        run_id (object): Invalid response value.
+        response (dict[str, Any]): Invalid dispatch response fixture.
     """
     monkeypatch.setattr(
         verify,
         "github_api",
-        lambda _arguments, expected_status=None: {"workflow_run_id": run_id},
+        lambda _arguments, expected_status=None: response,
     )
 
-    with pytest.raises(verify.GitHubCommandError):
+    with pytest.raises(verify.GitHubCommandError, match="valid workflow_run_id"):
         verify.dispatch_workflow(REPOSITORY, "validate.yml", REF, SHA)
 
 
-def test_parse_required_checks_derives_workflows_in_first_seen_order() -> None:
-    """Group required jobs while preserving workflow dispatch order."""
-    checks = verify.parse_required_checks(
-        [
-            "pytest_check.yml::pytest and coverage report",
-            "validate.yml::HACS Validation",
-            "validate.yml::Hassfest Validation",
-            "pytest_check.yml::pytest and coverage report",
-        ]
-    )
-
-    assert list(checks) == ["pytest_check.yml", "validate.yml"]
-    assert checks == {
-        "pytest_check.yml": {"pytest and coverage report"},
-        "validate.yml": {"HACS Validation", "Hassfest Validation"},
-    }
-
-
-def test_wait_for_workflow_requires_exact_identity_and_successful_jobs(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(("status", "body"), [(204, ""), (200, ""), (200, "not-json")])
+def test_dispatch_workflow_rejects_non_authoritative_http_responses(
+    monkeypatch: pytest.MonkeyPatch, status: int, body: str
 ) -> None:
-    """Verify the exact dispatched run, Actions suite, and exact required job.
+    """Reject 204, empty, and malformed dispatch API responses.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing API and time helpers.
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI execution.
+        status (int): HTTP status returned by the fixture.
+        body (str): Response body returned by the fixture.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=f"HTTP/2 {status} status\n\n{body}",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises((verify.GitHubCommandError, json.JSONDecodeError)):
+        verify.dispatch_workflow(REPOSITORY, "validate.yml", REF, SHA)
+
+
+def test_wait_for_workflow_returns_completed_run_id_after_pending_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return the exact completed run ID after tolerating an in-progress run.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing clock and checks.
+    """
+    responses = iter(
+        [
+            {"id": 7},
+            {
+                "id": 42,
+                "workflow_id": 7,
+                "event": "workflow_dispatch",
+                "head_branch": REF,
+                "head_sha": SHA,
+                "status": "in_progress",
+            },
+            {
+                "id": 42,
+                "workflow_id": 7,
+                "event": "workflow_dispatch",
+                "head_branch": REF,
+                "head_sha": SHA,
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ]
+    )
+    sleeps: list[float] = []
+    suite_calls: list[tuple[dict[str, Any], str]] = []
+    job_calls: list[tuple[int, set[str]]] = []
+    clock = iter([0.0, 0.1])
+
+    monkeypatch.setattr(verify, "github_api", lambda _arguments: next(responses))
+    monkeypatch.setattr(verify.time, "monotonic", lambda: next(clock, 1.0))
+    monkeypatch.setattr(verify.time, "sleep", sleeps.append)
+    monkeypatch.setattr(
+        verify,
+        "verify_check_suite",
+        lambda _repository, run, sha: suite_calls.append((run, sha)),
+    )
+    monkeypatch.setattr(
+        verify,
+        "verify_jobs",
+        lambda _repository, run_id, checks: job_calls.append((run_id, checks)),
+    )
+
+    assert (
+        verify.wait_for_workflow(
+            REPOSITORY,
+            "validate.yml",
+            REF,
+            SHA,
+            {"HACS Validation"},
+            deadline=1.0,
+            expected_run_id=42,
+        )
+        == 42
+    )
+    assert sleeps == [10]
+    assert suite_calls == [
+        (
+            {
+                "id": 42,
+                "workflow_id": 7,
+                "event": "workflow_dispatch",
+                "head_branch": REF,
+                "head_sha": SHA,
+                "status": "completed",
+                "conclusion": "success",
+            },
+            SHA,
+        )
+    ]
+    assert job_calls == [(42, {"HACS Validation"})]
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled"])
+def test_wait_for_workflow_rejects_unsuccessful_conclusion(
+    monkeypatch: pytest.MonkeyPatch, conclusion: str
+) -> None:
+    """Stop promotion for both failed and cancelled workflow conclusions.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing workflow polling.
+        conclusion (str): Unsuccessful conclusion under test.
     """
     responses = iter(
         [
@@ -389,181 +230,297 @@ def test_wait_for_workflow_requires_exact_identity_and_successful_jobs(
                 "head_branch": REF,
                 "head_sha": SHA,
                 "status": "completed",
-                "conclusion": "success",
-                "check_suite_id": 99,
-            },
-            {"head_sha": SHA, "app": {"slug": "github-actions"}},
-            {
-                "total_count": 1,
-                "jobs": [{"name": "HACS Validation", "conclusion": "success"}],
+                "conclusion": conclusion,
             },
         ]
     )
     monkeypatch.setattr(verify, "github_api", lambda _arguments: next(responses))
     monkeypatch.setattr(verify.time, "monotonic", lambda: 0.0)
 
-    assert (
+    with pytest.raises(verify.GitHubCommandError, match=f"{conclusion!r}"):
         verify.wait_for_workflow(
             REPOSITORY,
             "validate.yml",
             REF,
             SHA,
-            {"HACS Validation"},
+            set(),
             deadline=1.0,
             expected_run_id=42,
         )
-        == 42
-    )
 
 
-def test_wait_for_workflow_retries_a_transient_run_not_found(
+def test_wait_for_workflow_times_out_with_bounded_polling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Retry a transient run lookup failure before verifying its completed checks.
+    """Stop polling at the deadline when no matching run is returned.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing API and time helpers.
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing clock and polling.
     """
-    responses: list[dict[str, Any] | RuntimeError] = [
-        {"id": 7},
-        verify.GitHubCommandError("HTTP 404 Not Found"),
-        {
-            "id": 42,
-            "workflow_id": 7,
-            "event": "workflow_dispatch",
-            "head_branch": REF,
-            "head_sha": SHA,
-            "status": "completed",
-            "conclusion": "success",
-            "check_suite_id": 99,
-        },
-        {"head_sha": SHA, "app": {"slug": "github-actions"}},
-        {
-            "total_count": 1,
-            "jobs": [{"name": "HACS Validation", "conclusion": "success"}],
-        },
-    ]
-    sleeps: list[int] = []
+    sleeps: list[float] = []
+    clock = iter([0.0, 1.0])
+    responses = iter([{"id": 7}, verify.GitHubCommandError("404 Not Found")])
 
     def fake_api(_arguments: Sequence[str]) -> dict[str, Any]:
-        """Return the next scripted API response.
-
-        Args:
-            _arguments (Sequence[str]): API request arguments, unused by this scripted response.
-
-        Returns:
-            dict[str, Any]: The scripted API response.
-
-        Raises:
-            verify.GitHubCommandError: When simulating a transient run lookup failure.
-        """
-        response = responses.pop(0)
-        if isinstance(response, RuntimeError):
-            raise verify.GitHubCommandError(str(response))
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
         return response
 
     monkeypatch.setattr(verify, "github_api", fake_api)
-    monkeypatch.setattr(verify.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(verify.time, "monotonic", lambda: next(clock, 1.0))
     monkeypatch.setattr(verify.time, "sleep", sleeps.append)
 
-    assert (
+    with pytest.raises(verify.GitHubCommandError, match="Timed out"):
         verify.wait_for_workflow(
             REPOSITORY,
             "validate.yml",
             REF,
             SHA,
-            {"HACS Validation"},
+            set(),
             deadline=1.0,
             expected_run_id=42,
         )
-        == 42
-    )
-    assert any(delay > 0 for delay in sleeps)
+
+    assert sleeps == [5]
 
 
-@pytest.mark.parametrize(
-    "run",
-    [
-        {"id": 41},
-        {
-            "id": 42,
-            "workflow_id": 7,
-            "event": "push",
-            "head_branch": REF,
-            "head_sha": SHA,
-        },
-    ],
-)
-def test_wait_for_workflow_rejects_non_authoritative_identity(
-    monkeypatch: pytest.MonkeyPatch, run: dict[str, Any]
+def test_wait_for_workflow_rejects_mismatched_authoritative_run_id(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Reject a mismatched run ID or workflow identity.
+    """Reject a response whose ID does not equal the authoritative dispatch ID.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing API and time helpers.
-        run (dict[str, Any]): Invalid workflow run response.
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing workflow polling.
     """
-    monkeypatch.setattr(
-        verify,
-        "github_api",
-        lambda _arguments: {"id": 7} if "/workflows/" in _arguments[0] else run,
+    responses = iter(
+        [
+            {"id": 7},
+            {
+                "id": 41,
+                "workflow_id": 7,
+                "event": "workflow_dispatch",
+                "head_branch": REF,
+                "head_sha": SHA,
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ]
     )
+    monkeypatch.setattr(verify, "github_api", lambda _arguments: next(responses))
     monkeypatch.setattr(verify.time, "monotonic", lambda: 0.0)
 
-    with pytest.raises(verify.GitHubCommandError):
+    with pytest.raises(verify.GitHubCommandError, match="does not match"):
         verify.wait_for_workflow(
-            REPOSITORY, "validate.yml", REF, SHA, set(), deadline=1.0, expected_run_id=42
+            REPOSITORY,
+            "validate.yml",
+            REF,
+            SHA,
+            set(),
+            deadline=1.0,
+            expected_run_id=42,
         )
 
 
-def test_verify_jobs_rejects_incomplete_required_check_results(
+@pytest.mark.parametrize(
+    ("suite", "message"),
+    [
+        ({"head_sha": "b" * 40, "app": {"slug": "github-actions"}}, "check suite"),
+        ({"head_sha": SHA, "app": {"slug": "other-app"}}, "check suite"),
+        ({"head_sha": SHA}, "check suite"),
+    ],
+)
+def test_verify_check_suite_requires_github_actions_source_and_sha(
     monkeypatch: pytest.MonkeyPatch,
+    suite: dict[str, Any],
+    message: str,
 ) -> None:
-    """Reject required checks unless every requested job has one successful result.
+    """Accept only a GitHub Actions check suite attached to the candidate SHA.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing the API helper.
+        suite (dict[str, Any]): Check-suite response fixture.
+        message (str): Expected validation-error fragment.
+    """
+    monkeypatch.setattr(verify, "github_api", lambda _arguments: suite)
+
+    with pytest.raises(verify.GitHubCommandError, match=message):
+        verify.verify_check_suite(REPOSITORY, {"check_suite_id": 99}, SHA)
+
+
+@pytest.mark.parametrize(
+    ("required_checks", "jobs", "failed_category", "failed_name"),
+    [
+        ({"missing"}, [], "missing", "missing"),
+        (
+            {"duplicate"},
+            [
+                {"name": "duplicate", "conclusion": "success"},
+                {"name": "duplicate", "conclusion": "success"},
+                {"name": "unrelated", "conclusion": "failure"},
+            ],
+            "duplicate",
+            "duplicate",
+        ),
+        (
+            {"failed"},
+            [
+                {"name": "failed", "conclusion": "failure"},
+                {"name": "unrelated", "conclusion": "success"},
+            ],
+            "unsuccessful",
+            "failed",
+        ),
+    ],
+)
+def test_verify_jobs_reports_mutually_exclusive_fail_closed_categories(
+    monkeypatch: pytest.MonkeyPatch,
+    required_checks: set[str],
+    jobs: list[dict[str, Any]],
+    failed_category: str,
+    failed_name: str,
+) -> None:
+    """Report missing, duplicate, and single unsuccessful jobs separately.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing the API helper.
+        required_checks (set[str]): Required job names for the deterministic fixture.
+        jobs (list[dict[str, Any]]): Workflow jobs returned by the API fixture.
+        failed_category (str): Diagnostic category expected for the fixture.
+        failed_name (str): Required job expected in that category.
     """
     monkeypatch.setattr(
         verify,
         "github_api",
-        lambda _arguments: {
-            "total_count": 4,
-            "jobs": [
-                {"name": "required", "conclusion": "success"},
-                {"name": "duplicate", "conclusion": "success"},
-                {"name": "duplicate", "conclusion": "success"},
-                {"name": "failed", "conclusion": "failure"},
-            ],
-        },
+        lambda _arguments: {"total_count": len(jobs), "jobs": jobs},
     )
 
-    with pytest.raises(verify.GitHubCommandError):
-        verify.verify_jobs(REPOSITORY, 42, {"required", "duplicate", "failed", "missing"})
+    with pytest.raises(verify.GitHubCommandError) as error:
+        verify.verify_jobs(REPOSITORY, 42, required_checks)
+
+    message = str(error.value)
+    assert f"{failed_category}=[{failed_name!r}]" in message
+    for category in {"missing", "duplicate", "unsuccessful"} - {failed_category}:
+        assert f"{category}=[]" in message
 
 
-def test_github_api_rejects_malformed_or_non_authoritative_http_response(
+def test_parse_required_checks_groups_exact_names_and_rejects_malformed_values() -> None:
+    """Group checks by workflow while retaining exact job-name boundaries."""
+    values = [
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
+    ]
+    checks = verify.parse_required_checks([*values, values[0]])
+
+    expected_workflows = ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW]
+    assert list(checks) == expected_workflows
+    assert checks == {
+        "pytest_check.yml": {"pytest check and post coverage"},
+        "uv-lock-check.yml": {"Validate uv lock consistency"},
+        "validate.yml": {"HACS Validation", "Hassfest Validation"},
+        LINT_WORKFLOW: {"review"},
+    }
+
+    with pytest.raises(ValueError, match="workflow::exact job name"):
+        verify.parse_required_checks(["validate.yml:HACS Validation"])
+
+
+def test_main_dispatches_workflows_in_required_check_first_seen_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fail closed for absent CLI, malformed JSON, and wrong dispatch status.
+    """Use the required-check manifest as the sole ordered workflow input.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI discovery and execution.
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing dispatch and polling helpers.
+    """
+    dispatches: list[str] = []
+    waits: list[tuple[str, set[str], int]] = []
+
+    def fake_dispatch(_repository: str, workflow: str, _ref: str, _sha: str) -> int:
+        dispatches.append(workflow)
+        return len(dispatches)
+
+    def fake_wait(
+        _repository: str,
+        workflow: str,
+        _ref: str,
+        _sha: str,
+        checks: set[str],
+        _deadline: float,
+        run_id: int,
+    ) -> int:
+        waits.append((workflow, checks, run_id))
+        return run_id
+
+    monkeypatch.setattr(verify, "dispatch_workflow", fake_dispatch)
+    monkeypatch.setattr(verify, "wait_for_workflow", fake_wait)
+    monkeypatch.setattr(verify.time, "monotonic", lambda: 100.0)
+    values = _required_check_values()
+    assert set(values) == {
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
+    }
+    arguments: list[str] = [
+        "verify_release_checks.py",
+        "--repository",
+        REPOSITORY,
+        "--ref",
+        REF,
+        "--sha",
+        SHA,
+    ]
+    for value in values:
+        arguments.extend(["--required-check", value])
+    monkeypatch.setattr(
+        verify.sys,
+        "argv",
+        arguments,
+    )
+
+    assert verify.main() == 0
+    assert dispatches == ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW]
+    assert waits == [
+        ("pytest_check.yml", {"pytest check and post coverage"}, 1),
+        ("uv-lock-check.yml", {"Validate uv lock consistency"}, 2),
+        ("validate.yml", {"HACS Validation", "Hassfest Validation"}, 3),
+        (LINT_WORKFLOW, {"review"}, 4),
+    ]
+
+
+def test_github_api_fails_closed_for_unavailable_or_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject missing CLI, command errors, non-object JSON, and malformed JSON.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI discovery and calls.
     """
     monkeypatch.setattr(shutil, "which", lambda _name: None)
-    with pytest.raises(verify.GitHubCommandError):
+    with pytest.raises(verify.GitHubCommandError, match="unavailable"):
         verify.github_api([])
 
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/gh")
     monkeypatch.setattr(
         subprocess,
         "run",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            returncode=0, stdout="HTTP/2 204 No Content\n\n", stderr=""
-        ),
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout="", stderr="API failed"),
     )
-    with pytest.raises(verify.GitHubCommandError):
-        verify.github_api([], expected_status=200)
+    with pytest.raises(verify.GitHubCommandError, match="API failed"):
+        verify.github_api([])
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="[]", stderr=""),
+    )
+    with pytest.raises(verify.GitHubCommandError, match="not an object"):
+        verify.github_api([])
 
     monkeypatch.setattr(
         subprocess,
@@ -574,156 +531,21 @@ def test_github_api_rejects_malformed_or_non_authoritative_http_response(
         verify.github_api([])
 
 
-def test_verify_check_suite_rejects_mismatched_candidate_commit(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Reject a check suite that is tied to a different candidate commit.
+def test_github_api_uses_a_bounded_request_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bound each GitHub API request so network stalls cannot defeat polling bounds.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing the API helper.
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI discovery and calls.
     """
-    monkeypatch.setattr(
-        verify,
-        "github_api",
-        lambda _arguments: {"head_sha": "b" * 40, "app": {"slug": "github-actions"}},
-    )
+    calls: list[dict[str, Any]] = []
 
-    with pytest.raises(verify.GitHubCommandError):
-        verify.verify_check_suite(REPOSITORY, {"check_suite_id": 99}, SHA)
+    def fake_run(*_args: object, **kwargs: Any) -> SimpleNamespace:
+        calls.append(kwargs)
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
 
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
-def test_release_workflow_has_guarded_promotion_and_firmware_archive_contract() -> None:
-    """Preserve published-release handling, lease promotion, and opnsense.zip uploads."""
-    document = _load_workflow("release.yml")
-    assert document["on"] == {"release": {"types": ["published"]}}
-    job = document["jobs"]["release"]
-    assert job["permissions"] == {
-        "actions": "write",
-        "checks": "read",
-        "contents": "write",
-        "statuses": "read",
-    }
-    steps = _named_steps(document, "release")
-    assert (
-        steps["Checkout trusted default-branch workflow revision"]["with"]["persist-credentials"]
-        is False
-    )
-    assert (
-        steps["Build prerelease archive without mutating refs"]["if"]
-        == "github.event.release.prerelease"
-    )
-    dispatch = steps["Dispatch and verify immutable release gates"]["run"]
-    assert "--workflow" not in dispatch
-    assert '"${required_check_args[@]}"' in dispatch
-    assert job["env"]["REQUIRED_CHECKS"].splitlines() == [
-        "linters.yml::Run Linters",
-        "pytest_check.yml::pytest and coverage report",
-        "validate.yml::Hassfest Validation",
-        "validate.yml::HACS Validation",
-    ]
-    promotion = steps["Atomically advance target and guarded release tag"]["run"]
-    assert "push --atomic" in promotion
-    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion
-    assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion
-    upload = steps["Verify release identity and upload verified archive"]["run"]
-    assert '"$RELEASE_ARCHIVE#$ARCHIVE_NAME"' in upload
-    assert "opnsense-firmware-compatibility" in upload
-    assert steps["Delete validated temporary branch"]["if"] == (
-        "github.event.release.prerelease == false && success()"
-    )
-
-
-def test_release_workflow_uses_scoped_github_cli_credentials_for_git_pushes() -> None:
-    """Authenticate release pushes without persisting checkout credentials."""
-    document = _load_workflow("release.yml")
-    steps = _named_steps(document, "release")
-    push_step_names = (
-        "Publish B to an isolated validation branch",
-        "Atomically advance target and guarded release tag",
-        "Delete validated temporary branch",
-    )
-
-    for step_name in push_step_names:
-        step = steps[step_name]
-        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
-        assert "extraheader" not in step["run"].lower()
-
-    assert "gh auth setup-git" in steps["Publish B to an isolated validation branch"]["run"]
-
-
-def test_release_workflow_preserves_resume_wiring_for_validated_release_commit() -> None:
-    """Preserve resume wiring for a previously validated stable release commit."""
-    document = _load_workflow("release.yml")
-    steps = _named_steps(document, "release")
-    base = steps["Validate trusted release metadata and immutable starting refs"]
-    candidate = steps["Create deterministic stable release commit B"]
-    promotion = steps["Atomically advance target and guarded release tag"]
-
-    assert re.search(
-        r'echo\s+"candidate-sha=\$target_sha"\s*>>\s*"\$GITHUB_OUTPUT"',
-        base["run"],
-        re.DOTALL,
-    )
-    assert candidate["env"]["RESUME"] == "${{ steps.base.outputs.resume }}"
-    assert candidate["env"]["RESUME_SHA"] == "${{ steps.base.outputs.candidate-sha }}"
-    candidate_run = candidate["run"]
-    assert re.search(
-        r'if\s+\[\[\s*"\$RESUME"\s*==\s*true\s*\]\]\s*;\s*then.*?'
-        r'echo\s+"sha=\$RESUME_SHA"\s*>>\s*"\$GITHUB_OUTPUT".*?exit\s+0\b',
-        candidate_run,
-        re.DOTALL,
-    )
-    promotion_if = promotion["if"]
-    assert "github.event.release.prerelease == false" in promotion_if
-    assert "steps.base.outputs.resume != 'true'" in promotion_if
-
-
-@pytest.mark.parametrize(
-    ("workflow", "jobs"),
-    [
-        ("validate.yml", ["ha_validation", "hacs_validation"]),
-        ("pytest_check.yml", ["tests"]),
-        ("linters.yml", ["linters"]),
-    ],
-)
-def test_release_gate_workflows_guard_and_checkout_the_exact_dispatch_sha(
-    workflow: str, jobs: list[str]
-) -> None:
-    """Require lowercase SHA validation and credential-free immutable checkout.
-
-    Args:
-        workflow (str): Workflow filename.
-        jobs (list[str]): Guarded job identifiers.
-    """
-    document = _load_workflow(workflow)
-    if workflow == "validate.yml":
-        assert document["permissions"] == {"contents": "read"}
-    assert document["on"]["workflow_dispatch"]["inputs"]["expected_sha"]["required"] is True
-    for job_id in jobs:
-        steps = _named_steps(document, job_id)
-        guard = steps["Require expected release commit"]
-        guard_run = guard["run"]
-        assert re.search(
-            r'\[\[\s*"\$EXPECTED_SHA"\s*=~\s*\^\[0-9a-f\]\{40\}\$\s*\]\]',
-            guard_run,
-            re.DOTALL,
-        )
-        assert re.search(
-            r'test\s+"\$WORKFLOW_SHA"\s*=\s*"\$EXPECTED_SHA"',
-            guard_run,
-            re.DOTALL,
-        )
-        checkout = next(
-            step
-            for step in steps.values()
-            if isinstance(step.get("uses"), str)
-            and step["uses"].split("@", 1)[0] == "actions/checkout"
-            and step.get("with", {}).get("ref") == "${{ inputs.expected_sha || github.sha }}"
-        )
-        assert checkout["with"]["persist-credentials"] is False
-
-    if workflow == "pytest_check.yml":
-        assert document["jobs"]["tests"]["permissions"] == {
-            "contents": "read",
-            "pull-requests": "read",
-        }
+    assert verify.github_api(["repos/example/repo"]) == {}
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == 30

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 import importlib.util
 import json
+import os
 from pathlib import Path
 import re
 import shutil
@@ -57,6 +58,255 @@ def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, A
     steps = job["steps"]
     assert isinstance(steps, list)
     return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    """Run one Git command in a temporary release-fixture repository.
+
+    Args:
+        repository (Path): Fixture repository.
+        *arguments (str): Arguments following the Git executable.
+
+    Returns:
+        str: Standard output from the successful command.
+    """
+    return subprocess.run(  # noqa: S603 -- test arguments are fixed by fixture helpers.
+        ["git", *arguments],  # noqa: S607 -- Git is the fixed test executable.
+        check=True,
+        cwd=repository,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
+    """Create a pushed tag whose release-subject commit also changes a third path.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+        tag (str): Release tag used by the fixture.
+
+    Returns:
+        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
+    """
+    remote = tmp_path / "remote.git"
+    repository = tmp_path / "repository"
+    subprocess.run(  # noqa: S603 -- test-only fixture repository initialization.
+        ["git", "init", "--bare", str(remote)],  # noqa: S607 -- test fixture executable.
+        check=True,
+        capture_output=True,
+    )
+    _git(tmp_path, "init", "-b", "main", str(repository))
+    _git(repository, "config", "user.name", "Release Test")
+    _git(repository, "config", "user.email", "release-test@example.invalid")
+    integration = repository / "custom_components" / "opnsense"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
+    (integration / "const.py").write_text(
+        'VERSION = "v0.0.0"\nOPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n',
+        encoding="utf-8",
+    )
+    helper = repository / ".github" / "scripts"
+    helper.mkdir(parents=True)
+    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
+    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "Initial component")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "-u", "origin", "main")
+    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
+    (integration / "const.py").write_text(
+        f'VERSION = "{tag}"\nOPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n',
+        encoding="utf-8",
+    )
+    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", f"Release {tag}")
+    source_sha = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "tag", "-a", tag, "-m", tag)
+    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
+    _git(repository, "push", "origin", "main", tag)
+    return repository, source_sha, tag_oid
+
+
+def _run_workflow_shell(
+    repository: Path, run: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run an extracted workflow shell block in a release fixture.
+
+    Args:
+        repository (Path): Fixture repository.
+        run (str): Workflow step shell content.
+        environment (dict[str, str]): Step-specific environment values.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed workflow shell process.
+    """
+    component = next(
+        path.name for path in (repository / "custom_components").iterdir() if path.is_dir()
+    )
+    workflow_environment = {
+        "ARCHIVE_NAME": f"{component}.zip",
+        "COMPONENT_PATH": f"custom_components/{component}",
+        "FIRMWARE_NOTES": str(component == "opnsense").lower(),
+        "STABLE_TAG_PARTS": "2,3,4",
+    }
+    return subprocess.run(  # noqa: S603 -- extracted trusted workflow shell is under test.
+        ["bash", "-c", run],  # noqa: S607 -- test shell for extracted workflow source.
+        cwd=repository,
+        env={**os.environ, **workflow_environment, **environment},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a deterministic GitHub CLI stub that records release mutations.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+
+    Returns:
+        tuple[Path, Path]: Stub binary directory and its command log path.
+    """
+    binary_dir = tmp_path / "bin"
+    binary_dir.mkdir()
+    log_path = tmp_path / "gh.log"
+    gh = binary_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
+        'if [[ "$1 $2" == "release view" ]]; then\n'
+        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return binary_dir, log_path
+
+
+def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
+    """Keep archive-only prereleases outside stable resume provenance validation.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3-beta.1"
+    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
+    steps = _named_steps(_load_workflow("release.yml"), "release")
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        steps["Validate trusted release metadata and immutable starting refs"]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "true",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode == 0, base.stderr
+    assert "resume=false" in output.read_text(encoding="utf-8")
+    binary_dir, log_path = _stub_gh(tmp_path)
+    archive = tmp_path / "opnsense.zip"
+    prerelease = _run_workflow_shell(
+        repository,
+        steps["Build prerelease archive without mutating refs"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+
+    assert prerelease.returncode == 0, prerelease.stderr
+    assert archive.is_file()
+    upload = _run_workflow_shell(
+        repository,
+        steps["Verify prerelease identity and upload archive"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+    assert upload.returncode == 0, upload.stderr
+    assert "release upload" in log_path.read_text(encoding="utf-8")
+
+
+def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
+    """Reject stable retry candidates whose version transform changed a third path.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3"
+    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        _named_steps(_load_workflow("release.yml"), "release")[
+            "Validate trusted release metadata and immutable starting refs"
+        ]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "false",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode != 0
+    assert "invalid release contents" in base.stderr
+
+
+def test_prerelease_ref_mismatch_does_not_edit_or_upload_release(tmp_path: Path) -> None:
+    """Fail before any GitHub release mutation when the source branch advances.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3-beta.1"
+    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
+    (repository / "advanced.txt").write_text("moved branch\n", encoding="utf-8")
+    _git(repository, "add", "advanced.txt")
+    _git(repository, "commit", "-m", "Advance main")
+    _git(repository, "push", "origin", "HEAD:main")
+    _git(repository, "checkout", "--detach", source_sha)
+    binary_dir, log_path = _stub_gh(tmp_path)
+    archive = tmp_path / "opnsense.zip"
+    prerelease = _run_workflow_shell(
+        repository,
+        _named_steps(_load_workflow("release.yml"), "release")[
+            "Verify prerelease identity and upload archive"
+        ]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+
+    assert prerelease.returncode != 0
+    assert not log_path.exists()
 
 
 def test_dispatch_workflow_uses_expected_ref_sha_and_authoritative_run_id(
@@ -364,19 +614,20 @@ def test_release_workflow_has_guarded_promotion_and_firmware_archive_contract() 
     )
     dispatch = steps["Dispatch and verify immutable release gates"]["run"]
     assert "--workflow" not in dispatch
-    assert "validate.yml::HACS Validation" in dispatch
-    assert "validate.yml::Hassfest Validation" in dispatch
-    assert "pytest_check.yml::pytest and coverage report" in dispatch
-    assert "linters.yml::Run Linters" in dispatch
+    assert '"${required_check_args[@]}"' in dispatch
+    assert job["env"]["REQUIRED_CHECKS"].splitlines() == [
+        "linters.yml::Run Linters",
+        "pytest_check.yml::pytest and coverage report",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+    ]
     promotion = steps["Atomically advance target and guarded release tag"]["run"]
     assert "push --atomic" in promotion
-    assert "refs/heads/$RELEASE_TARGET:$TARGET_SHA" in promotion
+    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion
     assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion
-    assert "opnsense.zip" in steps["Verify release identity and upload B archive"]["run"]
-    assert (
-        "opnsense-firmware-compatibility"
-        in steps["Verify release identity and upload B archive"]["run"]
-    )
+    upload = steps["Verify release identity and upload verified archive"]["run"]
+    assert '"$RELEASE_ARCHIVE#$ARCHIVE_NAME"' in upload
+    assert "opnsense-firmware-compatibility" in upload
     assert steps["Delete validated temporary branch"]["if"] == (
         "github.event.release.prerelease == false && success()"
     )


### PR DESCRIPTION
## Summary

Reworks the published-release path so a deterministic release candidate is validated by immutable, exact-SHA gates before a stable branch and tag promotion. The branch consolidates release preparation, archive checks, and release-gate verification into shared helpers with contract coverage.

## What Changed

- Reuse the existing release workflow and validation entry points instead of maintaining a parallel validation workflow, with shared release-preparation, HACS-archive, and release-check helpers and tests.
- Require stable published releases to create a version-only candidate, validate a deterministic archive, dispatch the required checks for that exact candidate SHA, and promote branch and annotated tag under leases before upload.
- Keep prereleases archive-only while checking that the selected tag and target branch still resolve to the source identity used for the upload.
- Validate numeric version tags with two to four components and an optional prerelease suffix, and extend workflow contracts for retry, gate, archive, and partial-failure paths.
- Retain hass-opnsense-specific firmware compatibility notes while adding expected-SHA dispatch protection to its release gates.

## Why

A release spans GitHub release metadata, branches, tags, temporary validation refs, and uploaded archives. Verifying the same immutable candidate across those boundaries makes races and partial failures fail closed while preserving the familiar published-release workflow.