### PR TITLE
Stop background OPNsense work on EVENT_HOMEASSISTANT_STOP

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -8,6 +8,7 @@ and various other OPNsense features through the Home Assistant interface.
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
+from functools import partial
 import logging
 from typing import Any
 
@@ -22,8 +23,8 @@ from aiopnsense.exceptions import (
 )
 import awesomeversion
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
@@ -41,10 +42,12 @@ from .const import (
     CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_INTERFACES,
     CONF_SYNC_LIVE_TRAFFIC,
+    COORDINATOR,
     DEFAULT_DEVICE_TRACKER_ENABLED,
     DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SYNC_OPTION_VALUE,
+    DEVICE_TRACKER_COORDINATOR,
     DOMAIN,
     GRANULAR_SYNC_PREFIX,
     LOADED_PLATFORMS,
@@ -106,6 +109,35 @@ class OPNsenseData:
     live_traffic_coordinator: OPNsenseLiveTrafficCoordinator | None = None
     repair_reconciliation: RepairReconciliation | None = None
     should_reload: bool = True
+
+
+async def _async_handle_hass_stop(entry: ConfigEntry, _event: Event) -> None:
+    """Stop an entry's background work before EVENT_HOMEASSISTANT_CLOSE detaches its session.
+
+    Home Assistant does not call async_unload_entry on a full restart, only
+    EVENT_HOMEASSISTANT_STOP followed by EVENT_HOMEASSISTANT_CLOSE, and the
+    latter detaches the aiohttp session backing this entry's client. Without
+    this listener the coordinators and aiopnsense queue workers keep running
+    and race that detach, logging bursts of "Session is closed" errors.
+
+    Args:
+        entry (ConfigEntry): Config entry whose background work should stop.
+        _event (Event): Unused EVENT_HOMEASSISTANT_STOP event payload.
+    """
+    live_traffic_coordinator: OPNsenseLiveTrafficCoordinator | None = getattr(
+        entry.runtime_data, "live_traffic_coordinator", None
+    )
+    if live_traffic_coordinator is not None:
+        await live_traffic_coordinator.async_shutdown()
+    coordinator: OPNsenseDataUpdateCoordinator = getattr(entry.runtime_data, COORDINATOR)
+    await coordinator.async_shutdown()
+    device_tracker_coordinator: OPNsenseDataUpdateCoordinator | None = getattr(
+        entry.runtime_data, DEVICE_TRACKER_COORDINATOR, None
+    )
+    if device_tracker_coordinator is not None:
+        await device_tracker_coordinator.async_shutdown()
+    client: OPNsenseClient = getattr(entry.runtime_data, OPNSENSE_CLIENT)
+    await client.async_close()
 
 
 def _align_aiopnsense_log_level() -> None:
@@ -503,6 +535,11 @@ async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
         )
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+        entry.async_on_unload(
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, partial(_async_handle_hass_stop, entry)
+            )
+        )
 
         setup_succeeded = True
         return True
@@ -817,6 +854,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+        entry.async_on_unload(
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, partial(_async_handle_hass_stop, entry)
+            )
+        )
 
         setup_succeeded = True
         return True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,8 @@ from custom_components.opnsense.const import (
     CONF_SYNC_INTERFACES,
     CONF_SYNC_LIVE_TRAFFIC,
     CONF_TLS_INSECURE,
+    COORDINATOR,
+    DEVICE_TRACKER_COORDINATOR,
     DOMAIN,
     ENTRY_TYPE_CARP,
     GRANULAR_SYNC_PREFIX,
@@ -1035,9 +1037,10 @@ async def test_async_setup_entry_carp_registers_update_listener_after_forwarding
 
     assert await init_mod.async_setup_entry(hass, entry) is True
 
-    assert call_order == ["forward", "add_listener", "async_on_unload"]
+    assert call_order == ["forward", "add_listener", "async_on_unload", "async_on_unload"]
     entry.add_update_listener.assert_called_once_with(init_mod._async_update_listener)
-    entry.async_on_unload.assert_called_once_with(remove_listener)
+    assert entry.async_on_unload.call_count == 2
+    entry.async_on_unload.assert_any_call(remove_listener)
     remove_listener.assert_not_called()
 
 
@@ -1783,6 +1786,68 @@ async def test_async_unload_entry_and_pop(
     assert unload_order == ["platforms_unloaded", "live_shutdown", "client_close"]
     fake_client.async_close.assert_awaited_once()
     fake_live_traffic.async_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_handle_hass_stop_shuts_down_background_work(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """_async_handle_hass_stop should stop every coordinator and close the client.
+
+    Args:
+        make_config_entry (Callable[..., MockConfigEntry]): Fixture that creates a mock configuration entry.
+    """
+    entry = make_config_entry()
+    stop_order: list[str] = []
+    entry.runtime_data.live_traffic_coordinator.async_shutdown = AsyncMock(
+        side_effect=lambda: stop_order.append("live_traffic")
+    )
+    setattr(
+        entry.runtime_data,
+        COORDINATOR,
+        MagicMock(async_shutdown=AsyncMock(side_effect=lambda: stop_order.append("coordinator"))),
+    )
+    setattr(
+        entry.runtime_data,
+        DEVICE_TRACKER_COORDINATOR,
+        MagicMock(
+            async_shutdown=AsyncMock(side_effect=lambda: stop_order.append("device_tracker"))
+        ),
+    )
+    setattr(
+        entry.runtime_data,
+        OPNSENSE_CLIENT,
+        MagicMock(async_close=AsyncMock(side_effect=lambda: stop_order.append("client"))),
+    )
+
+    await init_mod._async_handle_hass_stop(entry, MagicMock())
+
+    assert stop_order == ["live_traffic", "coordinator", "device_tracker", "client"]
+
+
+@pytest.mark.asyncio
+async def test_async_handle_hass_stop_skips_absent_coordinators(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """_async_handle_hass_stop should tolerate a CARP-style entry with no trackers.
+
+    Args:
+        make_config_entry (Callable[..., MockConfigEntry]): Fixture that creates a mock configuration entry.
+    """
+    entry = make_config_entry(
+        runtime_data=init_mod.OPNsenseData(
+            coordinator=MagicMock(async_shutdown=AsyncMock()),
+            device_tracker_coordinator=None,
+            opnsense_client=MagicMock(async_close=AsyncMock()),
+            loaded_platforms=[],
+            device_unique_id=None,
+        )
+    )
+
+    await init_mod._async_handle_hass_stop(entry, MagicMock())
+
+    entry.runtime_data.coordinator.async_shutdown.assert_awaited_once()
+    entry.runtime_data.opnsense_client.async_close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -6148,7 +6213,8 @@ async def test_async_setup_entry_registers_update_listener_after_forwarding(
     assert res is True
     assert call_order.index("forward") < call_order.index("add_listener")
     entry.add_update_listener.assert_called_once_with(init_mod._async_update_listener)
-    entry.async_on_unload.assert_called_once_with(remove_listener)
+    assert entry.async_on_unload.call_count == 2
+    entry.async_on_unload.assert_any_call(remove_listener)
     remove_listener.assert_not_called()
 
 


### PR DESCRIPTION
## What's broken

On a full Home Assistant restart, every configured OPNsense entry logs a burst of paired `Session is closed` errors, once per fetch method that happened to be in flight (certificates, interfaces, telemetry, etc.), doubled because it's logged both in aiopnsense's queue processor and again by its error decorator.

Home Assistant does not call `async_unload_entry` for loaded entries on a full restart, it only fires the global `EVENT_HOMEASSISTANT_STOP` and `EVENT_HOMEASSISTANT_CLOSE` bus events. `EVENT_HOMEASSISTANT_CLOSE` detaches the aiohttp session backing each entry's client regardless of what that entry is doing. Since nothing here listened for the stop event, the coordinators and aiopnsense's queue workers were still running when the session got pulled out from under them.

A plain reload doesn't hit this, because `async_unload_entry` already stops the coordinators and closes the client before Home Assistant tears down the session.

Fixes #717

## Fix

Register an `EVENT_HOMEASSISTANT_STOP` listener in `async_setup_entry` and `_async_setup_carp_entry` that shuts down the coordinators and closes the client, the same cleanup `async_unload_entry` already does on reload, just wired to the event Home Assistant actually fires on restart.

## Testing

- `pytest` (full suite, including two new tests for the stop handler)
- `ruff check` / `ruff format --check`
- `mypy`
- Verified live on a running instance with two OPNsense entries: a restart before this fix reproduced the full error burst, a restart with the fix applied produced none.
