### PR TITLE
Fix initial config menu translations

### DIFF
--- a/custom_components/opnsense/config_flow.py
+++ b/custom_components/opnsense/config_flow.py
@@ -71,6 +71,12 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 DeviceEntries = dict[str, str]
 
+CONFIG_FLOW_DOCUMENTATION_URL = "https://github.com/travisghansen/hass-opnsense"
+USER_MENU_OPTIONS = {
+    "device": "OPNsense device entry",
+    "carp": "CARP VIP entry",
+}
+
 
 class OPNsenseCarpNotConfiguredError(OPNsenseError):
     """Raised when an endpoint has no usable CARP VIP rows."""
@@ -1006,7 +1012,16 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             ConfigFlowResult: Menu containing device and CARP setup choices.
         """
-        return self.async_show_menu(step_id="user", menu_options=["device", "carp"])
+        # Home Assistant Core also provides an ``opnsense`` integration. Its user-step
+        # translation can be loaded before this custom integration and requires
+        # ``doc_url`` while providing no labels for this menu. Supplying both values in
+        # the flow result keeps the custom flow renderable regardless of which
+        # translation bundle was cached first.
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=USER_MENU_OPTIONS,
+            description_placeholders={"doc_url": CONFIG_FLOW_DOCUMENTATION_URL},
+        )
 
     async def async_step_device(
         self, user_input: MutableMapping[str, Any] | None = None

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -515,7 +515,7 @@ async def test_validate_input_timeout_uses_connect_timeout_error(
 
 @pytest.mark.asyncio
 async def test_async_step_user_shows_menu() -> None:
-    """Initial config flow step should present a menu with two entry types."""
+    """Initial config flow step should provide standalone labels and placeholders."""
     flow = cf_mod.OPNsenseConfigFlow()
     flow.hass = MagicMock()
 
@@ -523,7 +523,13 @@ async def test_async_step_user_shows_menu() -> None:
 
     assert result["type"] == "menu"
     assert result["step_id"] == "user"
-    assert result["menu_options"] == ["device", "carp"]
+    assert result["menu_options"] == {
+        "device": "OPNsense device entry",
+        "carp": "CARP VIP entry",
+    }
+    assert result["description_placeholders"] == {
+        "doc_url": "https://github.com/travisghansen/hass-opnsense"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Restores a readable initial configuration menu when Home Assistant loads its built-in OPNsense translations before this custom integration's translations.

## What Changed

- Supplies the documentation placeholder required by Home Assistant Core's OPNsense user-step description.
- Returns explicit labels for the device and CARP menu choices so they do not depend on translation cache order.
- Extends config-flow regression coverage for both labels and the placeholder.

## Why

Home Assistant Core ships an integration with the same `opnsense` domain. On occasion, Core's user-step translation can win the cache race, introducing a required `doc_url` placeholder while omitting this integration's menu labels.

The flow result now carries everything needed to render that initial menu. It uses the mapping and placeholder contract supported by Home Assistant Core and Frontend from 2026.3 onward.

## Related Issues

Closes #714